### PR TITLE
feat(db): 添加 PostgreSQL 数据库后端支持

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ PORT=8088
 # 数据库后端选择，目前仅 mongodb 可用于生产。
 # postgresql 当前仅为 Repository 抽象骨架（repository_pg.py 里所有方法 NotImplementedError），
 # 设置为 postgresql 会在 init 阶段报错；真正可用要等后续 PR 完成 PG 实现。
-DB_BACKEND=mongodb
+DB_BACKEND=postgresql
 
 # mongodb 相关配置，请勿注释，如无特殊需求无需更改
 
@@ -18,15 +18,15 @@ MONGO_PORT=27017
 # 请勿注释，如需认证可填写以下两项
 MONGO_USER=
 MONGO_PASSWORD=
+#MONGO_DB=PallasBot
 
-# postgresql 相关配置（预留占位，skeleton-only）
-# 启用前需：
-#  1. uv sync --extra pg 安装 sqlalchemy + asyncpg
-#  2. 完成 src/common/db/repository_pg.py 的实际实现
+# postgresql 相关配置
+# 启用前需：uv sync --extra pg 安装 sqlalchemy + asyncpg
 #PG_HOST=127.0.0.1
 #PG_PORT=5432
 #PG_USER=
 #PG_PASSWORD=
+# PostgreSQL 数据库名，默认 PallasBot；不存在时会自动创建
 #PG_DB=PallasBot
 
 

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ config = driver.config
 
 @driver.on_startup
 async def startup():
-    await init_db(config.mongo_host, config.mongo_port, config.mongo_user, config.mongo_password)
+    await init_db()
 
     await ensure_voices()
 

--- a/src/common/config/__init__.py
+++ b/src/common/config/__init__.py
@@ -273,13 +273,18 @@ class GroupConfig(Config):
         """
         获取歌曲进度
         """
-        return await self._find("sing_progress")
+        result = await self._find("sing_progress")
+        if result is None:
+            return None
+        if isinstance(result, dict):
+            return SingProgress(**result)
+        return result
 
     async def update_sing_progress(self, progress: SingProgress) -> None:
         """
         更新歌曲进度
         """
-        await self._update("sing_progress", progress)
+        await self._update("sing_progress", progress.model_dump())
 
 
 class UserConfig(Config):

--- a/src/common/db/__init__.py
+++ b/src/common/db/__init__.py
@@ -28,6 +28,14 @@ from .repository import (
 
 def get_db_backend() -> str:
     """读取当前配置的数据库后端名称，默认为 mongodb。"""
+    try:
+        import nonebot
+
+        backend = getattr(nonebot.get_driver().config, "db_backend", None)
+        if backend:
+            return str(backend).lower()
+    except Exception:
+        pass
     return os.getenv("DB_BACKEND", "mongodb").lower()
 
 
@@ -117,15 +125,35 @@ def make_mongo_image_cache() -> ImageCacheRepository:
     return MongoImageCacheRepository()
 
 
-async def init_mongodb_db(host: str, port: int, user: str, password: str) -> None:
+def _cfg(key: str, default: str = "") -> str:
+    try:
+        import nonebot
+
+        val = getattr(nonebot.get_driver().config, key.lower(), None)
+        if val is not None:
+            return str(val)
+    except Exception:
+        pass
+    return os.getenv(key.upper(), default)
+
+
+async def init_mongodb_db() -> None:
     """初始化 MongoDB 连接。"""
+    from nonebot.log import logger
+
+    host = _cfg("MONGO_HOST", "127.0.0.1")
+    port = int(_cfg("MONGO_PORT", "27017"))
+    user = _cfg("MONGO_USER", "")
+    password = _cfg("MONGO_PASSWORD", "")
     if user and password:
         connection_string = f"mongodb://{quote_plus(user)}:{quote_plus(password)}@{host}:{port}"
     else:
         connection_string = f"mongodb://{host}:{port}"
+    db_name = _cfg("MONGO_DB", "PallasBot")
+    logger.info(f"正在尝试连接 MongoDB {host}:{port}，Database：{db_name}")
     mongo_client = AsyncMongoClient(connection_string, unicode_decode_error_handler="ignore")
     await init_beanie(
-        database=mongo_client["PallasBot"],
+        database=mongo_client[db_name],
         document_models=[
             BotConfigModule,
             GroupConfigModule,
@@ -136,6 +164,7 @@ async def init_mongodb_db(host: str, port: int, user: str, password: str) -> Non
             ImageCache,
         ],
     )
+    logger.info(f"{db_name} 连接成功！")
 
 
 def make_pg_context() -> ContextRepository:
@@ -180,17 +209,52 @@ def make_pg_image_cache() -> ImageCacheRepository:
     return PgImageCacheRepository()
 
 
-async def init_postgresql_db(host: str, port: int, user: str, password: str) -> None:
-    """
-    初始化 PostgreSQL 连接（预留骨架，尚未实现）。
+async def init_postgresql_db() -> None:
+    """初始化 PostgreSQL 连接"""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
 
-    当前 PG 后端仅包含接口骨架（repository_pg.Pg*Repository），数据库建库、
-    建表、ORM 映射等实际实现留给后续 PR。一旦实现完整，再填充此函数。
-    """
-    raise NotImplementedError(
-        "PostgreSQL 后端尚未实现。Repository 抽象层已就绪，但 PG 侧实现仅为骨架；"
-        "若要启用，请先完成 src/common/db/repository_pg.py 并补齐 pg optional-dependency。"
-    )
+    from .repository_pg import dispose_pg, init_pg
+
+    host = _cfg("PG_HOST", _cfg("MONGO_HOST", "127.0.0.1"))
+    port = int(_cfg("PG_PORT", "5432"))
+    user = _cfg("PG_USER", "")
+    password = _cfg("PG_PASSWORD", "")
+    db_name = _cfg("PG_DB", "PallasBot")
+    auth = f"{quote_plus(user)}:{quote_plus(password)}@" if user and password else ""
+    base_url = f"postgresql+asyncpg://{auth}{host}:{port}"
+
+    from nonebot.log import logger
+
+    logger.info(f"正在连接 PostgreSQL {host}:{port}，Database：{db_name}")
+
+    admin_engine = create_async_engine(f"{base_url}/postgres", isolation_level="AUTOCOMMIT")
+    try:
+        async with admin_engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :db"), {"db": db_name})
+            if result.scalar() is None:
+                logger.info(f"{db_name} 不存在，正在自动创建...")
+                await conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+                logger.info(f"{db_name} 创建成功")
+    finally:
+        await admin_engine.dispose()
+
+    engine = create_async_engine(f"{base_url}/{db_name}")
+    await init_pg(engine)
+    logger.info(f"{db_name} 连接成功！")
+
+    # bot 退出时释放连接池
+    try:
+        import nonebot
+
+        driver = nonebot.get_driver()
+
+        @driver.on_shutdown
+        async def _dispose_pg():
+            await dispose_pg()
+
+    except Exception:
+        pass
 
 
 register_backend(
@@ -277,12 +341,12 @@ def make_image_cache_repository() -> ImageCacheRepository:
     return IMAGE_CACHE_REPO_REGISTRY[backend]()
 
 
-async def init_db(host: str, port: int, user: str, password: str, backend: str | None = None) -> None:
+async def init_db(backend: str | None = None) -> None:
     """
     初始化数据库连接。
 
     根据 backend 参数选择后端，未传入时从环境变量 DB_BACKEND 读取，
-    默认使用 mongodb。新增后端只需调用 register_backend() 注册，无需修改此函数。
+    默认使用 mongodb。连接参数均从环境变量读取。
     """
     if backend is None:
         backend = get_db_backend()
@@ -290,4 +354,4 @@ async def init_db(host: str, port: int, user: str, password: str, backend: str |
     if backend not in INIT_DB_REGISTRY:
         raise ValueError(f"不支持的数据库后端: {backend}，已注册的后端: {list(INIT_DB_REGISTRY)}")
 
-    await INIT_DB_REGISTRY[backend](host, port, user, password)
+    await INIT_DB_REGISTRY[backend]()

--- a/src/common/db/repository_pg.py
+++ b/src/common/db/repository_pg.py
@@ -1,30 +1,365 @@
-"""PostgreSQL Repository 实现（预留接口，尚未实现）"""
+"""PostgreSQL Repository 实现"""
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import JSON, BigInteger, Boolean, ForeignKey, Text, delete, select, update
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, selectinload
+
 if TYPE_CHECKING:
-    from src.common.db.modules import Answer, Ban, BlackList, Context, ImageCache, Message
+    from src.common.db.modules import Answer, Ban, Context, ImageCache, Message
+
+_JsonB = JSONB().with_variant(JSON(), "sqlite")
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class ContextAnswerRow(Base):
+    __tablename__ = "context_answer"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    context_id: Mapped[int] = mapped_column(ForeignKey("context.id", ondelete="CASCADE"), nullable=False, index=True)
+    keywords: Mapped[str] = mapped_column(Text, nullable=False)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    count: Mapped[int] = mapped_column(nullable=False, default=1)
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+    messages: Mapped[list[ContextAnswerMessageRow]] = relationship(
+        "ContextAnswerMessageRow", cascade="all, delete-orphan", lazy="noload"
+    )
+
+
+class ContextAnswerMessageRow(Base):
+    __tablename__ = "context_answer_message"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    answer_id: Mapped[int] = mapped_column(
+        ForeignKey("context_answer.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class ContextBanRow(Base):
+    __tablename__ = "context_ban"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    context_id: Mapped[int] = mapped_column(ForeignKey("context.id", ondelete="CASCADE"), nullable=False, index=True)
+    keywords: Mapped[str] = mapped_column(Text, nullable=False)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+
+class ContextRow(Base):
+    __tablename__ = "context"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    keywords: Mapped[str] = mapped_column(Text, nullable=False)
+    keywords_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+    trigger_count: Mapped[int] = mapped_column(nullable=False, default=1)
+    clear_time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+    answers: Mapped[list[ContextAnswerRow]] = relationship(
+        "ContextAnswerRow", cascade="all, delete-orphan", lazy="noload"
+    )
+    ban: Mapped[list[ContextBanRow]] = relationship("ContextBanRow", cascade="all, delete-orphan", lazy="noload")
+
+
+class MessageRow(Base):
+    __tablename__ = "message"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    bot_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    raw_message: Mapped[str] = mapped_column(Text, nullable=False)
+    is_plain_text: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    plain_text: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    keywords: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+
+class BlackListRow(Base):
+    __tablename__ = "blacklist"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True, index=True)
+    answers: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+    answers_reserve: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+
+
+class BotConfigRow(Base):
+    __tablename__ = "bot_config"
+
+    account: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    admins: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+    auto_accept_friend: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    auto_accept_group: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    security: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    taken_name: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=dict)
+    drunk: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=dict)
+    disabled_plugins: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+
+
+class GroupConfigRow(Base):
+    __tablename__ = "group_config"
+
+    group_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    roulette_mode: Mapped[int] = mapped_column(nullable=False, default=1)
+    banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    sing_progress: Mapped[Any] = mapped_column(_JsonB, nullable=True)
+    disabled_plugins: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+
+
+class UserConfigRow(Base):
+    __tablename__ = "user_config"
+
+    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+
+class ImageCacheRow(Base):
+    __tablename__ = "image_cache"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    cq_code: Mapped[str] = mapped_column(Text, unique=True, nullable=False, index=True)
+    base64_data: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ref_times: Mapped[int] = mapped_column(nullable=False, default=1)
+    date: Mapped[int] = mapped_column(nullable=False, index=True)
+
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+@asynccontextmanager
+async def get_session():
+    if _session_factory is None:
+        raise RuntimeError("PostgreSQL 尚未初始化，请先调用 init_pg()")
+    async with _session_factory() as session:
+        yield session
+
+
+async def init_pg(engine: AsyncEngine) -> None:
+    """创建表结构并注入 engine"""
+    global _engine, _session_factory
+    _engine = engine
+    _session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def dispose_pg() -> None:
+    """关闭连接池，bot 退出时调用"""
+    global _engine
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+
+
+_LOAD_RELATED = [
+    selectinload(ContextRow.answers).selectinload(ContextAnswerRow.messages),
+    selectinload(ContextRow.ban),
+]
+
+
+def keywords_hash(keywords: str) -> str:
+    import hashlib
+
+    return hashlib.md5(keywords.encode()).hexdigest()
+
+
+# asyncpg 单语句参数上限 32767
+_ANSWER_BATCH = 500  # ContextAnswerRow 5 列 × 500 = 2500
+_MSG_BATCH = 16000  # ContextAnswerMessageRow 2 列 × 16000 = 32000
+_BAN_BATCH = 6000  # ContextBanRow 5 列 × 6000 = 30000
+
+
+async def _insert_answers_batched(session: AsyncSession, context_id: int, answers) -> None:
+    """分批插入 ContextAnswerRow 及其关联的 ContextAnswerMessageRow"""
+
+    for i in range(0, len(answers), _ANSWER_BATCH):
+        batch: list[Answer] = answers[i : i + _ANSWER_BATCH]
+        # 先插入 answer 行（不带 messages 关系，避免 SQLAlchemy 一次性级联）
+        rows = [
+            ContextAnswerRow(
+                context_id=context_id,
+                keywords=a.keywords,
+                group_id=a.group_id,
+                count=a.count,
+                time=a.time,
+            )
+            for a in batch
+        ]
+        session.add_all(rows)
+        await session.flush()  # 获取自增 id
+
+        # 再分批插入 message 行
+        msg_rows = [
+            ContextAnswerMessageRow(answer_id=rows[j].id, message=m) for j, a in enumerate(batch) for m in a.messages
+        ]
+        for k in range(0, len(msg_rows), _MSG_BATCH):
+            session.add_all(msg_rows[k : k + _MSG_BATCH])
+            await session.flush()
+
+
+async def _insert_bans_batched(session: AsyncSession, context_id: int, bans) -> None:
+    """分批插入 ContextBanRow"""
+    for i in range(0, len(bans), _BAN_BATCH):
+        batch = bans[i : i + _BAN_BATCH]
+        session.add_all([
+            ContextBanRow(
+                context_id=context_id,
+                keywords=b.keywords,
+                group_id=b.group_id,
+                reason=b.reason,
+                time=b.time,
+            )
+            for b in batch
+        ])
+        await session.flush()
+
+
+def row_to_context(row: ContextRow) -> Context:
+    from src.common.db.modules import Answer, Ban, Context
+
+    answers = [
+        Answer.model_construct(
+            keywords=a.keywords,
+            group_id=a.group_id,
+            count=a.count,
+            time=a.time,
+            messages=[m.message for m in a.messages],
+        )
+        for a in row.answers
+    ]
+    ban = [
+        Ban.model_construct(
+            keywords=b.keywords,
+            group_id=b.group_id,
+            reason=b.reason,
+            time=b.time,
+        )
+        for b in row.ban
+    ]
+    return Context.model_construct(
+        keywords=row.keywords,
+        time=row.time,
+        trigger_count=row.trigger_count,
+        answers=answers,
+        ban=ban,
+        clear_time=row.clear_time,
+    )
+
+
+def row_to_blacklist(row: BlackListRow):
+    from src.common.db.modules import BlackList
+
+    return BlackList.model_construct(
+        group_id=row.group_id,
+        answers=list(row.answers),
+        answers_reserve=list(row.answers_reserve),
+    )
+
+
+def row_to_image_cache(row: ImageCacheRow) -> ImageCache:
+    from src.common.db.modules import ImageCache
+
+    return ImageCache.model_construct(
+        cq_code=row.cq_code,
+        base64_data=row.base64_data,
+        ref_times=row.ref_times,
+        date=row.date,
+    )
 
 
 class PgContextRepository:
-    """PostgreSQL 版 ContextRepository 实现（预留）"""
-
     async def find_by_keywords(self, keywords: str) -> Context | None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            result = await session.execute(
+                select(ContextRow).options(*_LOAD_RELATED).where(ContextRow.keywords_hash == khash)
+            )
+            row = result.scalar_one_or_none()
+            return row_to_context(row) if row else None
 
     async def save(self, context: Context) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(context.keywords)
+        async with get_session() as session:
+            result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            row = result.scalar_one_or_none()
+
+            if row is None:
+                row = ContextRow(
+                    keywords=context.keywords,
+                    keywords_hash=khash,
+                    time=context.time,
+                    trigger_count=context.trigger_count,
+                    clear_time=context.clear_time,
+                )
+                session.add(row)
+                await session.flush()
+            else:
+                row.time = context.time
+                row.trigger_count = context.trigger_count
+                row.clear_time = context.clear_time
+                await session.execute(delete(ContextAnswerRow).where(ContextAnswerRow.context_id == row.id))
+                await session.execute(delete(ContextBanRow).where(ContextBanRow.context_id == row.id))
+
+            await _insert_answers_batched(session, row.id, context.answers)
+            await _insert_bans_batched(session, row.id, context.ban)
+            await session.commit()
 
     async def insert(self, context: Context) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(context.keywords)
+        try:
+            async with get_session() as session:
+                row = ContextRow(
+                    keywords=context.keywords,
+                    keywords_hash=khash,
+                    time=context.time,
+                    trigger_count=context.trigger_count,
+                    clear_time=context.clear_time,
+                )
+                session.add(row)
+                await session.flush()
+                await _insert_answers_batched(session, row.id, context.answers)
+                await _insert_bans_batched(session, row.id, context.ban)
+                await session.commit()
+        except IntegrityError:
+            # 另一个协程已插入相同 keywords，忽略即可
+            pass
 
     async def delete_expired(self, expiration: int, threshold: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            await session.execute(
+                delete(ContextRow).where(
+                    ContextRow.time < expiration,
+                    ContextRow.trigger_count < threshold,
+                )
+            )
+            await session.commit()
 
     async def find_for_cleanup(self, trigger_threshold: int, expiration: int) -> list[Context]:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(ContextRow)
+                .options(*_LOAD_RELATED)
+                .where(
+                    ContextRow.trigger_count >= trigger_threshold,
+                    ContextRow.clear_time <= expiration,
+                )
+            )
+            rows = result.scalars().all()
+            return [row_to_context(r) for r in rows]
 
     async def upsert_answer(
         self,
@@ -35,75 +370,221 @@ class PgContextRepository:
         message: str,
         append_on_existing: bool,
     ) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            ctx_row = ctx_result.scalar_one_or_none()
+            if ctx_row is None:
+                return
+
+            ans_result = await session.execute(
+                select(ContextAnswerRow).where(
+                    ContextAnswerRow.context_id == ctx_row.id,
+                    ContextAnswerRow.group_id == group_id,
+                    ContextAnswerRow.keywords == answer_keywords,
+                )
+            )
+            ans_row = ans_result.scalar_one_or_none()
+
+            if ans_row is not None:
+                ans_row.count += 1
+                ans_row.time = answer_time
+                if append_on_existing:
+                    session.add(ContextAnswerMessageRow(answer_id=ans_row.id, message=message))
+            else:
+                new_ans = ContextAnswerRow(
+                    context_id=ctx_row.id,
+                    keywords=answer_keywords,
+                    group_id=group_id,
+                    count=1,
+                    time=answer_time,
+                )
+                session.add(new_ans)
+                await session.flush()
+                session.add(ContextAnswerMessageRow(answer_id=new_ans.id, message=message))
+
+            ctx_row.trigger_count += 1
+            ctx_row.time = answer_time
+            await session.commit()
 
     async def replace_answers(self, keywords: str, answers: list[Answer], clear_time: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            ctx_row = ctx_result.scalar_one_or_none()
+            if ctx_row is None:
+                return
+
+            await session.execute(delete(ContextAnswerRow).where(ContextAnswerRow.context_id == ctx_row.id))
+            await _insert_answers_batched(session, ctx_row.id, answers)
+            ctx_row.clear_time = clear_time
+            await session.commit()
 
     async def append_ban(self, keywords: str, ban: Ban) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            ctx_row = ctx_result.scalar_one_or_none()
+            if ctx_row is None:
+                return
+
+            session.add(
+                ContextBanRow(
+                    context_id=ctx_row.id,
+                    keywords=ban.keywords,
+                    group_id=ban.group_id,
+                    reason=ban.reason,
+                    time=ban.time,
+                )
+            )
+            await session.commit()
 
 
 class PgMessageRepository:
-    """PostgreSQL 版 MessageRepository 实现（预留）"""
+    # MessageRow 有 8 列，asyncpg 单语句参数上限 32767，保守取 4000 行/批
+    _BULK_BATCH_SIZE = 4000
 
     async def bulk_insert(self, messages: list[Message]) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            for i in range(0, len(messages), self._BULK_BATCH_SIZE):
+                batch = messages[i : i + self._BULK_BATCH_SIZE]
+                session.add_all([
+                    MessageRow(
+                        group_id=m.group_id,
+                        user_id=m.user_id,
+                        bot_id=m.bot_id,
+                        raw_message=m.raw_message,
+                        is_plain_text=m.is_plain_text,
+                        plain_text=m.plain_text,
+                        keywords=m.keywords,
+                        time=m.time,
+                    )
+                    for m in batch
+                ])
+                await session.flush()
+            await session.commit()
 
 
 class PgBlackListRepository:
-    """PostgreSQL 版 BlackListRepository 实现（预留）"""
-
-    async def find_all(self) -> list[BlackList]:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+    async def find_all(self):
+        async with get_session() as session:
+            result = await session.execute(select(BlackListRow))
+            rows = result.scalars().all()
+            return [row_to_blacklist(r) for r in rows]
 
     async def upsert_answers(self, group_id: int, answers: list[str]) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(BlackListRow).where(BlackListRow.group_id == group_id))
+            row = result.scalar_one_or_none()
+            if row is None:
+                session.add(BlackListRow(group_id=group_id, answers=answers, answers_reserve=[]))
+            else:
+                row.answers = answers
+            await session.commit()
 
     async def upsert_answers_reserve(self, group_id: int, answers: list[str]) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(BlackListRow).where(BlackListRow.group_id == group_id))
+            row = result.scalar_one_or_none()
+            if row is None:
+                session.add(BlackListRow(group_id=group_id, answers=[], answers_reserve=answers))
+            else:
+                row.answers_reserve = answers
+            await session.commit()
+
+
+_CONFIG_TABLE_MAP: dict[str, tuple[type, str]] = {
+    "bot_config": (BotConfigRow, "account"),
+    "group_config": (GroupConfigRow, "group_id"),
+    "user_config": (UserConfigRow, "user_id"),
+}
 
 
 class PgConfigRepository:
-    """
-    PostgreSQL 版 ConfigRepository 实现（预留）。
-
-    通过 (table, primary_key) 绑定到不同配置表，未来实现时可直接用同一份
-    SQL 逻辑服务 Bot/Group/User 三种配置。
-    """
-
     def __init__(self, table: str, primary_key: str) -> None:
-        self._table = table
-        self._primary_key = primary_key
+        if table not in _CONFIG_TABLE_MAP:
+            raise ValueError(f"Unknown config table: {table}")
+        self._row_class, self._pk_field = _CONFIG_TABLE_MAP[table]
 
     async def get(self, key_id: int, *, ignore_cache: bool = False) -> Any | None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+            )
+            return result.scalar_one_or_none()
 
     async def get_or_create(self, key_id: int, **defaults: Any) -> tuple[Any, bool]:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+            )
+            row = result.scalar_one_or_none()
+            if row is not None:
+                return row, False
+            new_row = self._row_class(**{self._pk_field: key_id, **defaults})
+            session.add(new_row)
+            await session.commit()
+            return new_row, True
 
     async def upsert_field(self, key_id: int, field: str, value: Any) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+            )
+            row = result.scalar_one_or_none()
+            if row is not None:
+                await session.execute(
+                    update(self._row_class)
+                    .where(getattr(self._row_class, self._pk_field) == key_id)
+                    .values(**{field: value})
+                )
+            else:
+                session.add(self._row_class(**{self._pk_field: key_id, field: value}))
+            await session.commit()
 
     async def invalidate_cache(self) -> None:
-        # PG 无 Beanie 级缓存，no-op
         return None
 
 
 class PgImageCacheRepository:
-    """PostgreSQL 版 ImageCacheRepository 实现（预留）"""
-
     async def find_by_cq_code(self, cq_code: str) -> ImageCache | None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(ImageCacheRow).where(ImageCacheRow.cq_code == cq_code))
+            row = result.scalar_one_or_none()
+            return row_to_image_cache(row) if row else None
 
     async def insert(self, cache: ImageCache) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        try:
+            async with get_session() as session:
+                session.add(
+                    ImageCacheRow(
+                        cq_code=cache.cq_code,
+                        base64_data=cache.base64_data,
+                        ref_times=cache.ref_times,
+                        date=cache.date,
+                    )
+                )
+                await session.commit()
+        except IntegrityError:
+            # 另一个协程已插入相同 cq_code，忽略即可
+            pass
 
     async def save(self, cache: ImageCache) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(ImageCacheRow).where(ImageCacheRow.cq_code == cache.cq_code))
+            row = result.scalar_one_or_none()
+            if row is not None:
+                row.ref_times = cache.ref_times
+                row.date = cache.date
+                row.base64_data = cache.base64_data
+                await session.commit()
 
     async def delete_old(self, before_date: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            await session.execute(delete(ImageCacheRow).where(ImageCacheRow.date < before_date))
+            await session.commit()
 
     async def delete_low_ref(self, ref_threshold: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            await session.execute(delete(ImageCacheRow).where(ImageCacheRow.ref_times < ref_threshold))
+            await session.commit()

--- a/src/common/utils/media_cache/__init__.py
+++ b/src/common/utils/media_cache/__init__.py
@@ -16,7 +16,9 @@ async def insert_image(image_seg: MessageSegment):
     cq_code = re.sub(r"\.image,.+?\]", ".image]", str(image_seg))
     cache = await image_cache_repo.find_by_cq_code(cq_code)
     if not cache:
-        cache = ImageCache(cq_code=cq_code)
+        cache = ImageCache.model_construct(
+            cq_code=cq_code, base64_data=None, ref_times=1, date=int(str(datetime.now().date()).replace("-", ""))
+        )
         await image_cache_repo.insert(cache)
         return
     cache.ref_times += 1

--- a/src/plugins/repeater/learner.py
+++ b/src/plugins/repeater/learner.py
@@ -94,10 +94,12 @@ class Learner:
                 append_on_existing=chat_data.is_plain_text,
             )
         else:
-            context = Context(
+            context = Context.model_construct(
                 keywords=pre_keywords,
                 time=cur_time,
-                trigger_count=1,  # type: ignore
+                trigger_count=1,
                 answers=[Answer(keywords=keywords, group_id=group_id, count=1, time=cur_time, messages=[raw_message])],
+                ban=[],
+                clear_time=0,
             )
             await context_repo.insert(context)

--- a/src/plugins/repeater/message_store.py
+++ b/src/plugins/repeater/message_store.py
@@ -52,7 +52,7 @@ class MessageStore:
 
         async with MessageStore._message_lock:
             MessageStore._message_dict[group_id].append(
-                MessageModel(
+                MessageModel.model_construct(
                     group_id=group_id,
                     user_id=chat_data.user_id,
                     bot_id=chat_data.bot_id,

--- a/tests/common/test_backend_switching.py
+++ b/tests/common/test_backend_switching.py
@@ -24,6 +24,15 @@ class _FakeContextRepo:
     async def find_for_cleanup(self, trigger_threshold, expiration):  # noqa: ARG002
         return []
 
+    async def upsert_answer(self, keywords, group_id, answer_keywords, answer_time, message, append_on_existing):  # noqa: ARG002
+        return None
+
+    async def replace_answers(self, keywords, answers, clear_time):  # noqa: ARG002
+        return None
+
+    async def append_ban(self, keywords, ban):  # noqa: ARG002
+        return None
+
 
 class _FakeMessageRepo:
     async def bulk_insert(self, messages):  # noqa: ARG002
@@ -41,7 +50,7 @@ class _FakeBlackListRepo:
         return None
 
 
-async def _fake_init(host, port, user, password):  # noqa: ARG001
+async def _fake_init():
     return None
 
 
@@ -107,13 +116,4 @@ async def test_init_db_dispatches_to_registered_backend(fake_backend):
     from src.common.db import init_db
 
     # fake backend 的 init 直接返回 None 不抛异常
-    await init_db("host", 0, "", "", backend=fake_backend)
-
-
-@pytest.mark.asyncio
-async def test_init_db_postgresql_skeleton_raises():
-    """当前 postgresql 后端为 skeleton-only，init 应抛 NotImplementedError。"""
-    from src.common.db import init_db
-
-    with pytest.raises(NotImplementedError, match="PostgreSQL"):
-        await init_db("host", 5432, "", "", backend="postgresql")
+    await init_db(backend=fake_backend)

--- a/tools/migrate_mongo_to_pg.py
+++ b/tools/migrate_mongo_to_pg.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""
+MongoDB → PostgreSQL 迁移脚本
+
+迁移范围：Context、Message、BlackList、BotConfig、GroupConfig、UserConfig、ImageCache
+
+用法：
+    uv run --extra pg python tools/migrate_mongo_to_pg.py
+
+选项：
+    --batch N       每批处理条数，默认 1000
+    --dry-run       只统计数量，不写入 PostgreSQL
+    --pg-db NAME    目标 PostgreSQL 数据库名，默认读取 PG_DB 环境变量（fallback: PallasBot）
+    --tables TABLE  仅迁移指定表（可多选），可选值：
+                      context message blacklist botconfig groupconfig userconfig imagecache
+
+示例：
+    # 全量迁移
+    uv run --extra pg python tools/migrate_mongo_to_pg.py
+
+    # 指定目标数据库名
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --pg-db MyBot
+
+    # 仅迁移消息和上下文，每批 500 条
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --tables context message --batch 500
+
+    # 预演（不写入数据库）
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --dry-run
+
+环境变量（从 .env 读取，也可手动设置）：
+    MONGO_HOST / MONGO_PORT / MONGO_USER / MONGO_PASSWORD
+    PG_HOST / PG_PORT / PG_USER / PG_PASSWORD / PG_DB
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.parse import quote_plus
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(ROOT / ".env")
+except ImportError:
+    env_file = ROOT / ".env"
+    if env_file.exists():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                os.environ.setdefault(k.strip(), v.strip())
+
+ALL_TABLES = ["context", "message", "blacklist", "botconfig", "groupconfig", "userconfig", "imagecache"]
+
+# asyncpg 单语句参数上限 32767
+_ANS_BATCH = 6000  # ContextAnswerRow    5 列
+_MSG_BATCH = 16000  # ContextAnswerMsg    2 列
+_BAN_BATCH = 6000  # ContextBanRow       5 列
+_IC_BATCH = 6000  # ImageCacheRow       4 列
+_MSG_ROW_BATCH = 4000  # MessageRow       8 列
+
+
+def _mongo_dsn() -> str:
+    h, p = os.getenv("MONGO_HOST", "127.0.0.1"), int(os.getenv("MONGO_PORT", "27017"))
+    u, pw = os.getenv("MONGO_USER", ""), os.getenv("MONGO_PASSWORD", "")
+    return f"mongodb://{quote_plus(u)}:{quote_plus(pw)}@{h}:{p}" if u and pw else f"mongodb://{h}:{p}"
+
+
+def _pg_dsn() -> str:
+    h = os.getenv("PG_HOST", os.getenv("MONGO_HOST", "127.0.0.1"))
+    p = int(os.getenv("PG_PORT", "5432"))
+    u, pw = os.getenv("PG_USER", ""), os.getenv("PG_PASSWORD", "")
+    db = os.getenv("PG_DB", "PallasBot")
+    auth = f"{quote_plus(u)}:{quote_plus(pw)}@" if u and pw else ""
+    return f"postgresql+asyncpg://{auth}{h}:{p}/{db}"
+
+
+def _strip_null(obj):
+    """递归去除 PostgreSQL 不支持的 \\u0000 字符"""
+    if isinstance(obj, str):
+        return obj.replace("\x00", "")
+    if isinstance(obj, dict):
+        return {k: _strip_null(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_strip_null(i) for i in obj]
+    return obj
+
+
+def _kw_hash(keywords: str) -> str:
+    import hashlib
+
+    return hashlib.md5(keywords.encode("utf-8", errors="replace")).hexdigest()
+
+
+async def _ensure_db() -> None:
+    import re
+
+    import asyncpg
+
+    h = os.getenv("PG_HOST", os.getenv("MONGO_HOST", "127.0.0.1"))
+    p = int(os.getenv("PG_PORT", "5432"))
+    u, pw = os.getenv("PG_USER", "") or None, os.getenv("PG_PASSWORD", "") or None
+    db = os.getenv("PG_DB", "PallasBot")
+    if not re.match(r"^[A-Za-z0-9_\-]+$", db):
+        raise ValueError(f"非法数据库名: {db!r}")
+    conn = await asyncpg.connect(host=h, port=p, user=u, password=pw, database="postgres")
+    try:
+        if not await conn.fetchval("SELECT 1 FROM pg_database WHERE datname=$1", db):
+            await conn.execute(f'CREATE DATABASE "{db}"')
+            print(f"已创建数据库 {db}")
+        else:
+            print(f"数据库 {db} 已存在")
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 各表迁移函数
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_context(Context, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, batch_size, dry_run):
+    from sqlalchemy import delete as D
+    from sqlalchemy import select as S
+
+    total = await Context.count()
+    print(f"\n📦 Context: {total} 条")
+    migrated = skip = 0
+
+    while True:
+        batch = await Context.find_all().skip(skip).limit(batch_size).to_list()
+        if not batch:
+            break
+
+        seen: dict[str, tuple] = {}
+        for doc in batch:
+            h = _kw_hash(doc.keywords)
+            seen[h] = (
+                doc,
+                {
+                    "keywords": _strip_null(doc.keywords),
+                    "keywords_hash": h,
+                    "time": doc.time,
+                    "trigger_count": doc.trigger_count,
+                    "clear_time": doc.clear_time,
+                },
+            )
+
+        if not dry_run:
+            async with sf() as session:
+                stmt = ins(ContextRow).values([v[1] for v in seen.values()])
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["keywords_hash"],
+                        set_={
+                            "keywords": stmt.excluded.keywords,
+                            "time": stmt.excluded.time,
+                            "trigger_count": stmt.excluded.trigger_count,
+                            "clear_time": stmt.excluded.clear_time,
+                        },
+                    )
+                )
+                await session.commit()
+
+                result = await session.execute(
+                    S(ContextRow.id, ContextRow.keywords_hash).where(ContextRow.keywords_hash.in_(seen.keys()))
+                )
+                h2id = {r.keywords_hash: r.id for r in result}
+                ctx_ids = list(h2id.values())
+                await session.execute(D(AnsRow).where(AnsRow.context_id.in_(ctx_ids)))
+                await session.execute(D(BanRow).where(BanRow.context_id.in_(ctx_ids)))
+
+                ans_data, ban_rows = [], []
+                for h, (doc, _) in seen.items():
+                    cid = h2id.get(h)
+                    if cid is None:
+                        continue
+                    for a in doc.answers:
+                        ans_data.append({
+                            "context_id": cid,
+                            "keywords": _strip_null(a.keywords),
+                            "group_id": a.group_id,
+                            "count": a.count,
+                            "time": a.time,
+                            "_msgs": [_strip_null(m) for m in a.messages],
+                        })
+                    for b in doc.ban:
+                        ban_rows.append({
+                            "context_id": cid,
+                            "keywords": _strip_null(b.keywords),
+                            "group_id": b.group_id,
+                            "reason": _strip_null(b.reason),
+                            "time": b.time,
+                        })
+
+                if ans_data:
+                    no_msg = [{k: v for k, v in d.items() if k != "_msgs"} for d in ans_data]
+                    lookup: dict[tuple, list[int]] = {}
+                    for i in range(0, len(no_msg), _ANS_BATCH):
+                        ret = await session.execute(
+                            ins(AnsRow)
+                            .values(no_msg[i : i + _ANS_BATCH])
+                            .returning(AnsRow.id, AnsRow.context_id, AnsRow.group_id, AnsRow.keywords)
+                        )
+                        for r in ret.fetchall():
+                            lookup.setdefault((r.context_id, r.group_id, r.keywords), []).append(r.id)
+
+                    msg_rows = []
+                    for d in ans_data:
+                        ids = lookup.get((d["context_id"], d["group_id"], d["keywords"]), [])
+                        if ids:
+                            aid = ids.pop(0)
+                            msg_rows.extend({"answer_id": aid, "message": m} for m in d["_msgs"])
+                    for i in range(0, len(msg_rows), _MSG_BATCH):
+                        await session.execute(ins(AnsMsgRow).values(msg_rows[i : i + _MSG_BATCH]))
+
+                for i in range(0, len(ban_rows), _BAN_BATCH):
+                    await session.execute(ins(BanRow).values(ban_rows[i : i + _BAN_BATCH]))
+                await session.commit()
+
+        migrated += len(batch)
+        skip += batch_size
+        print(f"  Context {migrated}/{total}", end="\r")
+    print(f"  Context {migrated}/{total} ✓")
+
+
+async def _migrate_message(Message, sf, MsgRow, ins, batch_size, dry_run):
+    col = Message.get_pymongo_collection()
+    total = await col.count_documents({})
+    print(f"\n📦 Message: {total} 条")
+    migrated, batch = 0, []
+
+    async for doc in col.find({}, batch_size=batch_size):
+        raw = doc.get("raw_message", "")
+        batch.append(
+            _strip_null({
+                "group_id": int(doc.get("group_id", 0)),
+                "user_id": int(doc.get("user_id", 0)),
+                "bot_id": int(doc.get("bot_id", 0)),
+                "raw_message": raw,
+                "is_plain_text": doc.get("is_plain_text", True),
+                "plain_text": doc.get("plain_text", raw),
+                "keywords": doc.get("keywords", ""),
+                "time": doc.get("time", 0),
+            })
+        )
+        if len(batch) >= _MSG_ROW_BATCH:
+            if not dry_run:
+                async with sf() as session:
+                    await session.execute(ins(MsgRow).values(batch).on_conflict_do_nothing())
+                    await session.commit()
+            migrated += len(batch)
+            batch = []
+            print(f"  Message {migrated}/{total}", end="\r")
+
+    if batch:
+        if not dry_run:
+            async with sf() as session:
+                await session.execute(ins(MsgRow).values(batch).on_conflict_do_nothing())
+                await session.commit()
+        migrated += len(batch)
+    print(f"  Message {migrated}/{total} ✓")
+
+
+async def _migrate_blacklist(BlackList, sf, BLRow, ins, dry_run):
+    total = await BlackList.count()
+    print(f"\n📦 BlackList: {total} 条")
+    docs = await BlackList.find_all().to_list()
+    if not docs:
+        print("  BlackList 0/0 ✓")
+        return
+    rows = [
+        _strip_null({"group_id": int(d.group_id), "answers": d.answers, "answers_reserve": d.answers_reserve})
+        for d in docs
+    ]
+    if not dry_run:
+        async with sf() as session:
+            stmt = ins(BLRow).values(rows)
+            await session.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["group_id"],
+                    set_={"answers": stmt.excluded.answers, "answers_reserve": stmt.excluded.answers_reserve},
+                )
+            )
+            await session.commit()
+    print(f"  BlackList {len(docs)}/{total} ✓")
+
+
+async def _migrate_bot_config(BotConfigModule, sf, BCRow, ins, dry_run):
+    col = BotConfigModule.get_pymongo_collection()
+    total = await col.count_documents({})
+    print(f"\n📦 BotConfig: {total} 条")
+    raw_docs = await col.find({}).to_list(length=None)
+    if not raw_docs:
+        print("  BotConfig 0/0 ✓")
+        return
+
+    rows = []
+    for raw in raw_docs:
+        try:
+            if "auto_accept" in raw and "auto_accept_group" not in raw:
+                ag, af = bool(raw["auto_accept"]), False
+            else:
+                ag = bool(raw.get("auto_accept_group", False))
+                af = bool(raw.get("auto_accept_friend", False))
+            admins = []
+            for x in raw.get("admins", []):
+                try:
+                    admins.append(int(x))
+                except (TypeError, ValueError):
+                    print(f"  ⚠️  BotConfig account={raw.get('account')} admins 跳过无效值: {x!r}")
+            tn = raw.get("taken_name", {})
+            dk = raw.get("drunk", {})
+            rows.append(
+                _strip_null({
+                    "account": int(raw["account"]),
+                    "admins": admins,
+                    "auto_accept_friend": af,
+                    "auto_accept_group": ag,
+                    "security": bool(raw.get("security", False)),
+                    "taken_name": {str(k): v for k, v in (tn.items() if isinstance(tn, dict) else {})},
+                    "drunk": {str(k): v for k, v in (dk.items() if isinstance(dk, dict) else {})},
+                    "disabled_plugins": raw.get("disabled_plugins", []),
+                })
+            )
+        except Exception as e:
+            print(f"  ⚠️  BotConfig 跳过 account={raw.get('account')}: {e}")
+
+    if not dry_run:
+        async with sf() as session:
+            stmt = ins(BCRow).values(rows)
+            await session.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["account"],
+                    set_={
+                        f: getattr(stmt.excluded, f)
+                        for f in [
+                            "admins",
+                            "auto_accept_friend",
+                            "auto_accept_group",
+                            "security",
+                            "taken_name",
+                            "drunk",
+                            "disabled_plugins",
+                        ]
+                    },
+                )
+            )
+            await session.commit()
+    print(f"  BotConfig {len(rows)}/{total} ✓")
+
+
+async def _migrate_group_config(GroupConfigModule, sf, GCRow, ins, dry_run):
+    total = await GroupConfigModule.count()
+    print(f"\n📦 GroupConfig: {total} 条")
+    docs = await GroupConfigModule.find_all().to_list()
+    if not docs:
+        print("  GroupConfig 0/0 ✓")
+        return
+    rows = [
+        _strip_null({
+            "group_id": int(d.group_id),
+            "roulette_mode": d.roulette_mode,
+            "banned": d.banned,
+            "sing_progress": json.loads(d.sing_progress.model_dump_json()) if d.sing_progress else None,
+            "disabled_plugins": d.disabled_plugins,
+        })
+        for d in docs
+    ]
+    if not dry_run:
+        async with sf() as session:
+            stmt = ins(GCRow).values(rows)
+            await session.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["group_id"],
+                    set_={
+                        f: getattr(stmt.excluded, f)
+                        for f in ["roulette_mode", "banned", "sing_progress", "disabled_plugins"]
+                    },
+                )
+            )
+            await session.commit()
+    print(f"  GroupConfig {len(docs)}/{total} ✓")
+
+
+async def _migrate_user_config(UserConfigModule, sf, UCRow, ins, batch_size, dry_run):
+    total = await UserConfigModule.count()
+    print(f"\n📦 UserConfig: {total} 条")
+    migrated = skip = 0
+    while True:
+        batch = await UserConfigModule.find_all().skip(skip).limit(batch_size).to_list()
+        if not batch:
+            break
+        rows = [_strip_null({"user_id": int(d.user_id), "banned": d.banned}) for d in batch]
+        if not dry_run:
+            async with sf() as session:
+                stmt = ins(UCRow).values(rows)
+                await session.execute(
+                    stmt.on_conflict_do_update(index_elements=["user_id"], set_={"banned": stmt.excluded.banned})
+                )
+                await session.commit()
+        migrated += len(batch)
+        skip += batch_size
+        print(f"  UserConfig {migrated}/{total}", end="\r")
+    print(f"  UserConfig {migrated}/{total} ✓")
+
+
+async def _migrate_image_cache(ImageCache, sf, ICRow, ins, batch_size, dry_run):
+    col = ImageCache.get_pymongo_collection()
+    total = await col.count_documents({})
+    print(f"\n📦 ImageCache: {total} 条")
+    migrated, batch = 0, []
+
+    async for doc in col.find({}, batch_size=batch_size):
+        batch.append(
+            _strip_null({
+                "cq_code": doc.get("cq_code", ""),
+                "base64_data": doc.get("base64_data"),
+                "ref_times": int(doc.get("ref_times", 1)),
+                "date": int(doc.get("date", 0)),
+            })
+        )
+        if len(batch) >= _IC_BATCH:
+            if not dry_run:
+                async with sf() as session:
+                    stmt = ins(ICRow).values(batch)
+                    await session.execute(
+                        stmt.on_conflict_do_update(
+                            index_elements=["cq_code"],
+                            set_={f: getattr(stmt.excluded, f) for f in ["base64_data", "ref_times", "date"]},
+                        )
+                    )
+                    await session.commit()
+            migrated += len(batch)
+            batch = []
+            print(f"  ImageCache {migrated}/{total}", end="\r")
+
+    if batch:
+        if not dry_run:
+            async with sf() as session:
+                stmt = ins(ICRow).values(batch)
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["cq_code"],
+                        set_={f: getattr(stmt.excluded, f) for f in ["base64_data", "ref_times", "date"]},
+                    )
+                )
+                await session.commit()
+        migrated += len(batch)
+    print(f"  ImageCache {migrated}/{total} ✓")
+
+
+# ---------------------------------------------------------------------------
+# 主入口
+# ---------------------------------------------------------------------------
+
+
+async def migrate(batch_size: int, dry_run: bool, tables: set[str], pg_db: str | None = None) -> None:
+    if pg_db:
+        os.environ["PG_DB"] = pg_db
+    try:
+        from sqlalchemy.ext.asyncio import create_async_engine
+    except ImportError:
+        print("❌ 缺少 SQLAlchemy/asyncpg，请执行：uv sync --extra pg")
+        sys.exit(1)
+
+    from beanie import init_beanie
+    from pymongo import AsyncMongoClient
+    from sqlalchemy import text as T
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from src.common.db.modules import (
+        BlackList,
+        BotConfigModule,
+        Context,
+        GroupConfigModule,
+        ImageCache,
+        Message,
+        UserConfigModule,
+    )
+    from src.common.db.repository_pg import (
+        BlackListRow,
+        BotConfigRow,
+        ContextAnswerMessageRow,
+        ContextAnswerRow,
+        ContextBanRow,
+        ContextRow,
+        GroupConfigRow,
+        ImageCacheRow,
+        MessageRow,
+        UserConfigRow,
+        init_pg,
+    )
+
+    print(f"🔗 连接 MongoDB: {_mongo_dsn()}")
+    mongo_client = AsyncMongoClient(_mongo_dsn(), unicode_decode_error_handler="ignore")
+    await init_beanie(
+        database=mongo_client["PallasBot"],
+        document_models=[Context, Message, BlackList, BotConfigModule, GroupConfigModule, UserConfigModule, ImageCache],
+    )
+
+    print(f"🔗 连接 PostgreSQL: {_pg_dsn()}")
+    if not dry_run:
+        await _ensure_db()
+
+    engine = create_async_engine(_pg_dsn(), echo=False)
+    if not dry_run:
+        await init_pg(engine)
+        async with engine.begin() as conn:
+            # 删除旧的 keywords 唯一约束（超长值会超出 btree 2704 字节限制）
+            await conn.execute(T("ALTER TABLE context DROP CONSTRAINT IF EXISTS context_keywords_key"))
+            await conn.execute(T("DROP INDEX IF EXISTS ix_context_keywords"))
+            await conn.execute(T("ALTER TABLE context ADD COLUMN IF NOT EXISTS keywords_hash TEXT"))
+            await conn.execute(T("UPDATE context SET keywords_hash = md5(keywords) WHERE keywords_hash IS NULL"))
+            await conn.execute(T("ALTER TABLE context ALTER COLUMN keywords_hash SET NOT NULL"))
+            await conn.execute(
+                T("CREATE UNIQUE INDEX IF NOT EXISTS ix_context_keywords_hash ON context (keywords_hash)")
+            )
+
+    sf = async_sessionmaker(engine, expire_on_commit=False)
+
+    if "context" in tables:
+        await _migrate_context(
+            Context,
+            sf,
+            ContextRow,
+            ContextAnswerRow,
+            ContextAnswerMessageRow,
+            ContextBanRow,
+            pg_insert,
+            batch_size,
+            dry_run,
+        )
+    if "message" in tables:
+        await _migrate_message(Message, sf, MessageRow, pg_insert, batch_size, dry_run)
+    if "blacklist" in tables:
+        await _migrate_blacklist(BlackList, sf, BlackListRow, pg_insert, dry_run)
+    if "botconfig" in tables:
+        await _migrate_bot_config(BotConfigModule, sf, BotConfigRow, pg_insert, dry_run)
+    if "groupconfig" in tables:
+        await _migrate_group_config(GroupConfigModule, sf, GroupConfigRow, pg_insert, dry_run)
+    if "userconfig" in tables:
+        await _migrate_user_config(UserConfigModule, sf, UserConfigRow, pg_insert, batch_size, dry_run)
+    if "imagecache" in tables:
+        await _migrate_image_cache(ImageCache, sf, ImageCacheRow, pg_insert, batch_size, dry_run)
+
+    await engine.dispose()
+    print("\n✅ 迁移完成")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="MongoDB → PostgreSQL 数据迁移",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"可迁移的表：{', '.join(ALL_TABLES)}",
+    )
+    parser.add_argument("--batch", type=int, default=1000, metavar="N", help="每批处理条数（默认 1000）")
+    parser.add_argument("--dry-run", action="store_true", help="只统计数量，不写入 PostgreSQL")
+    parser.add_argument("--pg-db", metavar="NAME", help="目标 PostgreSQL 数据库名（覆盖 PG_DB 环境变量）")
+    parser.add_argument(
+        "--tables", nargs="+", choices=ALL_TABLES, metavar="TABLE", help="仅迁移指定表（空格分隔），不指定则迁移全部"
+    )
+    args = parser.parse_args()
+
+    selected = set(args.tables) if args.tables else set(ALL_TABLES)
+    if args.dry_run:
+        print("⚠️  dry-run 模式，不会写入 PostgreSQL")
+    if args.tables:
+        print(f"📋 仅迁移：{', '.join(t for t in ALL_TABLES if t in selected)}")
+
+    asyncio.run(migrate(args.batch, args.dry_run, selected, args.pg_db))


### PR DESCRIPTION
- 实现了完整的 PostgreSQL 数据库后端，包括表结构定义和 ORM 映射
- 支持自动创建数据库，如果目标数据库不存在
- 添加了 PostgreSQL 连接参数从环境变量或 nonebot 配置中读取的功能
- 实现了所有 Repository 接口的 PostgreSQL 版本，包括 Context、Message、BlackList、Config 和 ImageCache
- 支持批量插入操作以提高性能，并处理了并发插入冲突
- 更新了数据库初始化流程，现在根据配置动态选择后端类型

## Summary by Sourcery

添加一个功能完整的 PostgreSQL 数据库后端，并将数据库初始化重构为由配置驱动的方式，包括用于迁移现有 MongoDB 数据的工具。

新功能：
- 为上下文、消息、黑名单、配置和图片缓存数据引入完整的 PostgreSQL ORM 模型和仓储实现。
- 支持通过 NoneBot 配置或环境变量动态选择数据库后端（MongoDB 或 PostgreSQL），无需修改代码。
- 添加独立的 MongoDB 到 PostgreSQL 迁移脚本，覆盖所有主要数据集合。

增强：
- 重构 MongoDB 初始化，使其从 NoneBot 配置或环境变量中读取连接参数和数据库名，并增加连接日志。
- 简化通用数据库初始化 API，不再需要显式传入 host/port/user/password 参数。
- 调整配置、复读机与媒体缓存相关代码，以与新的 PostgreSQL 层兼容的、与后端无关的方式构造和序列化模型。

测试：
- 更新后端切换测试，以匹配新的 `init_db` 函数签名和现已实现的 PostgreSQL 后端行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a fully functional PostgreSQL database backend and refactor database initialization to be configuration-driven, including tooling to migrate existing MongoDB data.

New Features:
- Introduce complete PostgreSQL ORM models and repository implementations for context, messages, blacklist, config, and image cache data.
- Support selecting the database backend (MongoDB or PostgreSQL) dynamically via NoneBot config or environment variables without changing code.
- Add a standalone MongoDB-to-PostgreSQL migration script covering all major data collections.

Enhancements:
- Refactor MongoDB initialization to read connection parameters and database name from NoneBot config or environment variables and add connection logging.
- Simplify the generic database initialization API to no longer require explicit host/port/user/password arguments.
- Adjust config, repeater, and media cache code to construct and serialize models in a backend-agnostic way compatible with the new PostgreSQL layer.

Tests:
- Update backend switching tests to match the new init_db signature and the now-implemented PostgreSQL backend behavior.

</details>