### PR TITLE
重构 __init__  文件

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ plugin_dirs = ["src/plugins"]
 [build-system]
 requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+pythonpath = [".", "src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,9 @@
 nonebot2~=2.0.0b2
 nonebot-adapter-onebot~=2.0.0b1
 
+# tests
+pytest~=7.1.2
+
 # greeting
 requests~=2.22.0
 requests-html~=0.10.0

--- a/src/common/config/__init__.py
+++ b/src/common/config/__init__.py
@@ -1,17 +1,23 @@
 import pymongo
+from pymongo.collection import Collection
 
 from dataclasses import dataclass
-from typing import Any
-
-
-mongo_client = pymongo.MongoClient('127.0.0.1', 27017, w=0)
-mongo_db = mongo_client['PallasBot']
-config_mongo = mongo_db['config']
-config_mongo.create_index(name='accounts_index',
-                          keys=[('account', pymongo.HASHED)])
+from typing import Any, Optional
 
 
 class BotConfig:
+    __config_mongo: Optional[Collection] = None
+
+    @classmethod
+    def _get_config_mongo(cls) -> Collection:
+        if cls.__config_mongo is None:
+            mongo_client = pymongo.MongoClient('127.0.0.1', 27017, w=0)
+            mongo_db = mongo_client['PallasBot']
+            cls.__config_mongo = mongo_db['config']
+            cls.__config_mongo.create_index(name='accounts_index',
+                                            keys=[('account', pymongo.HASHED)])
+        return cls.__config_mongo
+
     def __init__(self, bot_id: int) -> None:
         self.bot_id = bot_id
         self._mongo_find_key = {
@@ -19,7 +25,7 @@ class BotConfig:
         }
 
     def _find_key(self, key: str) -> Any:
-        info = config_mongo.find_one(self._mongo_find_key)
+        info = self._get_config_mongo().find_one(self._mongo_find_key)
         if info and key in info:
             return info[key]
         else:
@@ -50,7 +56,7 @@ class BotConfig:
         '''
         添加管理员
         '''
-        config_mongo.update_one(
+        self._get_config_mongo().update_one(
             self._mongo_find_key,
             {'$push': {'admins': user_id}},
             upsert=True

--- a/tests/plugins/roulette/test_pseudorandom.py
+++ b/tests/plugins/roulette/test_pseudorandom.py
@@ -1,0 +1,45 @@
+import unittest
+from plugins.roulette.pseudorandom import RouletteRandomizer
+
+GROUP = 1
+OTHER_GROUP = 2
+
+
+class TestRouletteRandomizer(unittest.TestCase):
+    def test_roulette_random(self):
+        '''Test roulette_random().'''
+        roulette = RouletteRandomizer()
+
+        # test probability changes
+        original_weights = roulette.ROULETTE_WEIGHTS[GROUP][:]
+        result = roulette.roulette_random(GROUP)
+        index = result - 1
+        for i in range(len(original_weights)):
+            actual_weight = roulette.ROULETTE_WEIGHTS[GROUP][i]
+            if i == index:
+                expected_weight = original_weights[i] - \
+                    5*roulette.ROULETTE_DELTA
+            else:
+                expected_weight = original_weights[i] + \
+                    roulette.ROULETTE_DELTA
+            self.assertAlmostEqual(expected_weight, actual_weight)
+
+        # test group isolation
+        original_weights = roulette.ROULETTE_WEIGHTS[GROUP][:]
+        original_weights_other = roulette.ROULETTE_WEIGHTS[OTHER_GROUP][:]
+        result = roulette.roulette_random(OTHER_GROUP)
+        index = result - 1
+        for i in range(len(original_weights_other)):
+            actual_weight = roulette.ROULETTE_WEIGHTS[OTHER_GROUP][i]
+            print(i, index)
+            if i == index:
+                expected_weight = original_weights_other[i] - \
+                    5*roulette.ROULETTE_DELTA
+            else:
+                expected_weight = original_weights_other[i] + \
+                    roulette.ROULETTE_DELTA
+            self.assertAlmostEqual(expected_weight, actual_weight)
+        for i in range(len(original_weights)):
+            actual_weight = roulette.ROULETTE_WEIGHTS[GROUP][i]
+            expected_weight = original_weights[i]
+            self.assertAlmostEqual(expected_weight, actual_weight)


### PR DESCRIPTION
1. 重构了  `__init__.py` 中的数据库连接操作，现在它们只会在需要使用的时候连接，并且使用了单例模式，不会再次建立连接。
2. 为 `roulette` 模块中的 `pseudorandom` 模块创建了单元测试。

解决了：https://github.com/InvoluteHell/Pallas-Bot/issues/19