### PR TITLE
feat(db): 引入 PostgreSQL 后端与 Mongo→PG 迁移方案

### DIFF
--- a/.env
+++ b/.env
@@ -28,7 +28,8 @@ MONGO_PASSWORD=
 #PG_PASSWORD=
 # PostgreSQL 数据库名，默认 PallasBot；不存在时会自动创建
 #PG_DB=PallasBot
-
+# PG_POOL_SIZE=20
+# PG_MAX_OVERFLOW=40
 
 # 以下配置项均有默认值，保持注释即使用默认值
 

--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ PORT=8088
 # 数据库后端选择，目前仅 mongodb 可用于生产。
 # postgresql 当前仅为 Repository 抽象骨架（repository_pg.py 里所有方法 NotImplementedError），
 # 设置为 postgresql 会在 init 阶段报错；真正可用要等后续 PR 完成 PG 实现。
-DB_BACKEND=mongodb
+DB_BACKEND=postgresql
 
 # mongodb 相关配置，请勿注释，如无特殊需求无需更改
 
@@ -18,15 +18,15 @@ MONGO_PORT=27017
 # 请勿注释，如需认证可填写以下两项
 MONGO_USER=
 MONGO_PASSWORD=
+#MONGO_DB=PallasBot
 
-# postgresql 相关配置（预留占位，skeleton-only）
-# 启用前需：
-#  1. uv sync --extra pg 安装 sqlalchemy + asyncpg
-#  2. 完成 src/common/db/repository_pg.py 的实际实现
+# postgresql 相关配置
+# 启用前需：uv sync --extra pg 安装 sqlalchemy + asyncpg
 #PG_HOST=127.0.0.1
 #PG_PORT=5432
 #PG_USER=
 #PG_PASSWORD=
+# PostgreSQL 数据库名，默认 PallasBot；不存在时会自动创建
 #PG_DB=PallasBot
 
 

--- a/.env
+++ b/.env
@@ -6,10 +6,9 @@ HOST=0.0.0.0
 PORT=8088
 
 
-# 数据库后端选择，目前仅 mongodb 可用于生产。
-# postgresql 当前仅为 Repository 抽象骨架（repository_pg.py 里所有方法 NotImplementedError），
-# 设置为 postgresql 会在 init 阶段报错；真正可用要等后续 PR 完成 PG 实现。
-DB_BACKEND=postgresql
+# 数据库后端选择：mongodb（默认）或 postgresql。
+# postgresql 启用前需先执行：uv sync --extra pg
+DB_BACKEND=mongodb
 
 # mongodb 相关配置，请勿注释，如无特殊需求无需更改
 
@@ -22,14 +21,21 @@ MONGO_PASSWORD=
 
 # postgresql 相关配置
 # 启用前需：uv sync --extra pg 安装 sqlalchemy + asyncpg
+# 若未设置 PG_HOST，会 fallback 使用 MONGO_HOST（仅适合同机部署，否则请显式填写）
 #PG_HOST=127.0.0.1
 #PG_PORT=5432
 #PG_USER=
 #PG_PASSWORD=
 # PostgreSQL 数据库名，默认 PallasBot；不存在时会自动创建
+# 仅允许字母/数字/下划线/连字符，避免 CREATE DATABASE 注入
 #PG_DB=PallasBot
-# PG_POOL_SIZE=20
-# PG_MAX_OVERFLOW=40
+
+# 连接池参数（默认 10 常驻 + 20 弹性 + 1800 秒空闲回收）
+# 小规模部署可维持默认；QPS 高或并发群数多时可适度调大 pool_size / max_overflow
+#PG_POOL_SIZE=10
+#PG_MAX_OVERFLOW=20
+#PG_POOL_RECYCLE=1800
+
 
 # 以下配置项均有默认值，保持注释即使用默认值
 

--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@
 </div>
 <br>
 
-🚀 Pallas-Bot 2.0 发布啦！🥳
+🚀 Pallas-Bot 3.0 发布啦！🥳
 
-## Pallas-Bot 2.0 有什么改进？
+> 仍希望沿用 MongoDB-only 的老版本？完全兼容的 2.0 代码保留在 [`archive/v2`](https://github.com/PallasBot/Pallas-Bot/tree/archive/v2) 分支。
 
-1. 将 AI 功能分离至 [AI 服务端](https://github.com/PallasBot/Pallas-Bot-AI)
-2. 代码全面重构，牛牛更易维护
-3. 数据库操作全异步改造，牛牛运行更高效
-4. 项目文件规范化，牛牛部署更简单
-5. 优化 Docker 构建，支持 Arm64 架构
-6. 支持语音文件自动下载，启动时自动检查并配置语音资源
-7. 修复了一些老 bug
+## Pallas-Bot 3.0 有什么改进？
+
+1. 新增 PostgreSQL 数据库后端，通过 `DB_BACKEND` 环境变量一键切换，Mongo 与 PG 共用同一套 Repository 抽象
+2. 提供 Mongo → PG 迁移脚本，支持千万级数据流式迁移、断点续传与脏数据容错
+3. 牛牛的高频写入场景并发原子化（`upsert_answer` / 黑名单 / 图缓存 / 配置均走原子 `ON CONFLICT`），不再丢计数
+4. 主键 BigInt 化、冗余索引清理、`Message.time` 索引补齐，支撑千万级长期累积
+5. 内置配置 TTL 缓存与连接池参数化（`PG_POOL_SIZE` / `PG_MAX_OVERFLOW` / `PG_POOL_RECYCLE`），PG 后端在高 QPS 下表现稳定
+6. 修复了一些老 bug
 
 ## 牛牛有什么功能？
 

--- a/bot.py
+++ b/bot.py
@@ -13,7 +13,7 @@ config = driver.config
 
 @driver.on_startup
 async def startup():
-    await init_db(config.mongo_host, config.mongo_port, config.mongo_user, config.mongo_password)
+    await init_db()
 
     await ensure_voices()
 

--- a/src/common/config/__init__.py
+++ b/src/common/config/__init__.py
@@ -273,13 +273,18 @@ class GroupConfig(Config):
         """
         获取歌曲进度
         """
-        return await self._find("sing_progress")
+        result = await self._find("sing_progress")
+        if result is None:
+            return None
+        if isinstance(result, dict):
+            return SingProgress(**result)
+        return result
 
     async def update_sing_progress(self, progress: SingProgress) -> None:
         """
         更新歌曲进度
         """
-        await self._update("sing_progress", progress)
+        await self._update("sing_progress", progress.model_dump())
 
 
 class UserConfig(Config):

--- a/src/common/db/__init__.py
+++ b/src/common/db/__init__.py
@@ -211,20 +211,36 @@ def make_pg_image_cache() -> ImageCacheRepository:
 
 async def init_postgresql_db() -> None:
     """初始化 PostgreSQL 连接"""
+    import re
+
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
 
     from .repository_pg import dispose_pg, init_pg
 
-    host = _cfg("PG_HOST", _cfg("MONGO_HOST", "127.0.0.1"))
+    from nonebot.log import logger
+
+    pg_host_raw = _cfg("PG_HOST", "")
+    if pg_host_raw:
+        host = pg_host_raw
+    else:
+        host = _cfg("MONGO_HOST", "127.0.0.1")
+        if host != "127.0.0.1":
+            logger.warning(
+                f"PG_HOST 未设置，已 fallback 到 MONGO_HOST={host}；如 PG/Mongo 不同机器请显式设置 PG_HOST"
+            )
     port = int(_cfg("PG_PORT", "5432"))
     user = _cfg("PG_USER", "")
     password = _cfg("PG_PASSWORD", "")
     db_name = _cfg("PG_DB", "PallasBot")
+    if not re.match(r"^[A-Za-z0-9_\-]+$", db_name):
+        raise ValueError(f"非法的 PG_DB: {db_name!r}")
     auth = f"{quote_plus(user)}:{quote_plus(password)}@" if user and password else ""
     base_url = f"postgresql+asyncpg://{auth}{host}:{port}"
 
-    from nonebot.log import logger
+    pool_size = int(_cfg("PG_POOL_SIZE", "10"))
+    max_overflow = int(_cfg("PG_MAX_OVERFLOW", "20"))
+    pool_recycle = int(_cfg("PG_POOL_RECYCLE", "1800"))
 
     logger.info(f"正在连接 PostgreSQL {host}:{port}，Database：{db_name}")
 
@@ -239,16 +255,15 @@ async def init_postgresql_db() -> None:
     finally:
         await admin_engine.dispose()
 
-    pool_size = int(_cfg("PG_POOL_SIZE", "20"))
-    max_overflow = int(_cfg("PG_MAX_OVERFLOW", "40"))
     engine = create_async_engine(
         f"{base_url}/{db_name}",
         pool_size=pool_size,
         max_overflow=max_overflow,
+        pool_recycle=pool_recycle,
         pool_pre_ping=True,
     )
     await init_pg(engine)
-    logger.info(f"{db_name} 连接成功！")
+    logger.info(f"{db_name} 连接成功！(pool={pool_size}+{max_overflow}, recycle={pool_recycle}s)")
 
     # bot 退出时释放连接池
     try:

--- a/src/common/db/__init__.py
+++ b/src/common/db/__init__.py
@@ -250,7 +250,9 @@ async def init_postgresql_db() -> None:
             result = await conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :db"), {"db": db_name})
             if result.scalar() is None:
                 logger.info(f"{db_name} 不存在，正在自动创建...")
-                await conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+                # PG 不支持给 identifier 绑占位符，只能拼接；上面 [A-Za-z0-9_-]
+                # 的正则已保证 db_name 无注入风险。
+                await conn.execute(text(f'CREATE DATABASE "{db_name}"'))  # noqa: S608
                 logger.info(f"{db_name} 创建成功")
     finally:
         await admin_engine.dispose()

--- a/src/common/db/__init__.py
+++ b/src/common/db/__init__.py
@@ -239,7 +239,14 @@ async def init_postgresql_db() -> None:
     finally:
         await admin_engine.dispose()
 
-    engine = create_async_engine(f"{base_url}/{db_name}")
+    pool_size = int(_cfg("PG_POOL_SIZE", "20"))
+    max_overflow = int(_cfg("PG_MAX_OVERFLOW", "40"))
+    engine = create_async_engine(
+        f"{base_url}/{db_name}",
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+        pool_pre_ping=True,
+    )
     await init_pg(engine)
     logger.info(f"{db_name} 连接成功！")
 

--- a/src/common/db/__init__.py
+++ b/src/common/db/__init__.py
@@ -28,6 +28,14 @@ from .repository import (
 
 def get_db_backend() -> str:
     """读取当前配置的数据库后端名称，默认为 mongodb。"""
+    try:
+        import nonebot
+
+        backend = getattr(nonebot.get_driver().config, "db_backend", None)
+        if backend:
+            return str(backend).lower()
+    except Exception:
+        pass
     return os.getenv("DB_BACKEND", "mongodb").lower()
 
 
@@ -117,15 +125,35 @@ def make_mongo_image_cache() -> ImageCacheRepository:
     return MongoImageCacheRepository()
 
 
-async def init_mongodb_db(host: str, port: int, user: str, password: str) -> None:
+def _cfg(key: str, default: str = "") -> str:
+    try:
+        import nonebot
+
+        val = getattr(nonebot.get_driver().config, key.lower(), None)
+        if val is not None:
+            return str(val)
+    except Exception:
+        pass
+    return os.getenv(key.upper(), default)
+
+
+async def init_mongodb_db() -> None:
     """初始化 MongoDB 连接。"""
+    from nonebot.log import logger
+
+    host = _cfg("MONGO_HOST", "127.0.0.1")
+    port = int(_cfg("MONGO_PORT", "27017"))
+    user = _cfg("MONGO_USER", "")
+    password = _cfg("MONGO_PASSWORD", "")
     if user and password:
         connection_string = f"mongodb://{quote_plus(user)}:{quote_plus(password)}@{host}:{port}"
     else:
         connection_string = f"mongodb://{host}:{port}"
+    db_name = _cfg("MONGO_DB", "PallasBot")
+    logger.info(f"正在尝试连接 MongoDB {host}:{port}，Database：{db_name}")
     mongo_client = AsyncMongoClient(connection_string, unicode_decode_error_handler="ignore")
     await init_beanie(
-        database=mongo_client["PallasBot"],
+        database=mongo_client[db_name],
         document_models=[
             BotConfigModule,
             GroupConfigModule,
@@ -136,6 +164,7 @@ async def init_mongodb_db(host: str, port: int, user: str, password: str) -> Non
             ImageCache,
         ],
     )
+    logger.info(f"{db_name} 连接成功！")
 
 
 def make_pg_context() -> ContextRepository:
@@ -180,17 +209,52 @@ def make_pg_image_cache() -> ImageCacheRepository:
     return PgImageCacheRepository()
 
 
-async def init_postgresql_db(host: str, port: int, user: str, password: str) -> None:
-    """
-    初始化 PostgreSQL 连接（预留骨架，尚未实现）。
+async def init_postgresql_db() -> None:
+    """初始化 PostgreSQL 连接"""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
 
-    当前 PG 后端仅包含接口骨架（repository_pg.Pg*Repository），数据库建库、
-    建表、ORM 映射等实际实现留给后续 PR。一旦实现完整，再填充此函数。
-    """
-    raise NotImplementedError(
-        "PostgreSQL 后端尚未实现。Repository 抽象层已就绪，但 PG 侧实现仅为骨架；"
-        "若要启用，请先完成 src/common/db/repository_pg.py 并补齐 pg optional-dependency。"
-    )
+    from .repository_pg import dispose_pg, init_pg
+
+    host = _cfg("PG_HOST", _cfg("MONGO_HOST", "127.0.0.1"))
+    port = int(_cfg("PG_PORT", "5432"))
+    user = _cfg("PG_USER", "")
+    password = _cfg("PG_PASSWORD", "")
+    db_name = _cfg("PG_DB", "PallasBot")
+    auth = f"{quote_plus(user)}:{quote_plus(password)}@" if user and password else ""
+    base_url = f"postgresql+asyncpg://{auth}{host}:{port}"
+
+    from nonebot.log import logger
+
+    logger.info(f"正在连接 PostgreSQL {host}:{port}，Database：{db_name}")
+
+    admin_engine = create_async_engine(f"{base_url}/postgres", isolation_level="AUTOCOMMIT")
+    try:
+        async with admin_engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :db"), {"db": db_name})
+            if result.scalar() is None:
+                logger.info(f"{db_name} 不存在，正在自动创建...")
+                await conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+                logger.info(f"{db_name} 创建成功")
+    finally:
+        await admin_engine.dispose()
+
+    engine = create_async_engine(f"{base_url}/{db_name}")
+    await init_pg(engine)
+    logger.info(f"{db_name} 连接成功！")
+
+    # bot 退出时释放连接池
+    try:
+        import nonebot
+
+        driver = nonebot.get_driver()
+
+        @driver.on_shutdown
+        async def _dispose_pg():
+            await dispose_pg()
+
+    except Exception:
+        pass
 
 
 register_backend(
@@ -277,12 +341,12 @@ def make_image_cache_repository() -> ImageCacheRepository:
     return IMAGE_CACHE_REPO_REGISTRY[backend]()
 
 
-async def init_db(host: str, port: int, user: str, password: str, backend: str | None = None) -> None:
+async def init_db(backend: str | None = None) -> None:
     """
     初始化数据库连接。
 
     根据 backend 参数选择后端，未传入时从环境变量 DB_BACKEND 读取，
-    默认使用 mongodb。新增后端只需调用 register_backend() 注册，无需修改此函数。
+    默认使用 mongodb。连接参数均从环境变量读取。
     """
     if backend is None:
         backend = get_db_backend()
@@ -290,4 +354,4 @@ async def init_db(host: str, port: int, user: str, password: str, backend: str |
     if backend not in INIT_DB_REGISTRY:
         raise ValueError(f"不支持的数据库后端: {backend}，已注册的后端: {list(INIT_DB_REGISTRY)}")
 
-    await INIT_DB_REGISTRY[backend](host, port, user, password)
+    await INIT_DB_REGISTRY[backend]()

--- a/src/common/db/repository_pg.py
+++ b/src/common/db/repository_pg.py
@@ -216,11 +216,14 @@ async def init_pg(engine: AsyncEngine) -> None:
 
 
 async def dispose_pg() -> None:
-    """关闭连接池，bot 退出时调用"""
+    """关闭连接池并清空配置 TTL 缓存，bot 退出或测试 teardown 时调用。"""
     global _engine
     if _engine is not None:
         await _engine.dispose()
         _engine = None
+    # schema 重建后若保留旧 ORM 行，下一轮 get() 会命中已失效数据
+    for cache in _CONFIG_CACHES.values():
+        await cache.clear()
 
 
 _LOAD_RELATED = [

--- a/src/common/db/repository_pg.py
+++ b/src/common/db/repository_pg.py
@@ -1,30 +1,365 @@
-"""PostgreSQL Repository 实现（预留接口，尚未实现）"""
+"""PostgreSQL Repository 实现"""
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import JSON, BigInteger, Boolean, ForeignKey, Text, delete, select, update
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, selectinload
+
 if TYPE_CHECKING:
-    from src.common.db.modules import Answer, Ban, BlackList, Context, ImageCache, Message
+    from src.common.db.modules import Answer, Ban, Context, ImageCache, Message
+
+_JsonB = JSONB().with_variant(JSON(), "sqlite")
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class ContextAnswerRow(Base):
+    __tablename__ = "context_answer"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    context_id: Mapped[int] = mapped_column(ForeignKey("context.id", ondelete="CASCADE"), nullable=False, index=True)
+    keywords: Mapped[str] = mapped_column(Text, nullable=False)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    count: Mapped[int] = mapped_column(nullable=False, default=1)
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+    messages: Mapped[list[ContextAnswerMessageRow]] = relationship(
+        "ContextAnswerMessageRow", cascade="all, delete-orphan", lazy="noload"
+    )
+
+
+class ContextAnswerMessageRow(Base):
+    __tablename__ = "context_answer_message"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    answer_id: Mapped[int] = mapped_column(
+        ForeignKey("context_answer.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class ContextBanRow(Base):
+    __tablename__ = "context_ban"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    context_id: Mapped[int] = mapped_column(ForeignKey("context.id", ondelete="CASCADE"), nullable=False, index=True)
+    keywords: Mapped[str] = mapped_column(Text, nullable=False)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+
+class ContextRow(Base):
+    __tablename__ = "context"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    keywords: Mapped[str] = mapped_column(Text, nullable=False)
+    keywords_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+    trigger_count: Mapped[int] = mapped_column(nullable=False, default=1)
+    clear_time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+    answers: Mapped[list[ContextAnswerRow]] = relationship(
+        "ContextAnswerRow", cascade="all, delete-orphan", lazy="noload"
+    )
+    ban: Mapped[list[ContextBanRow]] = relationship("ContextBanRow", cascade="all, delete-orphan", lazy="noload")
+
+
+class MessageRow(Base):
+    __tablename__ = "message"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    bot_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    raw_message: Mapped[str] = mapped_column(Text, nullable=False)
+    is_plain_text: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    plain_text: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    keywords: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    time: Mapped[int] = mapped_column(nullable=False, default=0)
+
+
+class BlackListRow(Base):
+    __tablename__ = "blacklist"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True, index=True)
+    answers: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+    answers_reserve: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+
+
+class BotConfigRow(Base):
+    __tablename__ = "bot_config"
+
+    account: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    admins: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+    auto_accept_friend: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    auto_accept_group: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    security: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    taken_name: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=dict)
+    drunk: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=dict)
+    disabled_plugins: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+
+
+class GroupConfigRow(Base):
+    __tablename__ = "group_config"
+
+    group_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    roulette_mode: Mapped[int] = mapped_column(nullable=False, default=1)
+    banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    sing_progress: Mapped[Any] = mapped_column(_JsonB, nullable=True)
+    disabled_plugins: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
+
+
+class UserConfigRow(Base):
+    __tablename__ = "user_config"
+
+    user_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+
+class ImageCacheRow(Base):
+    __tablename__ = "image_cache"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    cq_code: Mapped[str] = mapped_column(Text, unique=True, nullable=False, index=True)
+    base64_data: Mapped[str | None] = mapped_column(Text, nullable=True)
+    ref_times: Mapped[int] = mapped_column(nullable=False, default=1)
+    date: Mapped[int] = mapped_column(nullable=False, index=True)
+
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+@asynccontextmanager
+async def get_session():
+    if _session_factory is None:
+        raise RuntimeError("PostgreSQL 尚未初始化，请先调用 init_pg()")
+    async with _session_factory() as session:
+        yield session
+
+
+async def init_pg(engine: AsyncEngine) -> None:
+    """创建表结构并注入 engine"""
+    global _engine, _session_factory
+    _engine = engine
+    _session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def dispose_pg() -> None:
+    """关闭连接池，bot 退出时调用"""
+    global _engine
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+
+
+_LOAD_RELATED = [
+    selectinload(ContextRow.answers).selectinload(ContextAnswerRow.messages),
+    selectinload(ContextRow.ban),
+]
+
+
+def keywords_hash(keywords: str) -> str:
+    import hashlib
+
+    return hashlib.md5(keywords.encode()).hexdigest()
+
+
+# asyncpg 单语句参数上限 32767
+_ANSWER_BATCH = 500  # ContextAnswerRow 5 列 × 500 = 2500
+_MSG_BATCH = 16000  # ContextAnswerMessageRow 2 列 × 16000 = 32000
+_BAN_BATCH = 6000  # ContextBanRow 5 列 × 6000 = 30000
+
+
+async def _insert_answers_batched(session: AsyncSession, context_id: int, answers) -> None:
+    """分批插入 ContextAnswerRow 及其关联的 ContextAnswerMessageRow"""
+
+    for i in range(0, len(answers), _ANSWER_BATCH):
+        batch: list[Answer] = answers[i : i + _ANSWER_BATCH]
+        # 先插入 answer 行（不带 messages 关系，避免 SQLAlchemy 一次性级联）
+        rows = [
+            ContextAnswerRow(
+                context_id=context_id,
+                keywords=a.keywords,
+                group_id=a.group_id,
+                count=a.count,
+                time=a.time,
+            )
+            for a in batch
+        ]
+        session.add_all(rows)
+        await session.flush()  # 获取自增 id
+
+        # 再分批插入 message 行
+        msg_rows = [
+            ContextAnswerMessageRow(answer_id=rows[j].id, message=m) for j, a in enumerate(batch) for m in a.messages
+        ]
+        for k in range(0, len(msg_rows), _MSG_BATCH):
+            session.add_all(msg_rows[k : k + _MSG_BATCH])
+            await session.flush()
+
+
+async def _insert_bans_batched(session: AsyncSession, context_id: int, bans) -> None:
+    """分批插入 ContextBanRow"""
+    for i in range(0, len(bans), _BAN_BATCH):
+        batch = bans[i : i + _BAN_BATCH]
+        session.add_all([
+            ContextBanRow(
+                context_id=context_id,
+                keywords=b.keywords,
+                group_id=b.group_id,
+                reason=b.reason,
+                time=b.time,
+            )
+            for b in batch
+        ])
+        await session.flush()
+
+
+def row_to_context(row: ContextRow) -> Context:
+    from src.common.db.modules import Answer, Ban, Context
+
+    answers = [
+        Answer.model_construct(
+            keywords=a.keywords,
+            group_id=a.group_id,
+            count=a.count,
+            time=a.time,
+            messages=[m.message for m in a.messages],
+        )
+        for a in row.answers
+    ]
+    ban = [
+        Ban.model_construct(
+            keywords=b.keywords,
+            group_id=b.group_id,
+            reason=b.reason,
+            time=b.time,
+        )
+        for b in row.ban
+    ]
+    return Context.model_construct(
+        keywords=row.keywords,
+        time=row.time,
+        trigger_count=row.trigger_count,
+        answers=answers,
+        ban=ban,
+        clear_time=row.clear_time,
+    )
+
+
+def row_to_blacklist(row: BlackListRow):
+    from src.common.db.modules import BlackList
+
+    return BlackList.model_construct(
+        group_id=row.group_id,
+        answers=list(row.answers),
+        answers_reserve=list(row.answers_reserve),
+    )
+
+
+def row_to_image_cache(row: ImageCacheRow) -> ImageCache:
+    from src.common.db.modules import ImageCache
+
+    return ImageCache.model_construct(
+        cq_code=row.cq_code,
+        base64_data=row.base64_data,
+        ref_times=row.ref_times,
+        date=row.date,
+    )
 
 
 class PgContextRepository:
-    """PostgreSQL 版 ContextRepository 实现（预留）"""
-
     async def find_by_keywords(self, keywords: str) -> Context | None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            result = await session.execute(
+                select(ContextRow).options(*_LOAD_RELATED).where(ContextRow.keywords_hash == khash)
+            )
+            row = result.scalar_one_or_none()
+            return row_to_context(row) if row else None
 
     async def save(self, context: Context) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(context.keywords)
+        async with get_session() as session:
+            result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            row = result.scalar_one_or_none()
+
+            if row is None:
+                row = ContextRow(
+                    keywords=context.keywords,
+                    keywords_hash=khash,
+                    time=context.time,
+                    trigger_count=context.trigger_count,
+                    clear_time=context.clear_time,
+                )
+                session.add(row)
+                await session.flush()
+            else:
+                row.time = context.time
+                row.trigger_count = context.trigger_count
+                row.clear_time = context.clear_time
+                await session.execute(delete(ContextAnswerRow).where(ContextAnswerRow.context_id == row.id))
+                await session.execute(delete(ContextBanRow).where(ContextBanRow.context_id == row.id))
+
+            await _insert_answers_batched(session, row.id, context.answers)
+            await _insert_bans_batched(session, row.id, context.ban)
+            await session.commit()
 
     async def insert(self, context: Context) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(context.keywords)
+        try:
+            async with get_session() as session:
+                row = ContextRow(
+                    keywords=context.keywords,
+                    keywords_hash=khash,
+                    time=context.time,
+                    trigger_count=context.trigger_count,
+                    clear_time=context.clear_time,
+                )
+                session.add(row)
+                await session.flush()
+                await _insert_answers_batched(session, row.id, context.answers)
+                await _insert_bans_batched(session, row.id, context.ban)
+                await session.commit()
+        except IntegrityError:
+            # 另一个协程已插入相同 keywords，忽略即可
+            pass
 
     async def delete_expired(self, expiration: int, threshold: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            await session.execute(
+                delete(ContextRow).where(
+                    ContextRow.time < expiration,
+                    ContextRow.trigger_count < threshold,
+                )
+            )
+            await session.commit()
 
     async def find_for_cleanup(self, trigger_threshold: int, expiration: int) -> list[Context]:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(ContextRow)
+                .options(*_LOAD_RELATED)
+                .where(
+                    ContextRow.trigger_count >= trigger_threshold,
+                    ContextRow.clear_time <= expiration,
+                )
+            )
+            rows = result.scalars().all()
+            return [row_to_context(r) for r in rows]
 
     async def upsert_answer(
         self,
@@ -35,75 +370,221 @@ class PgContextRepository:
         message: str,
         append_on_existing: bool,
     ) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            ctx_row = ctx_result.scalar_one_or_none()
+            if ctx_row is None:
+                return
+
+            ans_result = await session.execute(
+                select(ContextAnswerRow).where(
+                    ContextAnswerRow.context_id == ctx_row.id,
+                    ContextAnswerRow.group_id == group_id,
+                    ContextAnswerRow.keywords == answer_keywords,
+                )
+            )
+            ans_row = ans_result.scalar_one_or_none()
+
+            if ans_row is not None:
+                ans_row.count += 1
+                ans_row.time = answer_time
+                if append_on_existing:
+                    session.add(ContextAnswerMessageRow(answer_id=ans_row.id, message=message))
+            else:
+                new_ans = ContextAnswerRow(
+                    context_id=ctx_row.id,
+                    keywords=answer_keywords,
+                    group_id=group_id,
+                    count=1,
+                    time=answer_time,
+                )
+                session.add(new_ans)
+                await session.flush()
+                session.add(ContextAnswerMessageRow(answer_id=new_ans.id, message=message))
+
+            ctx_row.trigger_count += 1
+            ctx_row.time = answer_time
+            await session.commit()
 
     async def replace_answers(self, keywords: str, answers: list[Answer], clear_time: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            ctx_row = ctx_result.scalar_one_or_none()
+            if ctx_row is None:
+                return
+
+            await session.execute(delete(ContextAnswerRow).where(ContextAnswerRow.context_id == ctx_row.id))
+            await _insert_answers_batched(session, ctx_row.id, answers)
+            ctx_row.clear_time = clear_time
+            await session.commit()
 
     async def append_ban(self, keywords: str, ban: Ban) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
+            ctx_row = ctx_result.scalar_one_or_none()
+            if ctx_row is None:
+                return
+
+            session.add(
+                ContextBanRow(
+                    context_id=ctx_row.id,
+                    keywords=ban.keywords,
+                    group_id=ban.group_id,
+                    reason=ban.reason,
+                    time=ban.time,
+                )
+            )
+            await session.commit()
 
 
 class PgMessageRepository:
-    """PostgreSQL 版 MessageRepository 实现（预留）"""
+    # MessageRow 有 8 列，asyncpg 单语句参数上限 32767，保守取 4000 行/批
+    _BULK_BATCH_SIZE = 4000
 
     async def bulk_insert(self, messages: list[Message]) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            for i in range(0, len(messages), self._BULK_BATCH_SIZE):
+                batch = messages[i : i + self._BULK_BATCH_SIZE]
+                session.add_all([
+                    MessageRow(
+                        group_id=m.group_id,
+                        user_id=m.user_id,
+                        bot_id=m.bot_id,
+                        raw_message=m.raw_message,
+                        is_plain_text=m.is_plain_text,
+                        plain_text=m.plain_text,
+                        keywords=m.keywords,
+                        time=m.time,
+                    )
+                    for m in batch
+                ])
+                await session.flush()
+            await session.commit()
 
 
 class PgBlackListRepository:
-    """PostgreSQL 版 BlackListRepository 实现（预留）"""
-
-    async def find_all(self) -> list[BlackList]:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+    async def find_all(self):
+        async with get_session() as session:
+            result = await session.execute(select(BlackListRow))
+            rows = result.scalars().all()
+            return [row_to_blacklist(r) for r in rows]
 
     async def upsert_answers(self, group_id: int, answers: list[str]) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(BlackListRow).where(BlackListRow.group_id == group_id))
+            row = result.scalar_one_or_none()
+            if row is None:
+                session.add(BlackListRow(group_id=group_id, answers=answers, answers_reserve=[]))
+            else:
+                row.answers = answers
+            await session.commit()
 
     async def upsert_answers_reserve(self, group_id: int, answers: list[str]) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(BlackListRow).where(BlackListRow.group_id == group_id))
+            row = result.scalar_one_or_none()
+            if row is None:
+                session.add(BlackListRow(group_id=group_id, answers=[], answers_reserve=answers))
+            else:
+                row.answers_reserve = answers
+            await session.commit()
+
+
+_CONFIG_TABLE_MAP: dict[str, tuple[type, str]] = {
+    "bot_config": (BotConfigRow, "account"),
+    "group_config": (GroupConfigRow, "group_id"),
+    "user_config": (UserConfigRow, "user_id"),
+}
 
 
 class PgConfigRepository:
-    """
-    PostgreSQL 版 ConfigRepository 实现（预留）。
-
-    通过 (table, primary_key) 绑定到不同配置表，未来实现时可直接用同一份
-    SQL 逻辑服务 Bot/Group/User 三种配置。
-    """
-
     def __init__(self, table: str, primary_key: str) -> None:
-        self._table = table
-        self._primary_key = primary_key
+        if table not in _CONFIG_TABLE_MAP:
+            raise ValueError(f"Unknown config table: {table}")
+        self._row_class, self._pk_field = _CONFIG_TABLE_MAP[table]
 
     async def get(self, key_id: int, *, ignore_cache: bool = False) -> Any | None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+            )
+            return result.scalar_one_or_none()
 
     async def get_or_create(self, key_id: int, **defaults: Any) -> tuple[Any, bool]:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+            )
+            row = result.scalar_one_or_none()
+            if row is not None:
+                return row, False
+            new_row = self._row_class(**{self._pk_field: key_id, **defaults})
+            session.add(new_row)
+            await session.commit()
+            return new_row, True
 
     async def upsert_field(self, key_id: int, field: str, value: Any) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(
+                select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+            )
+            row = result.scalar_one_or_none()
+            if row is not None:
+                await session.execute(
+                    update(self._row_class)
+                    .where(getattr(self._row_class, self._pk_field) == key_id)
+                    .values(**{field: value})
+                )
+            else:
+                session.add(self._row_class(**{self._pk_field: key_id, field: value}))
+            await session.commit()
 
     async def invalidate_cache(self) -> None:
-        # PG 无 Beanie 级缓存，no-op
         return None
 
 
 class PgImageCacheRepository:
-    """PostgreSQL 版 ImageCacheRepository 实现（预留）"""
-
     async def find_by_cq_code(self, cq_code: str) -> ImageCache | None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(ImageCacheRow).where(ImageCacheRow.cq_code == cq_code))
+            row = result.scalar_one_or_none()
+            return row_to_image_cache(row) if row else None
 
     async def insert(self, cache: ImageCache) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        try:
+            async with get_session() as session:
+                session.add(
+                    ImageCacheRow(
+                        cq_code=cache.cq_code,
+                        base64_data=cache.base64_data,
+                        ref_times=cache.ref_times,
+                        date=cache.date,
+                    )
+                )
+                await session.commit()
+        except IntegrityError:
+            # 另一个协程已插入相同 cq_code，忽略即可
+            pass
 
     async def save(self, cache: ImageCache) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            result = await session.execute(select(ImageCacheRow).where(ImageCacheRow.cq_code == cache.cq_code))
+            row = result.scalar_one_or_none()
+            if row is not None:
+                row.ref_times = cache.ref_times
+                row.date = cache.date
+                row.base64_data = cache.base64_data
+                await session.commit()
 
     async def delete_old(self, before_date: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            await session.execute(delete(ImageCacheRow).where(ImageCacheRow.date < before_date))
+            await session.commit()
 
     async def delete_low_ref(self, ref_threshold: int) -> None:
-        raise NotImplementedError("PostgreSQL 后端尚未实现")
+        async with get_session() as session:
+            await session.execute(delete(ImageCacheRow).where(ImageCacheRow.ref_times < ref_threshold))
+            await session.commit()

--- a/src/common/db/repository_pg.py
+++ b/src/common/db/repository_pg.py
@@ -222,10 +222,13 @@ async def init_pg(engine: AsyncEngine) -> None:
 
 async def dispose_pg() -> None:
     """关闭连接池并清空配置 TTL 缓存，bot 退出或测试 teardown 时调用。"""
-    global _engine
+    global _engine, _session_factory
     if _engine is not None:
         await _engine.dispose()
         _engine = None
+    # 同步清掉 session factory，避免后续 get_session() 拿到绑定在已释放 engine
+    # 上的 AsyncSession；正确行为是抛 "PostgreSQL 尚未初始化"。
+    _session_factory = None
     # schema 重建后若保留旧 ORM 行，下一轮 get() 会命中已失效数据
     for cache in _CONFIG_CACHES.values():
         await cache.clear()
@@ -698,7 +701,14 @@ class PgConfigRepository:
     def __init__(self, table: str, primary_key: str) -> None:
         if table not in _CONFIG_TABLE_MAP:
             raise ValueError(f"Unknown config table: {table}")
-        self._row_class, self._pk_field = _CONFIG_TABLE_MAP[table]
+        row_class, pk_field = _CONFIG_TABLE_MAP[table]
+        # primary_key 由工厂函数传入（对齐 Mongo ConfigRepository 的构造签名），
+        # 这里做一致性断言，避免静默与 _CONFIG_TABLE_MAP 失同步。
+        if primary_key != pk_field:
+            raise ValueError(
+                f"primary_key {primary_key!r} 与 {table} 登记的主键 {pk_field!r} 不一致"
+            )
+        self._row_class, self._pk_field = row_class, pk_field
         self._cache = _get_config_cache(self._row_class)
 
     async def get(self, key_id: int, *, ignore_cache: bool = False) -> Any | None:

--- a/src/common/db/repository_pg.py
+++ b/src/common/db/repository_pg.py
@@ -2,11 +2,32 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import os
+import time
+from collections import OrderedDict
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import JSON, BigInteger, Boolean, ForeignKey, Text, delete, select, update
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    Boolean,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    delete,
+    insert,
+    literal_column,
+    or_,
+    select,
+    update,
+)
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, selectinload
@@ -17,19 +38,49 @@ if TYPE_CHECKING:
 _JsonB = JSONB().with_variant(JSON(), "sqlite")
 
 
+# ---------------------------------------------------------------------------
+# 运行时 \x00 防御：PostgreSQL TEXT 不接受 NUL 字符，需在写入前统一剥除
+# ---------------------------------------------------------------------------
+
+
+def _s(x: str | None) -> str | None:
+    if x is None:
+        return None
+    return x.replace("\x00", "") if "\x00" in x else x
+
+
+def _strip_null_deep(obj: Any) -> Any:
+    """递归剥除 str / dict / list 中的 \\u0000，用于 JSONB 字段。"""
+    if isinstance(obj, str):
+        return _s(obj)
+    if isinstance(obj, dict):
+        return {k: _strip_null_deep(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_strip_null_deep(i) for i in obj]
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# ORM 定义
+# ---------------------------------------------------------------------------
+
+
 class Base(DeclarativeBase):
     pass
 
 
 class ContextAnswerRow(Base):
     __tablename__ = "context_answer"
+    __table_args__ = (
+        UniqueConstraint("context_id", "group_id", "keywords", name="uq_context_answer_ctx_group_kw"),
+    )
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     context_id: Mapped[int] = mapped_column(ForeignKey("context.id", ondelete="CASCADE"), nullable=False, index=True)
     keywords: Mapped[str] = mapped_column(Text, nullable=False)
-    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
-    count: Mapped[int] = mapped_column(nullable=False, default=1)
-    time: Mapped[int] = mapped_column(nullable=False, default=0)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    time: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
     messages: Mapped[list[ContextAnswerMessageRow]] = relationship(
         "ContextAnswerMessageRow", cascade="all, delete-orphan", lazy="noload"
@@ -39,7 +90,7 @@ class ContextAnswerRow(Base):
 class ContextAnswerMessageRow(Base):
     __tablename__ = "context_answer_message"
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     answer_id: Mapped[int] = mapped_column(
         ForeignKey("context_answer.id", ondelete="CASCADE"), nullable=False, index=True
     )
@@ -49,23 +100,24 @@ class ContextAnswerMessageRow(Base):
 class ContextBanRow(Base):
     __tablename__ = "context_ban"
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     context_id: Mapped[int] = mapped_column(ForeignKey("context.id", ondelete="CASCADE"), nullable=False, index=True)
     keywords: Mapped[str] = mapped_column(Text, nullable=False)
     group_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
-    time: Mapped[int] = mapped_column(nullable=False, default=0)
+    time: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
 
 class ContextRow(Base):
     __tablename__ = "context"
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     keywords: Mapped[str] = mapped_column(Text, nullable=False)
-    keywords_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
-    time: Mapped[int] = mapped_column(nullable=False, default=0)
-    trigger_count: Mapped[int] = mapped_column(nullable=False, default=1)
-    clear_time: Mapped[int] = mapped_column(nullable=False, default=0)
+    # unique=True 已由 PG 自动建 btree，不再附加 index=True 以免冗余索引
+    keywords_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    time: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    trigger_count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    clear_time: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
     answers: Mapped[list[ContextAnswerRow]] = relationship(
         "ContextAnswerRow", cascade="all, delete-orphan", lazy="noload"
@@ -75,8 +127,9 @@ class ContextRow(Base):
 
 class MessageRow(Base):
     __tablename__ = "message"
+    __table_args__ = (Index("ix_message_time", "time"),)
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
     user_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     bot_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
@@ -84,14 +137,14 @@ class MessageRow(Base):
     is_plain_text: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     plain_text: Mapped[str] = mapped_column(Text, nullable=False, default="")
     keywords: Mapped[str] = mapped_column(Text, nullable=False, default="")
-    time: Mapped[int] = mapped_column(nullable=False, default=0)
+    time: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
 
 
 class BlackListRow(Base):
     __tablename__ = "blacklist"
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True, index=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    group_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True)
     answers: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
     answers_reserve: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
 
@@ -113,7 +166,7 @@ class GroupConfigRow(Base):
     __tablename__ = "group_config"
 
     group_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    roulette_mode: Mapped[int] = mapped_column(nullable=False, default=1)
+    roulette_mode: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     banned: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     sing_progress: Mapped[Any] = mapped_column(_JsonB, nullable=True)
     disabled_plugins: Mapped[Any] = mapped_column(_JsonB, nullable=False, default=list)
@@ -129,11 +182,16 @@ class UserConfigRow(Base):
 class ImageCacheRow(Base):
     __tablename__ = "image_cache"
 
-    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    cq_code: Mapped[str] = mapped_column(Text, unique=True, nullable=False, index=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    cq_code: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
     base64_data: Mapped[str | None] = mapped_column(Text, nullable=True)
-    ref_times: Mapped[int] = mapped_column(nullable=False, default=1)
-    date: Mapped[int] = mapped_column(nullable=False, index=True)
+    ref_times: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    date: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+
+
+# ---------------------------------------------------------------------------
+# 引擎 / 会话
+# ---------------------------------------------------------------------------
 
 
 _engine: AsyncEngine | None = None
@@ -149,7 +207,7 @@ async def get_session():
 
 
 async def init_pg(engine: AsyncEngine) -> None:
-    """创建表结构并注入 engine"""
+    """创建表结构并注入 engine。新库首次启动时会建出当前最新 schema。"""
     global _engine, _session_factory
     _engine = engine
     _session_factory = async_sessionmaker(engine, expire_on_commit=False)
@@ -172,9 +230,9 @@ _LOAD_RELATED = [
 
 
 def keywords_hash(keywords: str) -> str:
-    import hashlib
-
-    return hashlib.md5(keywords.encode()).hexdigest()
+    # 先剥除 \x00 再哈希，与 ContextRow.keywords 实际存储值保持一致
+    clean = keywords.replace("\x00", "") if keywords and "\x00" in keywords else keywords
+    return hashlib.md5((clean or "").encode("utf-8", errors="replace")).hexdigest()
 
 
 # asyncpg 单语句参数上限 32767
@@ -188,11 +246,10 @@ async def _insert_answers_batched(session: AsyncSession, context_id: int, answer
 
     for i in range(0, len(answers), _ANSWER_BATCH):
         batch: list[Answer] = answers[i : i + _ANSWER_BATCH]
-        # 先插入 answer 行（不带 messages 关系，避免 SQLAlchemy 一次性级联）
         rows = [
             ContextAnswerRow(
                 context_id=context_id,
-                keywords=a.keywords,
+                keywords=_s(a.keywords) or "",
                 group_id=a.group_id,
                 count=a.count,
                 time=a.time,
@@ -200,11 +257,12 @@ async def _insert_answers_batched(session: AsyncSession, context_id: int, answer
             for a in batch
         ]
         session.add_all(rows)
-        await session.flush()  # 获取自增 id
+        await session.flush()
 
-        # 再分批插入 message 行
         msg_rows = [
-            ContextAnswerMessageRow(answer_id=rows[j].id, message=m) for j, a in enumerate(batch) for m in a.messages
+            ContextAnswerMessageRow(answer_id=rows[j].id, message=_s(m) or "")
+            for j, a in enumerate(batch)
+            for m in a.messages
         ]
         for k in range(0, len(msg_rows), _MSG_BATCH):
             session.add_all(msg_rows[k : k + _MSG_BATCH])
@@ -218,9 +276,9 @@ async def _insert_bans_batched(session: AsyncSession, context_id: int, bans) -> 
         session.add_all([
             ContextBanRow(
                 context_id=context_id,
-                keywords=b.keywords,
+                keywords=_s(b.keywords) or "",
                 group_id=b.group_id,
-                reason=b.reason,
+                reason=_s(b.reason) or "",
                 time=b.time,
             )
             for b in batch
@@ -299,7 +357,7 @@ class PgContextRepository:
 
             if row is None:
                 row = ContextRow(
-                    keywords=context.keywords,
+                    keywords=_s(context.keywords) or "",
                     keywords_hash=khash,
                     time=context.time,
                     trigger_count=context.trigger_count,
@@ -319,11 +377,12 @@ class PgContextRepository:
             await session.commit()
 
     async def insert(self, context: Context) -> None:
+        """插入新 Context。并发下同 keywords 第二个写入会被 unique 约束拒绝，等价为 no-op。"""
         khash = keywords_hash(context.keywords)
         try:
             async with get_session() as session:
                 row = ContextRow(
-                    keywords=context.keywords,
+                    keywords=_s(context.keywords) or "",
                     keywords_hash=khash,
                     time=context.time,
                     trigger_count=context.trigger_count,
@@ -335,31 +394,60 @@ class PgContextRepository:
                 await _insert_bans_batched(session, row.id, context.ban)
                 await session.commit()
         except IntegrityError:
-            # 另一个协程已插入相同 keywords，忽略即可
             pass
 
+    _DELETE_EXPIRED_CHUNK = 10000
+
     async def delete_expired(self, expiration: int, threshold: int) -> None:
-        async with get_session() as session:
-            await session.execute(
-                delete(ContextRow).where(
-                    ContextRow.time < expiration,
-                    ContextRow.trigger_count < threshold,
+        """分批删除过期 Context，避免千万级时长锁表。级联删除由 FK ondelete=CASCADE 处理。"""
+        while True:
+            async with get_session() as session:
+                subq = (
+                    select(ContextRow.id)
+                    .where(ContextRow.time < expiration, ContextRow.trigger_count < threshold)
+                    .limit(self._DELETE_EXPIRED_CHUNK)
+                    .subquery()
                 )
-            )
-            await session.commit()
+                result = await session.execute(
+                    delete(ContextRow).where(ContextRow.id.in_(select(subq.c.id))).returning(ContextRow.id)
+                )
+                deleted = len(result.scalars().all())
+                await session.commit()
+            if deleted < self._DELETE_EXPIRED_CHUNK:
+                break
+
+    _CLEANUP_CHUNK = 500
 
     async def find_for_cleanup(self, trigger_threshold: int, expiration: int) -> list[Context]:
-        async with get_session() as session:
-            result = await session.execute(
-                select(ContextRow)
-                .options(*_LOAD_RELATED)
-                .where(
-                    ContextRow.trigger_count >= trigger_threshold,
-                    ContextRow.clear_time <= expiration,
+        """
+        语义对齐 Mongo：trigger_count > threshold OR clear_time < expiration。
+        流式按主键 id 分页，避免千万级时一次性全加载 OOM。
+        """
+        results: list[Context] = []
+        last_id = 0
+        while True:
+            async with get_session() as session:
+                result = await session.execute(
+                    select(ContextRow)
+                    .options(*_LOAD_RELATED)
+                    .where(
+                        or_(
+                            ContextRow.trigger_count > trigger_threshold,
+                            ContextRow.clear_time < expiration,
+                        ),
+                        ContextRow.id > last_id,
+                    )
+                    .order_by(ContextRow.id)
+                    .limit(self._CLEANUP_CHUNK)
                 )
-            )
-            rows = result.scalars().all()
-            return [row_to_context(r) for r in rows]
+                rows = list(result.scalars().all())
+            if not rows:
+                break
+            results.extend(row_to_context(r) for r in rows)
+            last_id = rows[-1].id
+            if len(rows) < self._CLEANUP_CHUNK:
+                break
+        return results
 
     async def upsert_answer(
         self,
@@ -370,41 +458,53 @@ class PgContextRepository:
         message: str,
         append_on_existing: bool,
     ) -> None:
+        """
+        原子 upsert，依赖 UNIQUE(context_id, group_id, keywords)：
+          - INSERT ... ON CONFLICT DO UPDATE SET count = count + 1, time = EXCLUDED.time
+          - RETURNING 中借助 xmax 判断 insert vs update，决定是否 append message
+          - 最后原子递增 Context.trigger_count / 更新 time
+        """
         khash = keywords_hash(keywords)
+        ans_kw_s = _s(answer_keywords) or ""
+        msg_s = _s(message) or ""
+
         async with get_session() as session:
-            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
-            ctx_row = ctx_result.scalar_one_or_none()
-            if ctx_row is None:
+            ctx_result = await session.execute(
+                select(ContextRow.id).where(ContextRow.keywords_hash == khash)
+            )
+            ctx_id = ctx_result.scalar_one_or_none()
+            if ctx_id is None:
                 return
 
-            ans_result = await session.execute(
-                select(ContextAnswerRow).where(
-                    ContextAnswerRow.context_id == ctx_row.id,
-                    ContextAnswerRow.group_id == group_id,
-                    ContextAnswerRow.keywords == answer_keywords,
-                )
+            stmt = pg_insert(ContextAnswerRow).values(
+                context_id=ctx_id,
+                keywords=ans_kw_s,
+                group_id=group_id,
+                count=1,
+                time=answer_time,
             )
-            ans_row = ans_result.scalar_one_or_none()
+            stmt = stmt.on_conflict_do_update(
+                constraint="uq_context_answer_ctx_group_kw",
+                set_={
+                    "count": ContextAnswerRow.count + 1,
+                    "time": stmt.excluded.time,
+                },
+            ).returning(ContextAnswerRow.id, literal_column("(xmax = 0)").label("was_insert"))
 
-            if ans_row is not None:
-                ans_row.count += 1
-                ans_row.time = answer_time
-                if append_on_existing:
-                    session.add(ContextAnswerMessageRow(answer_id=ans_row.id, message=message))
-            else:
-                new_ans = ContextAnswerRow(
-                    context_id=ctx_row.id,
-                    keywords=answer_keywords,
-                    group_id=group_id,
-                    count=1,
-                    time=answer_time,
+            row = (await session.execute(stmt)).first()
+            assert row is not None
+            ans_id, was_insert = int(row.id), bool(row.was_insert)
+
+            if was_insert or append_on_existing:
+                await session.execute(
+                    insert(ContextAnswerMessageRow).values(answer_id=ans_id, message=msg_s)
                 )
-                session.add(new_ans)
-                await session.flush()
-                session.add(ContextAnswerMessageRow(answer_id=new_ans.id, message=message))
 
-            ctx_row.trigger_count += 1
-            ctx_row.time = answer_time
+            await session.execute(
+                update(ContextRow)
+                .where(ContextRow.id == ctx_id)
+                .values(trigger_count=ContextRow.trigger_count + 1, time=answer_time)
+            )
             await session.commit()
 
     async def replace_answers(self, keywords: str, answers: list[Answer], clear_time: int) -> None:
@@ -423,17 +523,17 @@ class PgContextRepository:
     async def append_ban(self, keywords: str, ban: Ban) -> None:
         khash = keywords_hash(keywords)
         async with get_session() as session:
-            ctx_result = await session.execute(select(ContextRow).where(ContextRow.keywords_hash == khash))
-            ctx_row = ctx_result.scalar_one_or_none()
-            if ctx_row is None:
+            ctx_result = await session.execute(select(ContextRow.id).where(ContextRow.keywords_hash == khash))
+            ctx_id = ctx_result.scalar_one_or_none()
+            if ctx_id is None:
                 return
 
-            session.add(
-                ContextBanRow(
-                    context_id=ctx_row.id,
-                    keywords=ban.keywords,
+            await session.execute(
+                insert(ContextBanRow).values(
+                    context_id=ctx_id,
+                    keywords=_s(ban.keywords) or "",
                     group_id=ban.group_id,
-                    reason=ban.reason,
+                    reason=_s(ban.reason) or "",
                     time=ban.time,
                 )
             )
@@ -445,23 +545,26 @@ class PgMessageRepository:
     _BULK_BATCH_SIZE = 4000
 
     async def bulk_insert(self, messages: list[Message]) -> None:
+        if not messages:
+            return
         async with get_session() as session:
             for i in range(0, len(messages), self._BULK_BATCH_SIZE):
                 batch = messages[i : i + self._BULK_BATCH_SIZE]
-                session.add_all([
-                    MessageRow(
-                        group_id=m.group_id,
-                        user_id=m.user_id,
-                        bot_id=m.bot_id,
-                        raw_message=m.raw_message,
-                        is_plain_text=m.is_plain_text,
-                        plain_text=m.plain_text,
-                        keywords=m.keywords,
-                        time=m.time,
-                    )
+                values = [
+                    {
+                        "group_id": m.group_id,
+                        "user_id": m.user_id,
+                        "bot_id": m.bot_id,
+                        "raw_message": _s(m.raw_message) or "",
+                        "is_plain_text": m.is_plain_text,
+                        "plain_text": _s(m.plain_text) or "",
+                        "keywords": _s(m.keywords) or "",
+                        "time": m.time,
+                    }
                     for m in batch
-                ])
-                await session.flush()
+                ]
+                # 走 Core executemany，避免 ORM 构造开销
+                await session.execute(insert(MessageRow), values)
             await session.commit()
 
 
@@ -473,23 +576,26 @@ class PgBlackListRepository:
             return [row_to_blacklist(r) for r in rows]
 
     async def upsert_answers(self, group_id: int, answers: list[str]) -> None:
+        """原子 upsert，基于 group_id 唯一约束。"""
+        cleaned = _strip_null_deep(answers)
         async with get_session() as session:
-            result = await session.execute(select(BlackListRow).where(BlackListRow.group_id == group_id))
-            row = result.scalar_one_or_none()
-            if row is None:
-                session.add(BlackListRow(group_id=group_id, answers=answers, answers_reserve=[]))
-            else:
-                row.answers = answers
+            stmt = pg_insert(BlackListRow).values(group_id=group_id, answers=cleaned, answers_reserve=[])
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["group_id"],
+                set_={"answers": stmt.excluded.answers},
+            )
+            await session.execute(stmt)
             await session.commit()
 
     async def upsert_answers_reserve(self, group_id: int, answers: list[str]) -> None:
+        cleaned = _strip_null_deep(answers)
         async with get_session() as session:
-            result = await session.execute(select(BlackListRow).where(BlackListRow.group_id == group_id))
-            row = result.scalar_one_or_none()
-            if row is None:
-                session.add(BlackListRow(group_id=group_id, answers=[], answers_reserve=answers))
-            else:
-                row.answers_reserve = answers
+            stmt = pg_insert(BlackListRow).values(group_id=group_id, answers=[], answers_reserve=cleaned)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["group_id"],
+                set_={"answers_reserve": stmt.excluded.answers_reserve},
+            )
+            await session.execute(stmt)
             await session.commit()
 
 
@@ -500,18 +606,101 @@ _CONFIG_TABLE_MAP: dict[str, tuple[type, str]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# 配置 Repository 的 TTL 缓存
+# ---------------------------------------------------------------------------
+
+
+def _cfg_env(key: str, default: str) -> str:
+    try:
+        import nonebot
+
+        val = getattr(nonebot.get_driver().config, key.lower(), None)
+        if val is not None:
+            return str(val)
+    except Exception:
+        pass
+    return os.getenv(key, default)
+
+
+class _ConfigCache:
+    """
+    简单的容量 + TTL 缓存，对齐 Mongo Beanie 的 model-level cache 语义。
+    对每个 (row_class) 一个实例；key 是主键值，value 是 (row, expire_ts)；
+    None 也会被缓存（避免缓存击穿）。
+    """
+
+    def __init__(self, ttl: float, capacity: int) -> None:
+        self._ttl = ttl
+        self._capacity = capacity
+        self._store: OrderedDict[Any, tuple[Any, float]] = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: Any) -> tuple[bool, Any]:
+        """返回 (hit, value)。miss 时 value 未定义。"""
+        if self._ttl <= 0 or self._capacity <= 0:
+            return False, None
+        async with self._lock:
+            item = self._store.get(key)
+            if item is None:
+                return False, None
+            value, expire_ts = item
+            if expire_ts <= time.time():
+                self._store.pop(key, None)
+                return False, None
+            self._store.move_to_end(key)
+            return True, value
+
+    async def put(self, key: Any, value: Any) -> None:
+        if self._ttl <= 0 or self._capacity <= 0:
+            return
+        async with self._lock:
+            self._store[key] = (value, time.time() + self._ttl)
+            self._store.move_to_end(key)
+            while len(self._store) > self._capacity:
+                self._store.popitem(last=False)
+
+    async def invalidate(self, key: Any) -> None:
+        async with self._lock:
+            self._store.pop(key, None)
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self._store.clear()
+
+
+_CONFIG_CACHES: dict[type, _ConfigCache] = {}
+
+
+def _get_config_cache(row_class: type) -> _ConfigCache:
+    cache = _CONFIG_CACHES.get(row_class)
+    if cache is None:
+        ttl = float(_cfg_env("PG_CONFIG_CACHE_TTL", "60"))
+        capacity = int(_cfg_env("PG_CONFIG_CACHE_SIZE", "10000"))
+        cache = _ConfigCache(ttl=ttl, capacity=capacity)
+        _CONFIG_CACHES[row_class] = cache
+    return cache
+
+
 class PgConfigRepository:
     def __init__(self, table: str, primary_key: str) -> None:
         if table not in _CONFIG_TABLE_MAP:
             raise ValueError(f"Unknown config table: {table}")
         self._row_class, self._pk_field = _CONFIG_TABLE_MAP[table]
+        self._cache = _get_config_cache(self._row_class)
 
     async def get(self, key_id: int, *, ignore_cache: bool = False) -> Any | None:
+        if not ignore_cache:
+            hit, value = await self._cache.get(key_id)
+            if hit:
+                return value
         async with get_session() as session:
             result = await session.execute(
                 select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
             )
-            return result.scalar_one_or_none()
+            row = result.scalar_one_or_none()
+        await self._cache.put(key_id, row)
+        return row
 
     async def get_or_create(self, key_id: int, **defaults: Any) -> tuple[Any, bool]:
         async with get_session() as session:
@@ -520,30 +709,39 @@ class PgConfigRepository:
             )
             row = result.scalar_one_or_none()
             if row is not None:
+                await self._cache.put(key_id, row)
                 return row, False
-            new_row = self._row_class(**{self._pk_field: key_id, **defaults})
-            session.add(new_row)
-            await session.commit()
+            try:
+                new_row = self._row_class(**{self._pk_field: key_id, **_strip_null_deep(defaults)})
+                session.add(new_row)
+                await session.commit()
+            except IntegrityError:
+                # 并发下已被其他 writer 插入，回源拿最新行
+                await session.rollback()
+                result = await session.execute(
+                    select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+                )
+                existing = result.scalar_one_or_none()
+                await self._cache.put(key_id, existing)
+                return existing, False
+            await self._cache.put(key_id, new_row)
             return new_row, True
 
     async def upsert_field(self, key_id: int, field: str, value: Any) -> None:
+        """字段级 upsert，基于主键 ON CONFLICT 原子化。"""
+        cleaned_value = _strip_null_deep(value)
         async with get_session() as session:
-            result = await session.execute(
-                select(self._row_class).where(getattr(self._row_class, self._pk_field) == key_id)
+            stmt = pg_insert(self._row_class).values(**{self._pk_field: key_id, field: cleaned_value})
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[self._pk_field],
+                set_={field: getattr(stmt.excluded, field)},
             )
-            row = result.scalar_one_or_none()
-            if row is not None:
-                await session.execute(
-                    update(self._row_class)
-                    .where(getattr(self._row_class, self._pk_field) == key_id)
-                    .values(**{field: value})
-                )
-            else:
-                session.add(self._row_class(**{self._pk_field: key_id, field: value}))
+            await session.execute(stmt)
             await session.commit()
+        await self._cache.invalidate(key_id)
 
     async def invalidate_cache(self) -> None:
-        return None
+        await self._cache.clear()
 
 
 class PgImageCacheRepository:
@@ -554,30 +752,36 @@ class PgImageCacheRepository:
             return row_to_image_cache(row) if row else None
 
     async def insert(self, cache: ImageCache) -> None:
-        try:
-            async with get_session() as session:
-                session.add(
-                    ImageCacheRow(
-                        cq_code=cache.cq_code,
-                        base64_data=cache.base64_data,
-                        ref_times=cache.ref_times,
-                        date=cache.date,
-                    )
-                )
-                await session.commit()
-        except IntegrityError:
-            # 另一个协程已插入相同 cq_code，忽略即可
-            pass
+        """并发下相同 cq_code 的第二次 insert 等价为 no-op。"""
+        async with get_session() as session:
+            stmt = pg_insert(ImageCacheRow).values(
+                cq_code=_s(cache.cq_code) or "",
+                base64_data=_s(cache.base64_data),
+                ref_times=cache.ref_times,
+                date=cache.date,
+            )
+            await session.execute(stmt.on_conflict_do_nothing(index_elements=["cq_code"]))
+            await session.commit()
 
     async def save(self, cache: ImageCache) -> None:
+        """与 Mongo save() 语义一致：存在则更新，不存在则插入。"""
         async with get_session() as session:
-            result = await session.execute(select(ImageCacheRow).where(ImageCacheRow.cq_code == cache.cq_code))
-            row = result.scalar_one_or_none()
-            if row is not None:
-                row.ref_times = cache.ref_times
-                row.date = cache.date
-                row.base64_data = cache.base64_data
-                await session.commit()
+            stmt = pg_insert(ImageCacheRow).values(
+                cq_code=_s(cache.cq_code) or "",
+                base64_data=_s(cache.base64_data),
+                ref_times=cache.ref_times,
+                date=cache.date,
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["cq_code"],
+                set_={
+                    "ref_times": stmt.excluded.ref_times,
+                    "date": stmt.excluded.date,
+                    "base64_data": stmt.excluded.base64_data,
+                },
+            )
+            await session.execute(stmt)
+            await session.commit()
 
     async def delete_old(self, before_date: int) -> None:
         async with get_session() as session:

--- a/src/common/db/repository_pg.py
+++ b/src/common/db/repository_pg.py
@@ -71,13 +71,18 @@ class Base(DeclarativeBase):
 
 class ContextAnswerRow(Base):
     __tablename__ = "context_answer"
+    # 唯一性建在定长 md5(keywords_hash) 上：Mongo 侧 answer.keywords 最长可达
+    # 数 KB，直接把 TEXT 列塞进 btree 会超 2704 字节页上限（PG 报
+    # index row size ... exceeds btree version 4 maximum）。保留原 constraint
+    # 名便于 upsert 代码复用。
     __table_args__ = (
-        UniqueConstraint("context_id", "group_id", "keywords", name="uq_context_answer_ctx_group_kw"),
+        UniqueConstraint("context_id", "group_id", "keywords_hash", name="uq_context_answer_ctx_group_kw"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     context_id: Mapped[int] = mapped_column(ForeignKey("context.id", ondelete="CASCADE"), nullable=False, index=True)
     keywords: Mapped[str] = mapped_column(Text, nullable=False)
+    keywords_hash: Mapped[str] = mapped_column(Text, nullable=False)
     group_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     time: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
@@ -239,7 +244,7 @@ def keywords_hash(keywords: str) -> str:
 
 
 # asyncpg 单语句参数上限 32767
-_ANSWER_BATCH = 500  # ContextAnswerRow 5 列 × 500 = 2500
+_ANSWER_BATCH = 500  # ContextAnswerRow 6 列 × 500 = 3000
 _MSG_BATCH = 16000  # ContextAnswerMessageRow 2 列 × 16000 = 32000
 _BAN_BATCH = 6000  # ContextBanRow 5 列 × 6000 = 30000
 
@@ -249,16 +254,19 @@ async def _insert_answers_batched(session: AsyncSession, context_id: int, answer
 
     for i in range(0, len(answers), _ANSWER_BATCH):
         batch: list[Answer] = answers[i : i + _ANSWER_BATCH]
-        rows = [
-            ContextAnswerRow(
-                context_id=context_id,
-                keywords=_s(a.keywords) or "",
-                group_id=a.group_id,
-                count=a.count,
-                time=a.time,
+        rows = []
+        for a in batch:
+            kw = _s(a.keywords) or ""
+            rows.append(
+                ContextAnswerRow(
+                    context_id=context_id,
+                    keywords=kw,
+                    keywords_hash=keywords_hash(kw),
+                    group_id=a.group_id,
+                    count=a.count,
+                    time=a.time,
+                )
             )
-            for a in batch
-        ]
         session.add_all(rows)
         await session.flush()
 
@@ -482,6 +490,7 @@ class PgContextRepository:
             stmt = pg_insert(ContextAnswerRow).values(
                 context_id=ctx_id,
                 keywords=ans_kw_s,
+                keywords_hash=keywords_hash(ans_kw_s),
                 group_id=group_id,
                 count=1,
                 time=answer_time,

--- a/src/common/utils/media_cache/__init__.py
+++ b/src/common/utils/media_cache/__init__.py
@@ -16,7 +16,9 @@ async def insert_image(image_seg: MessageSegment):
     cq_code = re.sub(r"\.image,.+?\]", ".image]", str(image_seg))
     cache = await image_cache_repo.find_by_cq_code(cq_code)
     if not cache:
-        cache = ImageCache(cq_code=cq_code)
+        cache = ImageCache.model_construct(
+            cq_code=cq_code, base64_data=None, ref_times=1, date=int(str(datetime.now().date()).replace("-", ""))
+        )
         await image_cache_repo.insert(cache)
         return
     cache.ref_times += 1

--- a/src/plugins/repeater/learner.py
+++ b/src/plugins/repeater/learner.py
@@ -94,10 +94,12 @@ class Learner:
                 append_on_existing=chat_data.is_plain_text,
             )
         else:
-            context = Context(
+            context = Context.model_construct(
                 keywords=pre_keywords,
                 time=cur_time,
-                trigger_count=1,  # type: ignore
+                trigger_count=1,
                 answers=[Answer(keywords=keywords, group_id=group_id, count=1, time=cur_time, messages=[raw_message])],
+                ban=[],
+                clear_time=0,
             )
             await context_repo.insert(context)

--- a/src/plugins/repeater/message_store.py
+++ b/src/plugins/repeater/message_store.py
@@ -52,7 +52,7 @@ class MessageStore:
 
         async with MessageStore._message_lock:
             MessageStore._message_dict[group_id].append(
-                MessageModel(
+                MessageModel.model_construct(
                     group_id=group_id,
                     user_id=chat_data.user_id,
                     bot_id=chat_data.bot_id,

--- a/tests/common/conftest.py
+++ b/tests/common/conftest.py
@@ -1,0 +1,82 @@
+"""
+PostgreSQL 集成测试共用 fixture。
+
+需要本地 PG 实例：通过环境变量 ``PG_TEST_DSN`` 注入 SQLAlchemy asyncpg DSN，
+例如 ``postgresql+asyncpg://user:pw@/db?host=/run/postgresql``。未设置时依赖
+这些 fixture 的测试将被自动 skip。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PG_TEST_DSN = os.getenv("PG_TEST_DSN")
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+async def pg_engine():
+    """
+    每个测试独占一个干净 schema。
+
+    进入前：drop_all → init_pg，确保上一次遗留不影响当前用例。
+    退出后：drop_all → dispose_pg（顺便清 _CONFIG_CACHES），避免模块级缓存跨用例污染。
+    """
+    if not PG_TEST_DSN:
+        pytest.skip("需要设置 PG_TEST_DSN 指向测试 PG 实例")
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from src.common.db.repository_pg import Base, dispose_pg, init_pg
+
+    engine = create_async_engine(PG_TEST_DSN)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await init_pg(engine)
+    try:
+        yield engine
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await dispose_pg()
+
+
+@pytest.fixture
+async def pg_env(pg_engine):
+    """
+    迁移脚本集成测试用：在 pg_engine 基础上额外提供 session factory、
+    迁移模块句柄、以及 PG 方言的 insert 构造器。
+    """
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    migrate = _load_migrate_module()
+    await migrate._ensure_state_table(pg_engine)
+    sf = async_sessionmaker(pg_engine, expire_on_commit=False)
+
+    yield {
+        "engine": pg_engine,
+        "sf": sf,
+        "migrate": migrate,
+        "pg_insert": pg_insert,
+    }
+
+
+def _load_migrate_module():
+    """动态加载 tools/migrate_mongo_to_pg.py（非 package，只能按路径 import）。"""
+    mod_name = "_pallas_migrate_mongo_to_pg"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(
+        mod_name, _ROOT / "tools" / "migrate_mongo_to_pg.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod

--- a/tests/common/test_backend_switching.py
+++ b/tests/common/test_backend_switching.py
@@ -81,6 +81,23 @@ def fake_backend():
         INIT_DB_REGISTRY.pop("fake", None)
 
 
+def _set_db_backend(monkeypatch, backend: str) -> None:
+    """同时覆盖 nonebot driver config 与 env，兼容 get_db_backend 的双源读取。
+
+    get_db_backend() 优先从 nonebot.get_driver().config.db_backend 读取，fallback 到
+    DB_BACKEND 环境变量；.env 里若已设置 DB_BACKEND，nonebot 启动时会把它写进 config，
+    单纯 monkeypatch.setenv 不会生效。
+    """
+    import nonebot
+
+    monkeypatch.setenv("DB_BACKEND", backend)
+    try:
+        cfg = nonebot.get_driver().config
+        monkeypatch.setattr(cfg, "db_backend", backend, raising=False)
+    except Exception:
+        pass
+
+
 def test_factories_switch_by_db_backend_env(monkeypatch, fake_backend):
     """当 DB_BACKEND=fake 时，所有 Repository 工厂应返回 fake 实例。"""
     from src.common.db import (
@@ -89,7 +106,7 @@ def test_factories_switch_by_db_backend_env(monkeypatch, fake_backend):
         make_message_repository,
     )
 
-    monkeypatch.setenv("DB_BACKEND", fake_backend)
+    _set_db_backend(monkeypatch, fake_backend)
 
     ctx = make_context_repository()
     msg = make_message_repository()
@@ -104,7 +121,7 @@ def test_unknown_backend_raises(monkeypatch):
     """未注册的后端应抛 ValueError，明确提示已注册的后端列表。"""
     from src.common.db import make_context_repository
 
-    monkeypatch.setenv("DB_BACKEND", "nonexistent-backend")
+    _set_db_backend(monkeypatch, "nonexistent-backend")
 
     with pytest.raises(ValueError, match="不支持的数据库后端"):
         make_context_repository()

--- a/tests/common/test_backend_switching.py
+++ b/tests/common/test_backend_switching.py
@@ -24,6 +24,15 @@ class _FakeContextRepo:
     async def find_for_cleanup(self, trigger_threshold, expiration):  # noqa: ARG002
         return []
 
+    async def upsert_answer(self, keywords, group_id, answer_keywords, answer_time, message, append_on_existing):  # noqa: ARG002
+        return None
+
+    async def replace_answers(self, keywords, answers, clear_time):  # noqa: ARG002
+        return None
+
+    async def append_ban(self, keywords, ban):  # noqa: ARG002
+        return None
+
 
 class _FakeMessageRepo:
     async def bulk_insert(self, messages):  # noqa: ARG002
@@ -41,7 +50,7 @@ class _FakeBlackListRepo:
         return None
 
 
-async def _fake_init(host, port, user, password):  # noqa: ARG001
+async def _fake_init():
     return None
 
 
@@ -107,13 +116,4 @@ async def test_init_db_dispatches_to_registered_backend(fake_backend):
     from src.common.db import init_db
 
     # fake backend 的 init 直接返回 None 不抛异常
-    await init_db("host", 0, "", "", backend=fake_backend)
-
-
-@pytest.mark.asyncio
-async def test_init_db_postgresql_skeleton_raises():
-    """当前 postgresql 后端为 skeleton-only，init 应抛 NotImplementedError。"""
-    from src.common.db import init_db
-
-    with pytest.raises(NotImplementedError, match="PostgreSQL"):
-        await init_db("host", 5432, "", "", backend="postgresql")
+    await init_db(backend=fake_backend)

--- a/tests/common/test_migrate_robustness.py
+++ b/tests/common/test_migrate_robustness.py
@@ -1,0 +1,482 @@
+"""
+Mongo → PG 迁移脚本健壮性测试。
+
+依赖：本地 PG 实例（通过 `PG_TEST_DSN` 注入）。未设置则 skip。
+Mongo 侧用最小 fake 对象代替，不需要真实 Mongo。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_DSN = os.getenv("PG_TEST_DSN")
+
+pytestmark = pytest.mark.skipif(not _DSN, reason="需要设置 PG_TEST_DSN 指向测试 PG 实例")
+
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_migrate_module():
+    """动态加载 tools/migrate_mongo_to_pg.py（它不是 package）。"""
+    mod_name = "_pallas_migrate_mongo_to_pg"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(mod_name, _ROOT / "tools" / "migrate_mongo_to_pg.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Fake Mongo 最小实现
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, docs: list[dict]) -> None:
+        self._docs = docs
+        self._sort_key: str | None = None
+        self._limit: int | None = None
+
+    def sort(self, key: str, direction: int = 1) -> "_FakeCursor":
+        self._sort_key = key
+        reverse = direction < 0
+        self._docs = sorted(self._docs, key=lambda d: d.get(key), reverse=reverse)
+        return self
+
+    def limit(self, n: int) -> "_FakeCursor":
+        self._limit = n
+        return self
+
+    async def to_list(self, length: int | None = None):
+        out = self._docs
+        if self._limit is not None:
+            out = out[: self._limit]
+        if length is not None:
+            out = out[:length]
+        return list(out)
+
+
+class _FakeCollection:
+    def __init__(self, docs: list[dict] | None = None) -> None:
+        self._docs = docs or []
+
+    async def count_documents(self, q: dict) -> int:
+        return sum(1 for d in self._docs if self._match(d, q))
+
+    def find(self, q: dict | None = None):
+        q = q or {}
+        return _FakeCursor([d for d in self._docs if self._match(d, q)])
+
+    @staticmethod
+    def _match(doc: dict, q: dict) -> bool:
+        for k, v in q.items():
+            if isinstance(v, dict) and "$gt" in v:
+                if not (doc.get(k) is not None and doc.get(k) > v["$gt"]):
+                    return False
+            elif doc.get(k) != v:
+                return False
+        return True
+
+
+class _FakeDb:
+    def __init__(self, collections: dict[str, list[dict]]) -> None:
+        self._cols = {name: _FakeCollection(list(docs)) for name, docs in collections.items()}
+
+    def __getitem__(self, name: str) -> _FakeCollection:
+        return self._cols.setdefault(name, _FakeCollection([]))
+
+
+# ---------------------------------------------------------------------------
+# PG engine fixture（与 test_repository_pg 共用模式）
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def pg_env():
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from src.common.db.repository_pg import Base, dispose_pg, init_pg
+
+    assert _DSN is not None
+    engine = create_async_engine(_DSN)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await init_pg(engine)
+
+    migrate = _load_migrate_module()
+    # 建好 migration_state 表
+    await migrate._ensure_state_table(engine)
+
+    sf = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield {
+            "engine": engine,
+            "sf": sf,
+            "migrate": migrate,
+            "pg_insert": pg_insert,
+        }
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await dispose_pg()
+
+
+# ---------------------------------------------------------------------------
+# Defensive helpers 单元测试
+# ---------------------------------------------------------------------------
+
+
+def test_defensive_helpers_handle_garbage():
+    m = _load_migrate_module()
+    assert m._as_int("5") == 5
+    assert m._as_int("abc", 99) == 99
+    assert m._as_int(None, 7) == 7
+    assert m._as_int(True) == 1
+    assert m._as_bool("true") is True
+    assert m._as_bool("0") is False
+    assert m._as_bool(None, True) is True
+    assert m._as_list(None) == []
+    assert m._as_list((1, 2)) == [1, 2]
+    assert m._as_list("nope") == []
+    assert m._as_dict(None) == {}
+    assert m._as_dict([1]) == {}
+    assert m._strip_null("a\x00b") == "ab"
+    assert m._strip_null({"k": "v\x00"}) == {"k": "v"}
+    assert m._strip_null(["x\x00", {"y": "z\x00"}]) == ["x", {"y": "z"}]
+
+
+# ---------------------------------------------------------------------------
+# Context 迁移：脏数据 + keywords 合并 + \x00
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_context_merges_duplicate_keywords(pg_env):
+    from bson import ObjectId
+
+    from src.common.db.repository_pg import ContextAnswerMessageRow, ContextAnswerRow, ContextBanRow, ContextRow
+
+    migrate = pg_env["migrate"]
+    # 同 keywords 在 Mongo 中出现两条（脏数据场景）
+    docs = [
+        {
+            "_id": ObjectId(),
+            "keywords": "dup\x00kw",
+            "time": 100,
+            "trigger_count": 3,
+            "clear_time": 0,
+            "answers": [
+                {"keywords": "a", "group_id": 1, "count": 2, "time": 100, "messages": ["m1", "m2\x00"]},
+            ],
+            "ban": [{"keywords": "b", "group_id": 1, "reason": "r1\x00", "time": 100}],
+        },
+        {
+            "_id": ObjectId(),
+            "keywords": "dup\x00kw",  # 同 keywords
+            "time": 200,
+            "trigger_count": 1,
+            "clear_time": 50,
+            "answers": [
+                {"keywords": "a", "group_id": 1, "count": 1, "time": 200, "messages": ["m3"]},  # 同 answer key
+                {"keywords": "c", "group_id": 2, "count": 1, "time": 200, "messages": []},
+            ],
+            "ban": [],
+        },
+        # 脏数据：空 keywords 应被 skip
+        {"_id": ObjectId(), "keywords": "", "time": 0, "answers": [], "ban": []},
+        # 脏数据：answers 里混入非 dict，应被忽略
+        {"_id": ObjectId(), "keywords": "weird", "time": 0, "answers": ["not a dict", None], "ban": []},
+    ]
+    db = _FakeDb({"context": docs})
+
+    await migrate._migrate_context(
+        db,
+        pg_env["sf"],
+        ContextRow,
+        ContextAnswerRow,
+        ContextAnswerMessageRow,
+        ContextBanRow,
+        pg_env["pg_insert"],
+        batch_size=100,
+        dry_run=False,
+    )
+
+    from sqlalchemy import select
+
+    async with pg_env["sf"]() as session:
+        ctxs = (await session.execute(select(ContextRow))).scalars().all()
+        # "dup...kw" 合并成一条 + "weird" 一条 = 2
+        assert len(ctxs) == 2, [c.keywords for c in ctxs]
+        dup = next(c for c in ctxs if "dup" in c.keywords)
+        assert "\x00" not in dup.keywords
+        # 合并后 time/trigger_count/clear_time 应该取 max
+        assert dup.time == 200
+        assert dup.trigger_count == 3
+        assert dup.clear_time == 50
+
+        ans = (await session.execute(select(ContextAnswerRow).where(ContextAnswerRow.context_id == dup.id))).scalars().all()
+        # (group=1, kw=a) 合并, (group=2, kw=c) 单独 = 2
+        assert len(ans) == 2
+        ans_a = next(a for a in ans if a.group_id == 1 and a.keywords == "a")
+        # count 累加
+        assert ans_a.count == 3
+        # time 取 max
+        assert ans_a.time == 200
+
+        msgs = (await session.execute(
+            select(ContextAnswerMessageRow).where(ContextAnswerMessageRow.answer_id == ans_a.id)
+        )).scalars().all()
+        all_msgs = {m.message for m in msgs}
+        assert all_msgs == {"m1", "m2", "m3"}
+        assert all("\x00" not in m for m in all_msgs)
+
+        bans = (await session.execute(select(ContextBanRow).where(ContextBanRow.context_id == dup.id))).scalars().all()
+        assert len(bans) == 1
+        assert "\x00" not in bans[0].reason
+
+
+# ---------------------------------------------------------------------------
+# Message 迁移 + 断点续传
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_message_resumable(pg_env):
+    """模拟已迁移部分数据后重跑，只补齐未迁移的部分。"""
+    from bson import ObjectId
+    from sqlalchemy import func, select
+
+    from src.common.db.repository_pg import MessageRow
+
+    migrate = pg_env["migrate"]
+
+    ids = [ObjectId() for _ in range(10)]
+    docs = [
+        {
+            "_id": ids[i],
+            "group_id": 1,
+            "user_id": 2,
+            "bot_id": 3,
+            "raw_message": f"msg{i}\x00",
+            "is_plain_text": True,
+            "plain_text": f"msg{i}",
+            "keywords": "",
+            "time": 100 + i,
+        }
+        for i in range(10)
+    ]
+    db = _FakeDb({"message": docs})
+
+    # 第一次：只迁前 5 条（人为写 state）
+    async with pg_env["sf"]() as session:
+        # 先迁前 5
+        from sqlalchemy import insert as sa_insert
+
+        for i in range(5):
+            await session.execute(
+                sa_insert(MessageRow).values(
+                    group_id=1, user_id=2, bot_id=3,
+                    raw_message=f"msg{i}", is_plain_text=True, plain_text=f"msg{i}",
+                    keywords="", time=100 + i,
+                )
+            )
+        await migrate._set_state(session, "message", str(ids[4]))
+        await session.commit()
+
+    # 第二次：从 state 续迁
+    await migrate._migrate_message(
+        db, pg_env["sf"], MessageRow, pg_env["pg_insert"], batch_size=100, dry_run=False
+    )
+
+    async with pg_env["sf"]() as session:
+        total = (await session.execute(select(func.count()).select_from(MessageRow))).scalar_one()
+        assert total == 10  # 前 5 + 后 5, 无重复
+        # \x00 应被剥除
+        rows = (await session.execute(select(MessageRow).order_by(MessageRow.time))).scalars().all()
+        assert all("\x00" not in r.raw_message for r in rows)
+
+
+async def test_migrate_message_dirty_rows_counted(pg_env):
+    """脏数据（字段错类型）应 skip 并计入 failed，但不阻断。"""
+    from bson import ObjectId
+    from sqlalchemy import func, select
+
+    from src.common.db.repository_pg import MessageRow
+
+    migrate = pg_env["migrate"]
+
+    docs = [
+        # 正常
+        {
+            "_id": ObjectId(),
+            "group_id": 1,
+            "user_id": 2,
+            "bot_id": 3,
+            "raw_message": "ok",
+            "is_plain_text": True,
+            "plain_text": "ok",
+            "keywords": "",
+            "time": 100,
+        },
+        # 非法 group_id（字符串），defensive 转 0 还是能插入（保守处理）
+        {
+            "_id": ObjectId(),
+            "group_id": "not-a-number",
+            "user_id": 2,
+            "bot_id": 3,
+            "raw_message": "weird",
+            "is_plain_text": True,
+            "plain_text": "weird",
+            "keywords": "",
+            "time": 101,
+        },
+    ]
+    db = _FakeDb({"message": docs})
+    stats = await migrate._migrate_message(
+        db, pg_env["sf"], MessageRow, pg_env["pg_insert"], batch_size=100, dry_run=False
+    )
+    # 两条都应成功（defensive 把字符串 group_id 转成 0）
+    async with pg_env["sf"]() as session:
+        total = (await session.execute(select(func.count()).select_from(MessageRow))).scalar_one()
+    assert total == 2
+    assert stats.failed == 0
+
+
+# ---------------------------------------------------------------------------
+# BlackList / Config 迁移
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_blacklist_rerun_idempotent(pg_env):
+    from bson import ObjectId
+    from sqlalchemy import func, select
+
+    from src.common.db.repository_pg import BlackListRow
+
+    migrate = pg_env["migrate"]
+    docs = [
+        {"_id": ObjectId(), "group_id": 1, "answers": ["a\x00", "b"], "answers_reserve": []},
+        {"_id": ObjectId(), "group_id": 2, "answers": [], "answers_reserve": ["x"]},
+    ]
+    db = _FakeDb({"blacklist": docs})
+
+    await migrate._migrate_blacklist(db, pg_env["sf"], BlackListRow, pg_env["pg_insert"], batch_size=100, dry_run=False)
+
+    # 重跑：因 migration_state 记录的 last_id 已经是最后一条 _id，游标没有新数据
+    await migrate._migrate_blacklist(db, pg_env["sf"], BlackListRow, pg_env["pg_insert"], batch_size=100, dry_run=False)
+
+    async with pg_env["sf"]() as session:
+        rows = (await session.execute(select(BlackListRow).order_by(BlackListRow.group_id))).scalars().all()
+        assert len(rows) == 2
+        assert rows[0].answers == ["a", "b"]
+        assert rows[1].answers_reserve == ["x"]
+
+
+async def test_migrate_bot_config_handles_auto_accept_legacy(pg_env):
+    """旧 schema：auto_accept 仅存 group 维度；新 schema 拆成 friend/group。"""
+    from bson import ObjectId
+    from sqlalchemy import select
+
+    from src.common.db.repository_pg import BotConfigRow
+
+    migrate = pg_env["migrate"]
+    docs = [
+        # 旧字段
+        {"_id": ObjectId(), "account": 1001, "auto_accept": True, "admins": [1, "2", "bad"], "taken_name": {"100": 1}, "drunk": {"200": 0.5}},
+        # 新字段
+        {"_id": ObjectId(), "account": 1002, "auto_accept_group": False, "auto_accept_friend": True},
+    ]
+    db = _FakeDb({"config": docs})
+
+    await migrate._migrate_bot_config(db, pg_env["sf"], BotConfigRow, pg_env["pg_insert"], batch_size=100, dry_run=False)
+
+    async with pg_env["sf"]() as session:
+        rows = (await session.execute(select(BotConfigRow).order_by(BotConfigRow.account))).scalars().all()
+        assert rows[0].account == 1001
+        assert rows[0].auto_accept_group is True
+        assert rows[0].auto_accept_friend is False
+        assert rows[0].admins == [1, 2]  # "bad" 被 skip
+        assert rows[1].auto_accept_group is False
+        assert rows[1].auto_accept_friend is True
+
+
+async def test_migrate_image_cache_upsert(pg_env):
+    from bson import ObjectId
+    from sqlalchemy import select
+
+    from src.common.db.repository_pg import ImageCacheRow
+
+    migrate = pg_env["migrate"]
+    docs = [
+        {"_id": ObjectId(), "cq_code": "[CQ:image,file=a.image]", "base64_data": None, "ref_times": 1, "date": 20250101},
+        # 同 cq_code 再来一条，应 upsert 取最新
+        {"_id": ObjectId(), "cq_code": "[CQ:image,file=a.image]", "base64_data": "b64", "ref_times": 5, "date": 20250110},
+        # 脏：空 cq_code
+        {"_id": ObjectId(), "cq_code": "", "base64_data": None, "ref_times": 1, "date": 20250101},
+    ]
+    db = _FakeDb({"image_cache": docs})
+
+    stats = await migrate._migrate_image_cache(
+        db, pg_env["sf"], ImageCacheRow, pg_env["pg_insert"], batch_size=100, dry_run=False
+    )
+
+    async with pg_env["sf"]() as session:
+        rows = (await session.execute(select(ImageCacheRow))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].ref_times == 5
+    assert rows[0].base64_data == "b64"
+    assert stats.failed >= 1  # 空 cq_code 那条
+
+
+# ---------------------------------------------------------------------------
+# 游标流式工具
+# ---------------------------------------------------------------------------
+
+
+async def test_stream_batches_orders_by_id_and_paginates():
+    migrate = _load_migrate_module()
+    from bson import ObjectId
+
+    # 构造 25 个按 id 递增的 doc
+    ids = [ObjectId() for _ in range(25)]
+    docs = [{"_id": ids[i], "n": i} for i in range(25)]
+    col = _FakeCollection(docs)
+
+    seen: list[int] = []
+    async for batch in migrate._stream_batches(col, None, batch_size=10):
+        seen.extend(d["n"] for d in batch)
+    assert seen == list(range(25))
+
+    # 从中间续传
+    resume_from = str(ids[9])
+    seen2: list[int] = []
+    async for batch in migrate._stream_batches(col, resume_from, batch_size=10):
+        seen2.extend(d["n"] for d in batch)
+    assert seen2 == list(range(10, 25))
+
+
+async def test_dedupe_answers_aggregates_correctly():
+    migrate = _load_migrate_module()
+
+    answers = [
+        {"keywords": "a", "group_id": 1, "count": 3, "time": 100, "messages": ["m1"]},
+        {"keywords": "a", "group_id": 1, "count": 2, "time": 200, "messages": ["m2", "m3"]},
+        {"keywords": "b", "group_id": 1, "count": 1, "time": 150, "messages": ["m4"]},
+    ]
+    result = migrate._dedupe_answers(answers)
+    result.sort(key=lambda a: a["keywords"])
+    assert len(result) == 2
+    assert result[0]["keywords"] == "a"
+    assert result[0]["count"] == 5
+    assert result[0]["time"] == 200
+    assert result[0]["messages"] == ["m1", "m2", "m3"]

--- a/tests/common/test_migrate_robustness.py
+++ b/tests/common/test_migrate_robustness.py
@@ -1,40 +1,14 @@
 """
 Mongo → PG 迁移脚本健壮性测试。
 
-依赖：本地 PG 实例（通过 `PG_TEST_DSN` 注入）。未设置则 skip。
-Mongo 侧用最小 fake 对象代替，不需要真实 Mongo。
+fixture（``pg_env`` / 迁移模块加载）来自 ``tests/common/conftest.py``；未设置
+``PG_TEST_DSN`` 时依赖 pg_env 的用例自动 skip，纯函数用例（defensive helpers、
+去重聚合）无 DB 依赖、始终会跑。Mongo 侧以下方 ``_FakeDb`` 代替真实实例。
 """
 
 from __future__ import annotations
 
-import importlib.util
-import os
-import sys
-import uuid
-from pathlib import Path
-from typing import Any
-
-import pytest
-
-_DSN = os.getenv("PG_TEST_DSN")
-
-pytestmark = pytest.mark.skipif(not _DSN, reason="需要设置 PG_TEST_DSN 指向测试 PG 实例")
-
-
-_ROOT = Path(__file__).resolve().parents[2]
-
-
-def _load_migrate_module():
-    """动态加载 tools/migrate_mongo_to_pg.py（它不是 package）。"""
-    mod_name = "_pallas_migrate_mongo_to_pg"
-    if mod_name in sys.modules:
-        return sys.modules[mod_name]
-    spec = importlib.util.spec_from_file_location(mod_name, _ROOT / "tools" / "migrate_mongo_to_pg.py")
-    assert spec and spec.loader
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[mod_name] = mod
-    spec.loader.exec_module(mod)
-    return mod
+from .conftest import _load_migrate_module
 
 
 # ---------------------------------------------------------------------------
@@ -98,47 +72,12 @@ class _FakeDb:
 
 
 # ---------------------------------------------------------------------------
-# PG engine fixture（与 test_repository_pg 共用模式）
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-async def pg_env():
-    from sqlalchemy.dialects.postgresql import insert as pg_insert
-    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-
-    from src.common.db.repository_pg import Base, dispose_pg, init_pg
-
-    assert _DSN is not None
-    engine = create_async_engine(_DSN)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-    await init_pg(engine)
-
-    migrate = _load_migrate_module()
-    # 建好 migration_state 表
-    await migrate._ensure_state_table(engine)
-
-    sf = async_sessionmaker(engine, expire_on_commit=False)
-    try:
-        yield {
-            "engine": engine,
-            "sf": sf,
-            "migrate": migrate,
-            "pg_insert": pg_insert,
-        }
-    finally:
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-        await dispose_pg()
-
-
-# ---------------------------------------------------------------------------
-# Defensive helpers 单元测试
+# Defensive helpers（纯函数测试，无需 DB）
 # ---------------------------------------------------------------------------
 
 
 def test_defensive_helpers_handle_garbage():
+    """_as_int/_as_bool/_as_list/_as_dict/_strip_null 对 None、错类型、嵌套容器都要给合理默认。"""
     m = _load_migrate_module()
     assert m._as_int("5") == 5
     assert m._as_int("abc", 99) == 99
@@ -157,18 +96,57 @@ def test_defensive_helpers_handle_garbage():
     assert m._strip_null(["x\x00", {"y": "z\x00"}]) == ["x", {"y": "z"}]
 
 
+async def test_stream_batches_orders_by_id_and_paginates():
+    """_stream_batches 按 _id 升序分页，并支持从任意 last_id 处续传。"""
+    migrate = _load_migrate_module()
+    from bson import ObjectId
+
+    ids = [ObjectId() for _ in range(25)]
+    docs = [{"_id": ids[i], "n": i} for i in range(25)]
+    col = _FakeCollection(docs)
+
+    seen: list[int] = []
+    async for batch in migrate._stream_batches(col, None, batch_size=10):
+        seen.extend(d["n"] for d in batch)
+    assert seen == list(range(25))
+
+    resume_from = str(ids[9])
+    seen2: list[int] = []
+    async for batch in migrate._stream_batches(col, resume_from, batch_size=10):
+        seen2.extend(d["n"] for d in batch)
+    assert seen2 == list(range(10, 25))
+
+
+async def test_dedupe_answers_aggregates_correctly():
+    """_dedupe_answers 按 (group_id, keywords) 聚合：count 累加、time 取 max、messages 合并。"""
+    migrate = _load_migrate_module()
+
+    answers = [
+        {"keywords": "a", "group_id": 1, "count": 3, "time": 100, "messages": ["m1"]},
+        {"keywords": "a", "group_id": 1, "count": 2, "time": 200, "messages": ["m2", "m3"]},
+        {"keywords": "b", "group_id": 1, "count": 1, "time": 150, "messages": ["m4"]},
+    ]
+    result = migrate._dedupe_answers(answers)
+    result.sort(key=lambda a: a["keywords"])
+    assert len(result) == 2
+    assert result[0]["keywords"] == "a"
+    assert result[0]["count"] == 5
+    assert result[0]["time"] == 200
+    assert result[0]["messages"] == ["m1", "m2", "m3"]
+
+
 # ---------------------------------------------------------------------------
 # Context 迁移：脏数据 + keywords 合并 + \x00
 # ---------------------------------------------------------------------------
 
 
 async def test_migrate_context_merges_duplicate_keywords(pg_env):
+    """同 keywords_hash 的多条 Mongo 文档在单批内合并成 1 个 Context，answers/bans 正确聚合。"""
     from bson import ObjectId
 
     from src.common.db.repository_pg import ContextAnswerMessageRow, ContextAnswerRow, ContextBanRow, ContextRow
 
     migrate = pg_env["migrate"]
-    # 同 keywords 在 Mongo 中出现两条（脏数据场景）
     docs = [
         {
             "_id": ObjectId(),
@@ -183,19 +161,19 @@ async def test_migrate_context_merges_duplicate_keywords(pg_env):
         },
         {
             "_id": ObjectId(),
-            "keywords": "dup\x00kw",  # 同 keywords
+            "keywords": "dup\x00kw",  # 与上一条同 keywords
             "time": 200,
             "trigger_count": 1,
             "clear_time": 50,
             "answers": [
-                {"keywords": "a", "group_id": 1, "count": 1, "time": 200, "messages": ["m3"]},  # 同 answer key
+                {"keywords": "a", "group_id": 1, "count": 1, "time": 200, "messages": ["m3"]},
                 {"keywords": "c", "group_id": 2, "count": 1, "time": 200, "messages": []},
             ],
             "ban": [],
         },
-        # 脏数据：空 keywords 应被 skip
+        # 空 keywords 应被 skip
         {"_id": ObjectId(), "keywords": "", "time": 0, "answers": [], "ban": []},
-        # 脏数据：answers 里混入非 dict，应被忽略
+        # answers 里混入非 dict，应被忽略但 context 本身照常写入
         {"_id": ObjectId(), "keywords": "weird", "time": 0, "answers": ["not a dict", None], "ban": []},
     ]
     db = _FakeDb({"context": docs})
@@ -216,32 +194,33 @@ async def test_migrate_context_merges_duplicate_keywords(pg_env):
 
     async with pg_env["sf"]() as session:
         ctxs = (await session.execute(select(ContextRow))).scalars().all()
-        # "dup...kw" 合并成一条 + "weird" 一条 = 2
         assert len(ctxs) == 2, [c.keywords for c in ctxs]
         dup = next(c for c in ctxs if "dup" in c.keywords)
         assert "\x00" not in dup.keywords
-        # 合并后 time/trigger_count/clear_time 应该取 max
         assert dup.time == 200
         assert dup.trigger_count == 3
         assert dup.clear_time == 50
 
-        ans = (await session.execute(select(ContextAnswerRow).where(ContextAnswerRow.context_id == dup.id))).scalars().all()
-        # (group=1, kw=a) 合并, (group=2, kw=c) 单独 = 2
+        ans = (
+            await session.execute(select(ContextAnswerRow).where(ContextAnswerRow.context_id == dup.id))
+        ).scalars().all()
         assert len(ans) == 2
         ans_a = next(a for a in ans if a.group_id == 1 and a.keywords == "a")
-        # count 累加
         assert ans_a.count == 3
-        # time 取 max
         assert ans_a.time == 200
 
-        msgs = (await session.execute(
-            select(ContextAnswerMessageRow).where(ContextAnswerMessageRow.answer_id == ans_a.id)
-        )).scalars().all()
+        msgs = (
+            await session.execute(
+                select(ContextAnswerMessageRow).where(ContextAnswerMessageRow.answer_id == ans_a.id)
+            )
+        ).scalars().all()
         all_msgs = {m.message for m in msgs}
         assert all_msgs == {"m1", "m2", "m3"}
         assert all("\x00" not in m for m in all_msgs)
 
-        bans = (await session.execute(select(ContextBanRow).where(ContextBanRow.context_id == dup.id))).scalars().all()
+        bans = (
+            await session.execute(select(ContextBanRow).where(ContextBanRow.context_id == dup.id))
+        ).scalars().all()
         assert len(bans) == 1
         assert "\x00" not in bans[0].reason
 
@@ -252,9 +231,9 @@ async def test_migrate_context_merges_duplicate_keywords(pg_env):
 
 
 async def test_migrate_message_resumable(pg_env):
-    """模拟已迁移部分数据后重跑，只补齐未迁移的部分。"""
+    """migration_state 已写 last_id 时，重跑只补未迁部分、不产生重复。"""
     from bson import ObjectId
-    from sqlalchemy import func, select
+    from sqlalchemy import func, insert as sa_insert, select
 
     from src.common.db.repository_pg import MessageRow
 
@@ -277,11 +256,8 @@ async def test_migrate_message_resumable(pg_env):
     ]
     db = _FakeDb({"message": docs})
 
-    # 第一次：只迁前 5 条（人为写 state）
+    # 人为写入"前 5 条已迁 + state 停在第 5 条"的状态
     async with pg_env["sf"]() as session:
-        # 先迁前 5
-        from sqlalchemy import insert as sa_insert
-
         for i in range(5):
             await session.execute(
                 sa_insert(MessageRow).values(
@@ -293,21 +269,19 @@ async def test_migrate_message_resumable(pg_env):
         await migrate._set_state(session, "message", str(ids[4]))
         await session.commit()
 
-    # 第二次：从 state 续迁
     await migrate._migrate_message(
         db, pg_env["sf"], MessageRow, pg_env["pg_insert"], batch_size=100, dry_run=False
     )
 
     async with pg_env["sf"]() as session:
         total = (await session.execute(select(func.count()).select_from(MessageRow))).scalar_one()
-        assert total == 10  # 前 5 + 后 5, 无重复
-        # \x00 应被剥除
+        assert total == 10
         rows = (await session.execute(select(MessageRow).order_by(MessageRow.time))).scalars().all()
         assert all("\x00" not in r.raw_message for r in rows)
 
 
 async def test_migrate_message_dirty_rows_counted(pg_env):
-    """脏数据（字段错类型）应 skip 并计入 failed，但不阻断。"""
+    """defensive helpers 把错类型字段（如 group_id='not-a-number'）兜底成默认值后仍入库，保证单条脏数据不拖垮整个 batch。"""
     from bson import ObjectId
     from sqlalchemy import func, select
 
@@ -316,7 +290,6 @@ async def test_migrate_message_dirty_rows_counted(pg_env):
     migrate = pg_env["migrate"]
 
     docs = [
-        # 正常
         {
             "_id": ObjectId(),
             "group_id": 1,
@@ -328,10 +301,9 @@ async def test_migrate_message_dirty_rows_counted(pg_env):
             "keywords": "",
             "time": 100,
         },
-        # 非法 group_id（字符串），defensive 转 0 还是能插入（保守处理）
         {
             "_id": ObjectId(),
-            "group_id": "not-a-number",
+            "group_id": "not-a-number",  # 错类型：应被 _as_int 兜底成 0
             "user_id": 2,
             "bot_id": 3,
             "raw_message": "weird",
@@ -345,7 +317,6 @@ async def test_migrate_message_dirty_rows_counted(pg_env):
     stats = await migrate._migrate_message(
         db, pg_env["sf"], MessageRow, pg_env["pg_insert"], batch_size=100, dry_run=False
     )
-    # 两条都应成功（defensive 把字符串 group_id 转成 0）
     async with pg_env["sf"]() as session:
         total = (await session.execute(select(func.count()).select_from(MessageRow))).scalar_one()
     assert total == 2
@@ -358,8 +329,9 @@ async def test_migrate_message_dirty_rows_counted(pg_env):
 
 
 async def test_migrate_blacklist_rerun_idempotent(pg_env):
+    """迁完一次后重跑不产生重复写入；\\x00 字段已被剥除。"""
     from bson import ObjectId
-    from sqlalchemy import func, select
+    from sqlalchemy import select
 
     from src.common.db.repository_pg import BlackListRow
 
@@ -371,8 +343,6 @@ async def test_migrate_blacklist_rerun_idempotent(pg_env):
     db = _FakeDb({"blacklist": docs})
 
     await migrate._migrate_blacklist(db, pg_env["sf"], BlackListRow, pg_env["pg_insert"], batch_size=100, dry_run=False)
-
-    # 重跑：因 migration_state 记录的 last_id 已经是最后一条 _id，游标没有新数据
     await migrate._migrate_blacklist(db, pg_env["sf"], BlackListRow, pg_env["pg_insert"], batch_size=100, dry_run=False)
 
     async with pg_env["sf"]() as session:
@@ -383,7 +353,7 @@ async def test_migrate_blacklist_rerun_idempotent(pg_env):
 
 
 async def test_migrate_bot_config_handles_auto_accept_legacy(pg_env):
-    """旧 schema：auto_accept 仅存 group 维度；新 schema 拆成 friend/group。"""
+    """旧 schema 只有 auto_accept（仅对 group 生效），迁移要能 fallback；admins 里非法项直接跳过。"""
     from bson import ObjectId
     from sqlalchemy import select
 
@@ -391,9 +361,7 @@ async def test_migrate_bot_config_handles_auto_accept_legacy(pg_env):
 
     migrate = pg_env["migrate"]
     docs = [
-        # 旧字段
         {"_id": ObjectId(), "account": 1001, "auto_accept": True, "admins": [1, "2", "bad"], "taken_name": {"100": 1}, "drunk": {"200": 0.5}},
-        # 新字段
         {"_id": ObjectId(), "account": 1002, "auto_accept_group": False, "auto_accept_friend": True},
     ]
     db = _FakeDb({"config": docs})
@@ -405,12 +373,13 @@ async def test_migrate_bot_config_handles_auto_accept_legacy(pg_env):
         assert rows[0].account == 1001
         assert rows[0].auto_accept_group is True
         assert rows[0].auto_accept_friend is False
-        assert rows[0].admins == [1, 2]  # "bad" 被 skip
+        assert rows[0].admins == [1, 2]
         assert rows[1].auto_accept_group is False
         assert rows[1].auto_accept_friend is True
 
 
 async def test_migrate_image_cache_upsert(pg_env):
+    """同 cq_code 多条在单批内 upsert 只剩最后一条；空 cq_code 脏数据被计入 failed。"""
     from bson import ObjectId
     from sqlalchemy import select
 
@@ -419,9 +388,7 @@ async def test_migrate_image_cache_upsert(pg_env):
     migrate = pg_env["migrate"]
     docs = [
         {"_id": ObjectId(), "cq_code": "[CQ:image,file=a.image]", "base64_data": None, "ref_times": 1, "date": 20250101},
-        # 同 cq_code 再来一条，应 upsert 取最新
         {"_id": ObjectId(), "cq_code": "[CQ:image,file=a.image]", "base64_data": "b64", "ref_times": 5, "date": 20250110},
-        # 脏：空 cq_code
         {"_id": ObjectId(), "cq_code": "", "base64_data": None, "ref_times": 1, "date": 20250101},
     ]
     db = _FakeDb({"image_cache": docs})
@@ -435,48 +402,4 @@ async def test_migrate_image_cache_upsert(pg_env):
     assert len(rows) == 1
     assert rows[0].ref_times == 5
     assert rows[0].base64_data == "b64"
-    assert stats.failed >= 1  # 空 cq_code 那条
-
-
-# ---------------------------------------------------------------------------
-# 游标流式工具
-# ---------------------------------------------------------------------------
-
-
-async def test_stream_batches_orders_by_id_and_paginates():
-    migrate = _load_migrate_module()
-    from bson import ObjectId
-
-    # 构造 25 个按 id 递增的 doc
-    ids = [ObjectId() for _ in range(25)]
-    docs = [{"_id": ids[i], "n": i} for i in range(25)]
-    col = _FakeCollection(docs)
-
-    seen: list[int] = []
-    async for batch in migrate._stream_batches(col, None, batch_size=10):
-        seen.extend(d["n"] for d in batch)
-    assert seen == list(range(25))
-
-    # 从中间续传
-    resume_from = str(ids[9])
-    seen2: list[int] = []
-    async for batch in migrate._stream_batches(col, resume_from, batch_size=10):
-        seen2.extend(d["n"] for d in batch)
-    assert seen2 == list(range(10, 25))
-
-
-async def test_dedupe_answers_aggregates_correctly():
-    migrate = _load_migrate_module()
-
-    answers = [
-        {"keywords": "a", "group_id": 1, "count": 3, "time": 100, "messages": ["m1"]},
-        {"keywords": "a", "group_id": 1, "count": 2, "time": 200, "messages": ["m2", "m3"]},
-        {"keywords": "b", "group_id": 1, "count": 1, "time": 150, "messages": ["m4"]},
-    ]
-    result = migrate._dedupe_answers(answers)
-    result.sort(key=lambda a: a["keywords"])
-    assert len(result) == 2
-    assert result[0]["keywords"] == "a"
-    assert result[0]["count"] == 5
-    assert result[0]["time"] == 200
-    assert result[0]["messages"] == ["m1", "m2", "m3"]
+    assert stats.failed >= 1

--- a/tests/common/test_migrate_robustness.py
+++ b/tests/common/test_migrate_robustness.py
@@ -231,7 +231,7 @@ async def test_migrate_context_merges_duplicate_keywords(pg_env):
 
 
 async def test_migrate_message_resumable(pg_env):
-    """migration_state 已写 last_id 时，重跑只补未迁部分、不产生重复。"""
+    """pallas_migration_state 已写 last_id 时，重跑只补未迁部分、不产生重复。"""
     from bson import ObjectId
     from sqlalchemy import func, insert as sa_insert, select
 

--- a/tests/common/test_repository_pg.py
+++ b/tests/common/test_repository_pg.py
@@ -1,0 +1,316 @@
+"""
+PostgreSQL Repository 集成测试。
+
+需要本地 PG 实例：通过环境变量 `PG_TEST_DSN` 注入（SQLAlchemy asyncpg DSN 格式，
+例如 `postgresql+asyncpg://user:pw@/db?host=/run/postgresql`）。未设置则整个
+模块 skip，不阻塞 CI。
+
+覆盖内容：
+- find_for_cleanup OR 语义（与 Mongo 对齐）
+- upsert_answer 并发原子性（复合唯一约束）
+- BlackList / ImageCache 的 upsert 原子性
+- \\x00 过滤
+- ConfigRepository TTL 缓存命中/失效/ignore_cache/写失效
+- delete_expired chunked 行为
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+_DSN = os.getenv("PG_TEST_DSN")
+
+pytestmark = pytest.mark.skipif(not _DSN, reason="需要设置 PG_TEST_DSN 指向测试 PG 实例")
+
+
+@pytest.fixture
+async def pg_engine():
+    """每个测试一个独立 engine + schema，测试结束 drop 所有表。"""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    from src.common.db.repository_pg import Base, dispose_pg, init_pg
+
+    assert _DSN is not None
+    engine = create_async_engine(_DSN)
+    # 清理上一次跑剩的 schema（按 FK 顺序 drop）
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await init_pg(engine)
+    try:
+        yield engine
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await dispose_pg()
+
+
+# ---------------------------------------------------------------------------
+# Context 语义
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_find_for_cleanup_or_semantics(pg_engine):
+    """find_for_cleanup 必须是 trigger_count>threshold OR clear_time<expiration。"""
+    from src.common.db.modules import Context
+    from src.common.db.repository_pg import PgContextRepository
+
+    repo = PgContextRepository()
+    await repo.insert(
+        Context.model_construct(keywords="high", time=1000, trigger_count=150, answers=[], ban=[], clear_time=999)
+    )
+    await repo.insert(
+        Context.model_construct(keywords="old", time=1000, trigger_count=5, answers=[], ban=[], clear_time=100)
+    )
+    await repo.insert(
+        Context.model_construct(keywords="neither", time=1000, trigger_count=5, answers=[], ban=[], clear_time=999)
+    )
+
+    results = await repo.find_for_cleanup(trigger_threshold=100, expiration=500)
+    got = {c.keywords for c in results}
+    assert "high" in got
+    assert "old" in got
+    assert "neither" not in got
+
+
+@pytest.mark.asyncio
+async def test_upsert_answer_is_atomic(pg_engine):
+    """并发 50 次 upsert_answer 同一 (keywords, group_id, answer_keywords)，
+    必须只产生 1 个 Answer 行且 count=50，trigger_count=50。"""
+    from src.common.db.modules import Context
+    from src.common.db.repository_pg import PgContextRepository
+
+    repo = PgContextRepository()
+    await repo.insert(
+        Context.model_construct(keywords="kw", time=0, trigger_count=1, answers=[], ban=[], clear_time=0)
+    )
+
+    async def _u(i: int):
+        await repo.upsert_answer(
+            keywords="kw", group_id=1, answer_keywords="a", answer_time=100 + i, message=f"m{i}", append_on_existing=True
+        )
+
+    await asyncio.gather(*[_u(i) for i in range(50)])
+
+    found = await repo.find_by_keywords("kw")
+    assert found is not None
+    assert len(found.answers) == 1
+    assert found.answers[0].count == 50
+    assert len(found.answers[0].messages) == 50
+    # trigger_count 起始为 1（insert 时），每次 upsert_answer + 1
+    assert found.trigger_count == 1 + 50
+
+
+@pytest.mark.asyncio
+async def test_upsert_answer_append_flag(pg_engine):
+    """append_on_existing=False 时，已有 Answer 不应新增 message。"""
+    from src.common.db.modules import Context
+    from src.common.db.repository_pg import PgContextRepository
+
+    repo = PgContextRepository()
+    await repo.insert(
+        Context.model_construct(keywords="k", time=0, trigger_count=1, answers=[], ban=[], clear_time=0)
+    )
+
+    await repo.upsert_answer("k", 1, "a", 100, "first", append_on_existing=True)
+    await repo.upsert_answer("k", 1, "a", 200, "second", append_on_existing=False)
+    found = await repo.find_by_keywords("k")
+    assert found is not None
+    assert found.answers[0].count == 2
+    assert found.answers[0].time == 200
+    assert "first" in found.answers[0].messages
+    assert "second" not in found.answers[0].messages
+
+
+@pytest.mark.asyncio
+async def test_upsert_answer_context_missing(pg_engine):
+    """Context 不存在时，upsert_answer 必须 no-op。"""
+    from src.common.db.repository_pg import PgContextRepository
+
+    repo = PgContextRepository()
+    # 不先 insert context
+    await repo.upsert_answer("absent", 1, "a", 100, "m", append_on_existing=True)
+    found = await repo.find_by_keywords("absent")
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_chunked(pg_engine):
+    """插入 100 个过期 Context，delete_expired 应全部清掉。"""
+    from src.common.db.modules import Context
+    from src.common.db.repository_pg import PgContextRepository
+
+    repo = PgContextRepository()
+    for i in range(100):
+        await repo.insert(
+            Context.model_construct(keywords=f"old{i}", time=10, trigger_count=1, answers=[], ban=[], clear_time=0)
+        )
+    # 插入不应被删的
+    await repo.insert(
+        Context.model_construct(keywords="keep", time=9999, trigger_count=1, answers=[], ban=[], clear_time=0)
+    )
+
+    await repo.delete_expired(expiration=100, threshold=3)
+    assert await repo.find_by_keywords("old0") is None
+    assert await repo.find_by_keywords("old99") is None
+    assert await repo.find_by_keywords("keep") is not None
+
+
+@pytest.mark.asyncio
+async def test_null_byte_stripping(pg_engine):
+    """写入含 \\x00 的字段必须被剥除，不得让 PG 报错。"""
+    from src.common.db.modules import Answer, Ban, Context, Message
+    from src.common.db.repository_pg import PgContextRepository, PgMessageRepository
+
+    ctx_repo = PgContextRepository()
+    msg_repo = PgMessageRepository()
+
+    await ctx_repo.insert(
+        Context.model_construct(
+            keywords="null\x00kw",
+            time=0,
+            trigger_count=1,
+            answers=[Answer.model_construct(keywords="a\x00", group_id=1, count=1, time=0, messages=["m\x00sg"])],
+            ban=[Ban.model_construct(keywords="b\x00", group_id=1, reason="r\x00", time=0)],
+            clear_time=0,
+        )
+    )
+    found = await ctx_repo.find_by_keywords("null\x00kw")
+    assert found is not None
+    assert "\x00" not in found.keywords
+    assert "\x00" not in found.answers[0].keywords
+    assert "\x00" not in found.answers[0].messages[0]
+    assert "\x00" not in found.ban[0].keywords
+    assert "\x00" not in found.ban[0].reason
+
+    await msg_repo.bulk_insert([
+        Message.model_construct(
+            group_id=1,
+            user_id=2,
+            bot_id=3,
+            raw_message="raw\x00",
+            is_plain_text=True,
+            plain_text="plain\x00",
+            keywords="kw\x00",
+            time=0,
+        )
+    ])
+
+
+# ---------------------------------------------------------------------------
+# BlackList / ImageCache
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blacklist_upsert_is_atomic(pg_engine):
+    from src.common.db.repository_pg import PgBlackListRepository
+
+    repo = PgBlackListRepository()
+    # 并发写同一 group_id
+    await asyncio.gather(*[repo.upsert_answers(1, [f"a{i}"]) for i in range(20)])
+    all_bl = await repo.find_all()
+    # 应只有 1 行，且不会因 unique 冲突炸库
+    group_rows = [x for x in all_bl if x.group_id == 1]
+    assert len(group_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_image_cache_save_is_upsert(pg_engine):
+    """Mongo save() 在记录不存在时等价于 insert，PG 必须对齐。"""
+    from src.common.db.modules import ImageCache
+    from src.common.db.repository_pg import PgImageCacheRepository
+
+    repo = PgImageCacheRepository()
+    ic = ImageCache.model_construct(cq_code="[CQ:image,file=x.image]", base64_data=None, ref_times=1, date=20250419)
+    # 记录不存在 → save 必须插入
+    await repo.save(ic)
+    assert await repo.find_by_cq_code("[CQ:image,file=x.image]") is not None
+
+    ic.ref_times = 5
+    ic.base64_data = "b64"
+    await repo.save(ic)
+    got = await repo.find_by_cq_code("[CQ:image,file=x.image]")
+    assert got is not None
+    assert got.ref_times == 5
+    assert got.base64_data == "b64"
+
+
+# ---------------------------------------------------------------------------
+# ConfigRepository TTL 缓存
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_cache_hit_and_invalidate_on_write(pg_engine):
+    from src.common.db.repository_pg import PgConfigRepository
+
+    repo = PgConfigRepository("bot_config", "account")
+    # 写入
+    await repo.upsert_field(1001, "security", True)
+    # 读（走 DB 后填充缓存）
+    row1 = await repo.get(1001)
+    assert row1 is not None and row1.security is True
+
+    # 再次写入 → 失效
+    await repo.upsert_field(1001, "security", False)
+    row2 = await repo.get(1001)
+    assert row2 is not None and row2.security is False
+
+
+@pytest.mark.asyncio
+async def test_config_cache_ignore_cache_forces_db_read(pg_engine):
+    """ignore_cache=True 必须绕过缓存直接回源。"""
+    from sqlalchemy import update
+
+    from src.common.db.repository_pg import BotConfigRow, PgConfigRepository, get_session
+
+    repo = PgConfigRepository("bot_config", "account")
+    await repo.upsert_field(2002, "security", True)
+    # 读一次让缓存生效
+    assert (await repo.get(2002)).security is True
+
+    # 绕过 repo 直接改 DB（不失效缓存）
+    async with get_session() as session:
+        await session.execute(update(BotConfigRow).where(BotConfigRow.account == 2002).values(security=False))
+        await session.commit()
+
+    # 走缓存：应仍是 True
+    cached = await repo.get(2002)
+    assert cached.security is True
+    # ignore_cache：应返回新值 False
+    fresh = await repo.get(2002, ignore_cache=True)
+    assert fresh.security is False
+
+
+@pytest.mark.asyncio
+async def test_config_invalidate_all(pg_engine):
+    from src.common.db.repository_pg import PgConfigRepository
+
+    repo = PgConfigRepository("bot_config", "account")
+    await repo.upsert_field(3003, "security", True)
+    assert (await repo.get(3003)).security is True
+    await repo.invalidate_cache()
+    # cleared: 下一次 get 走 DB（值还是 True，但不会 hit 缓存）
+    assert (await repo.get(3003)).security is True
+
+
+@pytest.mark.asyncio
+async def test_config_get_or_create_concurrent(pg_engine):
+    """并发 get_or_create 同一 key 必须只创建 1 行。"""
+    from src.common.db.repository_pg import PgConfigRepository
+
+    repo = PgConfigRepository("bot_config", "account")
+    key = int(uuid.uuid4().int & 0x7FFFFFFF)
+
+    results = await asyncio.gather(*[repo.get_or_create(key, disabled_plugins=[]) for _ in range(20)])
+    created_count = sum(1 for _, created in results if created)
+    # 至多 1 个 True
+    assert created_count <= 1
+    row = await repo.get(key, ignore_cache=True)
+    assert row is not None

--- a/tests/common/test_repository_pg.py
+++ b/tests/common/test_repository_pg.py
@@ -200,6 +200,29 @@ async def test_blacklist_upsert_is_atomic(pg_engine):
 
 
 @pytest.mark.asyncio
+async def test_blacklist_answers_and_reserve_do_not_clobber(pg_engine):
+    """同一 group_id 下 upsert_answers 与 upsert_answers_reserve 各管各的列，互不覆盖。"""
+    from src.common.db.repository_pg import PgBlackListRepository
+
+    repo = PgBlackListRepository()
+    # 先写 answers，再写 reserve；reserve 分支不应把 answers 清空
+    await repo.upsert_answers(77, ["a", "b"])
+    await repo.upsert_answers_reserve(77, ["ra", "rb"])
+    rows = [r for r in await repo.find_all() if r.group_id == 77]
+    assert len(rows) == 1
+    assert sorted(rows[0].answers) == ["a", "b"]
+    assert sorted(rows[0].answers_reserve) == ["ra", "rb"]
+
+    # 反向：已有 reserve 的行，再追加 answers 也不能覆盖 reserve
+    await repo.upsert_answers_reserve(88, ["only_reserve"])
+    await repo.upsert_answers(88, ["a2"])
+    rows = [r for r in await repo.find_all() if r.group_id == 88]
+    assert len(rows) == 1
+    assert rows[0].answers == ["a2"]
+    assert rows[0].answers_reserve == ["only_reserve"]
+
+
+@pytest.mark.asyncio
 async def test_image_cache_save_is_upsert(pg_engine):
     """PgImageCacheRepository.save 必须对齐 Mongo save() 的 upsert 语义（存在则更新、不存在则插入）。"""
     from src.common.db.modules import ImageCache
@@ -217,6 +240,31 @@ async def test_image_cache_save_is_upsert(pg_engine):
     assert got is not None
     assert got.ref_times == 5
     assert got.base64_data == "b64"
+
+
+@pytest.mark.asyncio
+async def test_image_cache_insert_is_no_op_on_duplicate(pg_engine):
+    """insert() 的契约是并发下同 cq_code 第二次写等价 no-op，原行不得被覆盖。"""
+    from src.common.db.modules import ImageCache
+    from src.common.db.repository_pg import PgImageCacheRepository
+
+    repo = PgImageCacheRepository()
+    first = ImageCache.model_construct(
+        cq_code="[CQ:image,file=dup.image]", base64_data="v1", ref_times=1, date=20250419
+    )
+    await repo.insert(first)
+
+    # 第二次 insert 应被 ON CONFLICT DO NOTHING 吃掉，原有值保持不变
+    second = ImageCache.model_construct(
+        cq_code="[CQ:image,file=dup.image]", base64_data="v2", ref_times=99, date=20260101
+    )
+    await repo.insert(second)
+
+    got = await repo.find_by_cq_code("[CQ:image,file=dup.image]")
+    assert got is not None
+    assert got.base64_data == "v1"
+    assert got.ref_times == 1
+    assert got.date == 20250419
 
 
 @pytest.mark.asyncio

--- a/tests/common/test_repository_pg.py
+++ b/tests/common/test_repository_pg.py
@@ -167,6 +167,27 @@ async def test_null_byte_stripping(pg_engine):
 
 
 @pytest.mark.asyncio
+async def test_upsert_answer_handles_long_keywords(pg_engine):
+    """answer.keywords 超出 btree 2704 字节上限时，UNIQUE 约束走 keywords_hash，不应触发 ProgramLimitExceededError。"""
+    from src.common.db.modules import Context
+    from src.common.db.repository_pg import PgContextRepository
+
+    repo = PgContextRepository()
+    await repo.insert(
+        Context.model_construct(keywords="longkw", time=0, trigger_count=1, answers=[], ban=[], clear_time=0)
+    )
+    long_ak = "x" * 5000  # 远超 btree 单行 2704 字节硬上限
+    await repo.upsert_answer("longkw", 1, long_ak, 100, "m1", append_on_existing=True)
+    await repo.upsert_answer("longkw", 1, long_ak, 200, "m2", append_on_existing=True)
+
+    found = await repo.find_by_keywords("longkw")
+    assert found is not None
+    assert len(found.answers) == 1
+    assert found.answers[0].keywords == long_ak
+    assert found.answers[0].count == 2
+
+
+@pytest.mark.asyncio
 async def test_blacklist_upsert_is_atomic(pg_engine):
     """并发 upsert_answers 到同一 group_id 不会炸库、最终只剩 1 行。"""
     from src.common.db.repository_pg import PgBlackListRepository

--- a/tests/common/test_repository_pg.py
+++ b/tests/common/test_repository_pg.py
@@ -1,62 +1,29 @@
 """
 PostgreSQL Repository 集成测试。
 
-需要本地 PG 实例：通过环境变量 `PG_TEST_DSN` 注入（SQLAlchemy asyncpg DSN 格式，
-例如 `postgresql+asyncpg://user:pw@/db?host=/run/postgresql`）。未设置则整个
-模块 skip，不阻塞 CI。
+依赖：本地 PG 实例（通过 ``PG_TEST_DSN`` 注入）。fixture 定义在 ``conftest.py``，
+未设置 DSN 时整套用例自动 skip。
 
-覆盖内容：
-- find_for_cleanup OR 语义（与 Mongo 对齐）
-- upsert_answer 并发原子性（复合唯一约束）
-- BlackList / ImageCache 的 upsert 原子性
-- \\x00 过滤
-- ConfigRepository TTL 缓存命中/失效/ignore_cache/写失效
-- delete_expired chunked 行为
+覆盖矩阵：
+- Context：``find_for_cleanup`` OR 语义 / ``upsert_answer`` 并发原子与 append 标志
+  / 缺上下文 no-op / ``delete_expired`` 分块
+- \\x00 过滤：Context + Message 全链路
+- BlackList / ImageCache：upsert 原子性 / save() 语义
+- ConfigRepository：TTL 缓存命中、写失效、ignore_cache 回源、全量失效、并发
+  get_or_create
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
 import uuid
 
 import pytest
 
-_DSN = os.getenv("PG_TEST_DSN")
-
-pytestmark = pytest.mark.skipif(not _DSN, reason="需要设置 PG_TEST_DSN 指向测试 PG 实例")
-
-
-@pytest.fixture
-async def pg_engine():
-    """每个测试一个独立 engine + schema，测试结束 drop 所有表。"""
-    from sqlalchemy.ext.asyncio import create_async_engine
-
-    from src.common.db.repository_pg import Base, dispose_pg, init_pg
-
-    assert _DSN is not None
-    engine = create_async_engine(_DSN)
-    # 清理上一次跑剩的 schema（按 FK 顺序 drop）
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-
-    await init_pg(engine)
-    try:
-        yield engine
-    finally:
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.drop_all)
-        await dispose_pg()
-
-
-# ---------------------------------------------------------------------------
-# Context 语义
-# ---------------------------------------------------------------------------
-
 
 @pytest.mark.asyncio
 async def test_find_for_cleanup_or_semantics(pg_engine):
-    """find_for_cleanup 必须是 trigger_count>threshold OR clear_time<expiration。"""
+    """trigger_count>threshold 与 clear_time<expiration 必须是 OR 关系（对齐 Mongo）。"""
     from src.common.db.modules import Context
     from src.common.db.repository_pg import PgContextRepository
 
@@ -80,8 +47,7 @@ async def test_find_for_cleanup_or_semantics(pg_engine):
 
 @pytest.mark.asyncio
 async def test_upsert_answer_is_atomic(pg_engine):
-    """并发 50 次 upsert_answer 同一 (keywords, group_id, answer_keywords)，
-    必须只产生 1 个 Answer 行且 count=50，trigger_count=50。"""
+    """并发 50 次 upsert_answer 只产生 1 条 Answer、count=50、trigger_count 精确累加。"""
     from src.common.db.modules import Context
     from src.common.db.repository_pg import PgContextRepository
 
@@ -102,13 +68,12 @@ async def test_upsert_answer_is_atomic(pg_engine):
     assert len(found.answers) == 1
     assert found.answers[0].count == 50
     assert len(found.answers[0].messages) == 50
-    # trigger_count 起始为 1（insert 时），每次 upsert_answer + 1
     assert found.trigger_count == 1 + 50
 
 
 @pytest.mark.asyncio
 async def test_upsert_answer_append_flag(pg_engine):
-    """append_on_existing=False 时，已有 Answer 不应新增 message。"""
+    """append_on_existing=False 时 count 仍 +1，但不把新 message 追加到已有 Answer。"""
     from src.common.db.modules import Context
     from src.common.db.repository_pg import PgContextRepository
 
@@ -129,11 +94,10 @@ async def test_upsert_answer_append_flag(pg_engine):
 
 @pytest.mark.asyncio
 async def test_upsert_answer_context_missing(pg_engine):
-    """Context 不存在时，upsert_answer 必须 no-op。"""
+    """Context 不存在时 upsert_answer 必须 no-op，不得凭空造 Context。"""
     from src.common.db.repository_pg import PgContextRepository
 
     repo = PgContextRepository()
-    # 不先 insert context
     await repo.upsert_answer("absent", 1, "a", 100, "m", append_on_existing=True)
     found = await repo.find_by_keywords("absent")
     assert found is None
@@ -141,7 +105,7 @@ async def test_upsert_answer_context_missing(pg_engine):
 
 @pytest.mark.asyncio
 async def test_delete_expired_chunked(pg_engine):
-    """插入 100 个过期 Context，delete_expired 应全部清掉。"""
+    """delete_expired 分块模式下应清掉所有过期行、保留未过期行。"""
     from src.common.db.modules import Context
     from src.common.db.repository_pg import PgContextRepository
 
@@ -150,7 +114,6 @@ async def test_delete_expired_chunked(pg_engine):
         await repo.insert(
             Context.model_construct(keywords=f"old{i}", time=10, trigger_count=1, answers=[], ban=[], clear_time=0)
         )
-    # 插入不应被删的
     await repo.insert(
         Context.model_construct(keywords="keep", time=9999, trigger_count=1, answers=[], ban=[], clear_time=0)
     )
@@ -163,7 +126,7 @@ async def test_delete_expired_chunked(pg_engine):
 
 @pytest.mark.asyncio
 async def test_null_byte_stripping(pg_engine):
-    """写入含 \\x00 的字段必须被剥除，不得让 PG 报错。"""
+    """Context / Answer / Ban / Message 全链路入库前都剥除 \\x00，PG 不得因此报错。"""
     from src.common.db.modules import Answer, Ban, Context, Message
     from src.common.db.repository_pg import PgContextRepository, PgMessageRepository
 
@@ -188,6 +151,7 @@ async def test_null_byte_stripping(pg_engine):
     assert "\x00" not in found.ban[0].keywords
     assert "\x00" not in found.ban[0].reason
 
+    # bulk_insert 也必须接受带 \x00 的字段，不抛 StringDataError
     await msg_repo.bulk_insert([
         Message.model_construct(
             group_id=1,
@@ -202,33 +166,26 @@ async def test_null_byte_stripping(pg_engine):
     ])
 
 
-# ---------------------------------------------------------------------------
-# BlackList / ImageCache
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_blacklist_upsert_is_atomic(pg_engine):
+    """并发 upsert_answers 到同一 group_id 不会炸库、最终只剩 1 行。"""
     from src.common.db.repository_pg import PgBlackListRepository
 
     repo = PgBlackListRepository()
-    # 并发写同一 group_id
     await asyncio.gather(*[repo.upsert_answers(1, [f"a{i}"]) for i in range(20)])
     all_bl = await repo.find_all()
-    # 应只有 1 行，且不会因 unique 冲突炸库
     group_rows = [x for x in all_bl if x.group_id == 1]
     assert len(group_rows) == 1
 
 
 @pytest.mark.asyncio
 async def test_image_cache_save_is_upsert(pg_engine):
-    """Mongo save() 在记录不存在时等价于 insert，PG 必须对齐。"""
+    """PgImageCacheRepository.save 必须对齐 Mongo save() 的 upsert 语义（存在则更新、不存在则插入）。"""
     from src.common.db.modules import ImageCache
     from src.common.db.repository_pg import PgImageCacheRepository
 
     repo = PgImageCacheRepository()
     ic = ImageCache.model_construct(cq_code="[CQ:image,file=x.image]", base64_data=None, ref_times=1, date=20250419)
-    # 记录不存在 → save 必须插入
     await repo.save(ic)
     assert await repo.find_by_cq_code("[CQ:image,file=x.image]") is not None
 
@@ -241,23 +198,16 @@ async def test_image_cache_save_is_upsert(pg_engine):
     assert got.base64_data == "b64"
 
 
-# ---------------------------------------------------------------------------
-# ConfigRepository TTL 缓存
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_config_cache_hit_and_invalidate_on_write(pg_engine):
+    """读后走 TTL 缓存；一旦 upsert_field 写入必须让缓存失效，下次读能拿到新值。"""
     from src.common.db.repository_pg import PgConfigRepository
 
     repo = PgConfigRepository("bot_config", "account")
-    # 写入
     await repo.upsert_field(1001, "security", True)
-    # 读（走 DB 后填充缓存）
     row1 = await repo.get(1001)
     assert row1 is not None and row1.security is True
 
-    # 再次写入 → 失效
     await repo.upsert_field(1001, "security", False)
     row2 = await repo.get(1001)
     assert row2 is not None and row2.security is False
@@ -265,44 +215,41 @@ async def test_config_cache_hit_and_invalidate_on_write(pg_engine):
 
 @pytest.mark.asyncio
 async def test_config_cache_ignore_cache_forces_db_read(pg_engine):
-    """ignore_cache=True 必须绕过缓存直接回源。"""
+    """ignore_cache=True 必须绕过缓存直接回源，不受外部 SQL 旁路改库影响。"""
     from sqlalchemy import update
 
     from src.common.db.repository_pg import BotConfigRow, PgConfigRepository, get_session
 
     repo = PgConfigRepository("bot_config", "account")
     await repo.upsert_field(2002, "security", True)
-    # 读一次让缓存生效
     assert (await repo.get(2002)).security is True
 
-    # 绕过 repo 直接改 DB（不失效缓存）
+    # 绕过 repo 直接 SQL 改库（不触发缓存失效）
     async with get_session() as session:
         await session.execute(update(BotConfigRow).where(BotConfigRow.account == 2002).values(security=False))
         await session.commit()
 
-    # 走缓存：应仍是 True
     cached = await repo.get(2002)
-    assert cached.security is True
-    # ignore_cache：应返回新值 False
+    assert cached.security is True  # 走缓存：旧值
     fresh = await repo.get(2002, ignore_cache=True)
-    assert fresh.security is False
+    assert fresh.security is False  # 回源：新值
 
 
 @pytest.mark.asyncio
 async def test_config_invalidate_all(pg_engine):
+    """invalidate_cache() 必须能全量清空该 row_class 的缓存条目。"""
     from src.common.db.repository_pg import PgConfigRepository
 
     repo = PgConfigRepository("bot_config", "account")
     await repo.upsert_field(3003, "security", True)
     assert (await repo.get(3003)).security is True
     await repo.invalidate_cache()
-    # cleared: 下一次 get 走 DB（值还是 True，但不会 hit 缓存）
-    assert (await repo.get(3003)).security is True
+    assert (await repo.get(3003)).security is True  # 数据未变，只是不再走缓存
 
 
 @pytest.mark.asyncio
 async def test_config_get_or_create_concurrent(pg_engine):
-    """并发 get_or_create 同一 key 必须只创建 1 行。"""
+    """并发 get_or_create 同一 key 必须只有一次 created=True，不得出现 IntegrityError 冒泡。"""
     from src.common.db.repository_pg import PgConfigRepository
 
     repo = PgConfigRepository("bot_config", "account")
@@ -310,7 +257,6 @@ async def test_config_get_or_create_concurrent(pg_engine):
 
     results = await asyncio.gather(*[repo.get_or_create(key, disabled_plugins=[]) for _ in range(20)])
     created_count = sum(1 for _, created in results if created)
-    # 至多 1 个 True
     assert created_count <= 1
     row = await repo.get(key, ignore_cache=True)
     assert row is not None

--- a/tools/migrate_mongo_to_pg.py
+++ b/tools/migrate_mongo_to_pg.py
@@ -4,31 +4,43 @@ MongoDB → PostgreSQL 迁移脚本
 
 迁移范围：Context、Message、BlackList、BotConfig、GroupConfig、UserConfig、ImageCache
 
+特性：
+- 基于 Mongo `_id` 游标流式读取，不走 skip/limit，千万级数据也不会退化成 O(n)
+- migration_state 表记录每张表的 last_id；中断后重跑自动断点续传，不会重复写入
+- 批级 commit 与 migration_state 在同一事务内原子写入，保证"恰好一次"
+- 逐条 defensive 解析，脏数据（缺字段 / 非法类型 / NUL 字符）跳过并计入汇总，不阻断
+- Context 聚合同 batch 内相同 keywords_hash 的 answers / bans，不再丢数据
+- upsert 依赖 `repository_pg` 里定义的唯一约束（含复合 upsert_answer 约束），新字段自动加到 PG
+
 用法：
     uv run --extra pg python tools/migrate_mongo_to_pg.py
 
 选项：
     --batch N       每批处理条数，默认 1000
     --dry-run       只统计数量，不写入 PostgreSQL
-    --pg-db NAME    目标 PostgreSQL 数据库名，默认读取 PG_DB 环境变量（fallback: PallasBot）
-    --tables TABLE  仅迁移指定表（可多选），可选值：
-                      context message blacklist botconfig groupconfig userconfig imagecache
+    --pg-db NAME    目标 PG 库名，覆盖 PG_DB 环境变量
+    --mongo-db NAME 源 Mongo 库名，覆盖 MONGO_DB 环境变量（默认 PallasBot）
+    --tables TABLE  仅迁移指定表，可选：context message blacklist botconfig groupconfig userconfig imagecache
+    --restart       清空 migration_state 重新从头迁移
 
 示例：
-    # 全量迁移
+    # 全量迁移（自动续传）
     uv run --extra pg python tools/migrate_mongo_to_pg.py
 
-    # 指定目标数据库名
-    uv run --extra pg python tools/migrate_mongo_to_pg.py --pg-db MyBot
+    # 指定目标库
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --pg-db MyBot --mongo-db PallasBot
 
-    # 仅迁移消息和上下文，每批 500 条
+    # 仅迁移 context 和 message，批量 500
     uv run --extra pg python tools/migrate_mongo_to_pg.py --tables context message --batch 500
 
-    # 预演（不写入数据库）
+    # 预演
     uv run --extra pg python tools/migrate_mongo_to_pg.py --dry-run
 
+    # 重新迁移（清空 state）
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --restart
+
 环境变量（从 .env 读取，也可手动设置）：
-    MONGO_HOST / MONGO_PORT / MONGO_USER / MONGO_PASSWORD
+    MONGO_HOST / MONGO_PORT / MONGO_USER / MONGO_PASSWORD / MONGO_DB
     PG_HOST / PG_PORT / PG_USER / PG_PASSWORD / PG_DB
 """
 
@@ -36,10 +48,14 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import json
+import hashlib
 import os
+import re
 import sys
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote_plus
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -62,31 +78,83 @@ ALL_TABLES = ["context", "message", "blacklist", "botconfig", "groupconfig", "us
 
 # asyncpg 单语句参数上限 32767
 _ANS_BATCH = 6000  # ContextAnswerRow    5 列
-_MSG_BATCH = 16000  # ContextAnswerMsg    2 列
+_MSG_BATCH = 16000  # ContextAnswerMessageRow 2 列
 _BAN_BATCH = 6000  # ContextBanRow       5 列
 _IC_BATCH = 6000  # ImageCacheRow       4 列
-_MSG_ROW_BATCH = 4000  # MessageRow       8 列
+_MSG_ROW_BATCH = 4000  # MessageRow          8 列
 
 
-def _mongo_dsn() -> str:
-    h, p = os.getenv("MONGO_HOST", "127.0.0.1"), int(os.getenv("MONGO_PORT", "27017"))
-    u, pw = os.getenv("MONGO_USER", ""), os.getenv("MONGO_PASSWORD", "")
-    return f"mongodb://{quote_plus(u)}:{quote_plus(pw)}@{h}:{p}" if u and pw else f"mongodb://{h}:{p}"
+# ---------------------------------------------------------------------------
+# 通用工具 / defensive helpers
+# ---------------------------------------------------------------------------
 
 
-def _pg_dsn() -> str:
-    h = os.getenv("PG_HOST", os.getenv("MONGO_HOST", "127.0.0.1"))
-    p = int(os.getenv("PG_PORT", "5432"))
-    u, pw = os.getenv("PG_USER", ""), os.getenv("PG_PASSWORD", "")
-    db = os.getenv("PG_DB", "PallasBot")
-    auth = f"{quote_plus(u)}:{quote_plus(pw)}@" if u and pw else ""
-    return f"postgresql+asyncpg://{auth}{h}:{p}/{db}"
+@dataclass
+class _TableStats:
+    """单表迁移摘要，脏数据跳过时计入 failed。"""
+
+    total: int = 0
+    migrated: int = 0
+    skipped: int = 0
+    failed: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def warn(self, msg: str) -> None:
+        self.failed += 1
+        if len(self.warnings) < 20:
+            self.warnings.append(msg)
 
 
-def _strip_null(obj):
-    """递归去除 PostgreSQL 不支持的 \\u0000 字符"""
+def _as_int(x: Any, default: int = 0) -> int:
+    if isinstance(x, bool):
+        return int(x)
+    if isinstance(x, int):
+        return x
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_str(x: Any, default: str = "") -> str:
+    if x is None:
+        return default
+    if isinstance(x, str):
+        return x
+    return str(x)
+
+
+def _as_bool(x: Any, default: bool = False) -> bool:
+    if isinstance(x, bool):
+        return x
+    if x is None:
+        return default
+    if isinstance(x, (int, float)):
+        return bool(x)
+    if isinstance(x, str):
+        return x.strip().lower() in ("true", "1", "yes", "y", "on")
+    return default
+
+
+def _as_list(x: Any) -> list:
+    if isinstance(x, list):
+        return x
+    if x is None:
+        return []
+    # tuple / set 也视为可迭代
+    if isinstance(x, (tuple, set)):
+        return list(x)
+    return []
+
+
+def _as_dict(x: Any) -> dict:
+    return x if isinstance(x, dict) else {}
+
+
+def _strip_null(obj: Any) -> Any:
+    """递归剥除 PostgreSQL TEXT 不接受的 \\x00 字节。"""
     if isinstance(obj, str):
-        return obj.replace("\x00", "")
+        return obj.replace("\x00", "") if "\x00" in obj else obj
     if isinstance(obj, dict):
         return {k: _strip_null(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -95,17 +163,34 @@ def _strip_null(obj):
 
 
 def _kw_hash(keywords: str) -> str:
-    import hashlib
+    # 与 repository_pg.keywords_hash 保持一致：先 strip \x00 再哈希
+    clean = keywords.replace("\x00", "") if keywords and "\x00" in keywords else keywords
+    return hashlib.md5((clean or "").encode("utf-8", errors="replace")).hexdigest()
 
-    return hashlib.md5(keywords.encode("utf-8", errors="replace")).hexdigest()
+
+def _mongo_dsn() -> str:
+    h, p = os.getenv("MONGO_HOST", "127.0.0.1"), int(os.getenv("MONGO_PORT", "27017"))
+    u, pw = os.getenv("MONGO_USER", ""), os.getenv("MONGO_PASSWORD", "")
+    return f"mongodb://{quote_plus(u)}:{quote_plus(pw)}@{h}:{p}" if u and pw else f"mongodb://{h}:{p}"
+
+
+def _mongo_db_name() -> str:
+    return os.getenv("MONGO_DB") or "PallasBot"
+
+
+def _pg_dsn() -> str:
+    h = os.getenv("PG_HOST") or os.getenv("MONGO_HOST", "127.0.0.1")
+    p = int(os.getenv("PG_PORT", "5432"))
+    u, pw = os.getenv("PG_USER", ""), os.getenv("PG_PASSWORD", "")
+    db = os.getenv("PG_DB", "PallasBot")
+    auth = f"{quote_plus(u)}:{quote_plus(pw)}@" if u and pw else ""
+    return f"postgresql+asyncpg://{auth}{h}:{p}/{db}"
 
 
 async def _ensure_db() -> None:
-    import re
-
     import asyncpg
 
-    h = os.getenv("PG_HOST", os.getenv("MONGO_HOST", "127.0.0.1"))
+    h = os.getenv("PG_HOST") or os.getenv("MONGO_HOST", "127.0.0.1")
     p = int(os.getenv("PG_PORT", "5432"))
     u, pw = os.getenv("PG_USER", "") or None, os.getenv("PG_PASSWORD", "") or None
     db = os.getenv("PG_DB", "PallasBot")
@@ -123,40 +208,222 @@ async def _ensure_db() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 各表迁移函数
+# migration_state：断点续传
 # ---------------------------------------------------------------------------
 
 
-async def _migrate_context(Context, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, batch_size, dry_run):
+async def _ensure_state_table(engine) -> None:
+    from sqlalchemy import text as T
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            T(
+                """
+                CREATE TABLE IF NOT EXISTS migration_state (
+                    table_name TEXT PRIMARY KEY,
+                    last_id TEXT NOT NULL,
+                    updated_at TIMESTAMPTZ DEFAULT NOW()
+                )
+                """
+            )
+        )
+
+
+async def _reset_state(engine) -> None:
+    from sqlalchemy import text as T
+
+    async with engine.begin() as conn:
+        await conn.execute(T("DELETE FROM migration_state"))
+    print("已清空 migration_state，将从头迁移")
+
+
+async def _get_state(session, table: str) -> str | None:
+    from sqlalchemy import text as T
+
+    result = await session.execute(
+        T("SELECT last_id FROM migration_state WHERE table_name = :t"), {"t": table}
+    )
+    return result.scalar_one_or_none()
+
+
+async def _set_state(session, table: str, last_id: str) -> None:
+    from sqlalchemy import text as T
+
+    await session.execute(
+        T(
+            """
+            INSERT INTO migration_state (table_name, last_id, updated_at)
+            VALUES (:t, :id, NOW())
+            ON CONFLICT (table_name) DO UPDATE
+                SET last_id = EXCLUDED.last_id, updated_at = NOW()
+            """
+        ),
+        {"t": table, "id": last_id},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mongo 游标流式工具
+# ---------------------------------------------------------------------------
+
+
+def _oid(s: str | None):
+    """字符串 _id 转为 ObjectId（如果可能）。非合法 ObjectId 当字符串用。"""
+    from bson import ObjectId
+
+    if s is None:
+        return None
+    try:
+        return ObjectId(s)
+    except Exception:
+        return s
+
+
+async def _stream_batches(col, last_id_str: str | None, batch_size: int):
+    """按 _id 递增游标分批 yield Mongo 文档，返回 (batch_docs, last_id_str)。"""
+    last_id = _oid(last_id_str)
+    while True:
+        q: dict[str, Any] = {}
+        if last_id is not None:
+            q["_id"] = {"$gt": last_id}
+        cursor = col.find(q).sort("_id", 1).limit(batch_size)
+        batch = await cursor.to_list(length=batch_size)
+        if not batch:
+            return
+        yield batch
+        last_id = batch[-1].get("_id")
+        if len(batch) < batch_size:
+            return
+
+
+# ---------------------------------------------------------------------------
+# Context 迁移（支持 batch 内 keywords 合并）
+# ---------------------------------------------------------------------------
+
+
+def _prepare_context_batch(docs: list[dict], stats: _TableStats) -> dict[str, dict]:
+    """batch 内按 keywords_hash 合并，返回 hash -> {ctx fields, answers, bans}"""
+    merged: dict[str, dict] = {}
+    for doc in docs:
+        try:
+            kw = _as_str(doc.get("keywords"))
+            if not kw:
+                stats.warn(f"context skipped: empty keywords, _id={doc.get('_id')}")
+                continue
+            h = _kw_hash(kw)
+            time_v = _as_int(doc.get("time"))
+            # 兼容 Beanie alias："count" 或 "trigger_count" 都可能写到文档里
+            trigger_v = _as_int(doc.get("trigger_count", doc.get("count", 1)), 1)
+            clear_v = _as_int(doc.get("clear_time"))
+
+            if h not in merged:
+                merged[h] = {
+                    "keywords": _strip_null(kw),
+                    "keywords_hash": h,
+                    "time": time_v,
+                    "trigger_count": trigger_v,
+                    "clear_time": clear_v,
+                    "answers": [],
+                    "bans": [],
+                }
+            else:
+                g = merged[h]
+                g["time"] = max(g["time"], time_v)
+                g["trigger_count"] = max(g["trigger_count"], trigger_v)
+                g["clear_time"] = max(g["clear_time"], clear_v)
+
+            for a in _as_list(doc.get("answers")):
+                if not isinstance(a, dict):
+                    continue
+                ak = _as_str(a.get("keywords"))
+                if not ak:
+                    continue
+                merged[h]["answers"].append({
+                    "keywords": _strip_null(ak),
+                    "group_id": _as_int(a.get("group_id")),
+                    "count": _as_int(a.get("count"), 1),
+                    "time": _as_int(a.get("time")),
+                    "messages": [_strip_null(_as_str(m)) for m in _as_list(a.get("messages")) if m is not None],
+                })
+            for b in _as_list(doc.get("ban")):
+                if not isinstance(b, dict):
+                    continue
+                bk = _as_str(b.get("keywords"))
+                if not bk:
+                    continue
+                merged[h]["bans"].append({
+                    "keywords": _strip_null(bk),
+                    "group_id": _as_int(b.get("group_id")),
+                    "reason": _strip_null(_as_str(b.get("reason"))),
+                    "time": _as_int(b.get("time")),
+                })
+        except Exception as e:
+            stats.warn(f"context parse failed _id={doc.get('_id')}: {e}")
+    return merged
+
+
+def _dedupe_by_key(rows: list[dict], key_fields: tuple[str, ...]) -> list[dict]:
+    """同批内按唯一键去重，后入者覆盖（Mongo 游标按 _id 升序，后者即新）。
+
+    PG 的 INSERT ... ON CONFLICT 不允许单次语句里出现两条命中同一冲突目标的行，
+    必须先在客户端侧合并。
+    """
+    seen: dict[tuple, dict] = {}
+    for r in rows:
+        k = tuple(r.get(f) for f in key_fields)
+        seen[k] = r
+    return list(seen.values())
+
+
+def _dedupe_answers(answers: list[dict]) -> list[dict]:
+    """去重 (group_id, keywords)：累加 count / 取 max time / 合并 messages。"""
+    m: dict[tuple, dict] = {}
+    for a in answers:
+        k = (a["group_id"], a["keywords"])
+        if k not in m:
+            m[k] = {**a, "messages": list(a["messages"])}
+        else:
+            m[k]["count"] += a["count"]
+            m[k]["time"] = max(m[k]["time"], a["time"])
+            m[k]["messages"].extend(a["messages"])
+    return list(m.values())
+
+
+async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, batch_size, dry_run) -> _TableStats:
     from sqlalchemy import delete as D
     from sqlalchemy import select as S
 
-    total = await Context.count()
-    print(f"\n📦 Context: {total} 条")
-    migrated = skip = 0
+    col = db["context"]
+    stats = _TableStats()
+    stats.total = await col.count_documents({})
+    print(f"\n[Context] total={stats.total}")
 
-    while True:
-        batch = await Context.find_all().skip(skip).limit(batch_size).to_list()
-        if not batch:
-            break
+    last_id_str: str | None = None
+    if not dry_run:
+        async with sf() as session:
+            last_id_str = await _get_state(session, "context")
+        if last_id_str:
+            print(f"  [Context] resume from _id > {last_id_str}")
 
-        seen: dict[str, tuple] = {}
-        for doc in batch:
-            h = _kw_hash(doc.keywords)
-            seen[h] = (
-                doc,
-                {
-                    "keywords": _strip_null(doc.keywords),
-                    "keywords_hash": h,
-                    "time": doc.time,
-                    "trigger_count": doc.trigger_count,
-                    "clear_time": doc.clear_time,
-                },
-            )
+    t0 = time.time()
+    async for batch in _stream_batches(col, last_id_str, batch_size):
+        merged = _prepare_context_batch(batch, stats)
+        if not merged:
+            if not dry_run:
+                async with sf() as session:
+                    await _set_state(session, "context", str(batch[-1]["_id"]))
+                    await session.commit()
+            stats.skipped += len(batch)
+            continue
 
         if not dry_run:
             async with sf() as session:
-                stmt = ins(ContextRow).values([v[1] for v in seen.values()])
+                # 1. upsert context rows
+                ctx_values = [
+                    {k: v for k, v in g.items() if k in ("keywords", "keywords_hash", "time", "trigger_count", "clear_time")}
+                    for g in merged.values()
+                ]
+                stmt = ins(ContextRow).values(ctx_values)
                 await session.execute(
                     stmt.on_conflict_do_update(
                         index_elements=["keywords_hash"],
@@ -168,294 +435,391 @@ async def _migrate_context(Context, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, i
                         },
                     )
                 )
-                await session.commit()
-
+                # 2. 拿回 context_id
                 result = await session.execute(
-                    S(ContextRow.id, ContextRow.keywords_hash).where(ContextRow.keywords_hash.in_(seen.keys()))
+                    S(ContextRow.id, ContextRow.keywords_hash).where(
+                        ContextRow.keywords_hash.in_(list(merged.keys()))
+                    )
                 )
-                h2id = {r.keywords_hash: r.id for r in result}
-                ctx_ids = list(h2id.values())
-                await session.execute(D(AnsRow).where(AnsRow.context_id.in_(ctx_ids)))
-                await session.execute(D(BanRow).where(BanRow.context_id.in_(ctx_ids)))
+                h2id: dict[str, int] = {r.keywords_hash: r.id for r in result}
+                ctx_ids = [cid for cid in h2id.values() if cid is not None]
 
-                ans_data, ban_rows = [], []
-                for h, (doc, _) in seen.items():
+                # 3. 重写 answers / bans：先删再插（针对本批涉及的 context_id）
+                if ctx_ids:
+                    await session.execute(D(AnsRow).where(AnsRow.context_id.in_(ctx_ids)))
+                    await session.execute(D(BanRow).where(BanRow.context_id.in_(ctx_ids)))
+
+                ans_rows: list[dict] = []
+                ans_msg_pending: list[tuple[int, tuple[int, int, str], list[str]]] = []
+                ban_rows: list[dict] = []
+
+                for h, g in merged.items():
                     cid = h2id.get(h)
                     if cid is None:
+                        stats.warn(f"context_id missing after upsert: hash={h}")
                         continue
-                    for a in doc.answers:
-                        ans_data.append({
+                    for a in _dedupe_answers(g["answers"]):
+                        ans_rows.append({
                             "context_id": cid,
-                            "keywords": _strip_null(a.keywords),
-                            "group_id": a.group_id,
-                            "count": a.count,
-                            "time": a.time,
-                            "_msgs": [_strip_null(m) for m in a.messages],
+                            "keywords": a["keywords"],
+                            "group_id": a["group_id"],
+                            "count": a["count"],
+                            "time": a["time"],
                         })
-                    for b in doc.ban:
+                        if a["messages"]:
+                            ans_msg_pending.append(
+                                (cid, (cid, a["group_id"], a["keywords"]), a["messages"])
+                            )
+                    for b in g["bans"]:
                         ban_rows.append({
                             "context_id": cid,
-                            "keywords": _strip_null(b.keywords),
-                            "group_id": b.group_id,
-                            "reason": _strip_null(b.reason),
-                            "time": b.time,
+                            "keywords": b["keywords"],
+                            "group_id": b["group_id"],
+                            "reason": b["reason"],
+                            "time": b["time"],
                         })
 
-                if ans_data:
-                    no_msg = [{k: v for k, v in d.items() if k != "_msgs"} for d in ans_data]
-                    lookup: dict[tuple, list[int]] = {}
-                    for i in range(0, len(no_msg), _ANS_BATCH):
-                        ret = await session.execute(
-                            ins(AnsRow)
-                            .values(no_msg[i : i + _ANS_BATCH])
-                            .returning(AnsRow.id, AnsRow.context_id, AnsRow.group_id, AnsRow.keywords)
-                        )
-                        for r in ret.fetchall():
-                            lookup.setdefault((r.context_id, r.group_id, r.keywords), []).append(r.id)
+                # 4. 批量插 answer 并拿回 id（走 RETURNING）
+                key2aid: dict[tuple[int, int, str], int] = {}
+                for i in range(0, len(ans_rows), _ANS_BATCH):
+                    ret = await session.execute(
+                        ins(AnsRow)
+                        .values(ans_rows[i : i + _ANS_BATCH])
+                        .returning(AnsRow.id, AnsRow.context_id, AnsRow.group_id, AnsRow.keywords)
+                    )
+                    for r in ret.fetchall():
+                        key2aid[(r.context_id, r.group_id, r.keywords)] = int(r.id)
 
-                    msg_rows = []
-                    for d in ans_data:
-                        ids = lookup.get((d["context_id"], d["group_id"], d["keywords"]), [])
-                        if ids:
-                            aid = ids.pop(0)
-                            msg_rows.extend({"answer_id": aid, "message": m} for m in d["_msgs"])
-                    for i in range(0, len(msg_rows), _MSG_BATCH):
-                        await session.execute(ins(AnsMsgRow).values(msg_rows[i : i + _MSG_BATCH]))
+                # 5. 关联 messages
+                msg_rows: list[dict] = []
+                for _cid, key, messages in ans_msg_pending:
+                    aid = key2aid.get(key)
+                    if aid is None:
+                        continue
+                    msg_rows.extend({"answer_id": aid, "message": m} for m in messages)
+                for i in range(0, len(msg_rows), _MSG_BATCH):
+                    await session.execute(ins(AnsMsgRow).values(msg_rows[i : i + _MSG_BATCH]))
 
+                # 6. 插 bans
                 for i in range(0, len(ban_rows), _BAN_BATCH):
                     await session.execute(ins(BanRow).values(ban_rows[i : i + _BAN_BATCH]))
+
+                # 7. 更新 migration_state 并一并 commit
+                await _set_state(session, "context", str(batch[-1]["_id"]))
                 await session.commit()
 
-        migrated += len(batch)
-        skip += batch_size
-        print(f"  Context {migrated}/{total}", end="\r")
-    print(f"  Context {migrated}/{total} ✓")
+        stats.migrated += len(batch)
+        elapsed = time.time() - t0
+        rate = stats.migrated / elapsed if elapsed else 0
+        eta = (stats.total - stats.migrated) / rate if rate > 0 else 0
+        print(f"  [Context] {stats.migrated}/{stats.total} ({rate:.0f}/s, ETA {eta:.0f}s)", end="\r")
+
+    print(f"  [Context] {stats.migrated}/{stats.total} done (failed={stats.failed}, skipped={stats.skipped})")
+    return stats
 
 
-async def _migrate_message(Message, sf, MsgRow, ins, batch_size, dry_run):
-    col = Message.get_pymongo_collection()
-    total = await col.count_documents({})
-    print(f"\n📦 Message: {total} 条")
-    migrated, batch = 0, []
-
-    async for doc in col.find({}, batch_size=batch_size):
-        raw = doc.get("raw_message", "")
-        batch.append(
-            _strip_null({
-                "group_id": int(doc.get("group_id", 0)),
-                "user_id": int(doc.get("user_id", 0)),
-                "bot_id": int(doc.get("bot_id", 0)),
-                "raw_message": raw,
-                "is_plain_text": doc.get("is_plain_text", True),
-                "plain_text": doc.get("plain_text", raw),
-                "keywords": doc.get("keywords", ""),
-                "time": doc.get("time", 0),
-            })
-        )
-        if len(batch) >= _MSG_ROW_BATCH:
-            if not dry_run:
-                async with sf() as session:
-                    await session.execute(ins(MsgRow).values(batch).on_conflict_do_nothing())
-                    await session.commit()
-            migrated += len(batch)
-            batch = []
-            print(f"  Message {migrated}/{total}", end="\r")
-
-    if batch:
-        if not dry_run:
-            async with sf() as session:
-                await session.execute(ins(MsgRow).values(batch).on_conflict_do_nothing())
-                await session.commit()
-        migrated += len(batch)
-    print(f"  Message {migrated}/{total} ✓")
+# ---------------------------------------------------------------------------
+# Message 迁移
+# ---------------------------------------------------------------------------
 
 
-async def _migrate_blacklist(BlackList, sf, BLRow, ins, dry_run):
-    total = await BlackList.count()
-    print(f"\n📦 BlackList: {total} 条")
-    docs = await BlackList.find_all().to_list()
-    if not docs:
-        print("  BlackList 0/0 ✓")
-        return
-    rows = [
-        _strip_null({"group_id": int(d.group_id), "answers": d.answers, "answers_reserve": d.answers_reserve})
-        for d in docs
-    ]
+async def _migrate_message(db, sf, MsgRow, ins, batch_size, dry_run) -> _TableStats:
+    col = db["message"]
+    stats = _TableStats()
+    stats.total = await col.count_documents({})
+    print(f"\n[Message] total={stats.total}")
+
+    last_id_str: str | None = None
     if not dry_run:
         async with sf() as session:
-            stmt = ins(BLRow).values(rows)
-            await session.execute(
-                stmt.on_conflict_do_update(
-                    index_elements=["group_id"],
-                    set_={"answers": stmt.excluded.answers, "answers_reserve": stmt.excluded.answers_reserve},
+            last_id_str = await _get_state(session, "message")
+        if last_id_str:
+            print(f"  [Message] resume from _id > {last_id_str}")
+
+    t0 = time.time()
+    async for batch in _stream_batches(col, last_id_str, max(batch_size, _MSG_ROW_BATCH)):
+        rows: list[dict] = []
+        for doc in batch:
+            try:
+                raw = _as_str(doc.get("raw_message"))
+                rows.append({
+                    "group_id": _as_int(doc.get("group_id")),
+                    "user_id": _as_int(doc.get("user_id")),
+                    "bot_id": _as_int(doc.get("bot_id")),
+                    "raw_message": _strip_null(raw),
+                    "is_plain_text": _as_bool(doc.get("is_plain_text"), True),
+                    "plain_text": _strip_null(_as_str(doc.get("plain_text"), raw)),
+                    "keywords": _strip_null(_as_str(doc.get("keywords"))),
+                    "time": _as_int(doc.get("time")),
+                })
+            except Exception as e:
+                stats.warn(f"message parse failed _id={doc.get('_id')}: {e}")
+
+        if rows and not dry_run:
+            async with sf() as session:
+                # 分批插入避免超出 asyncpg 参数上限
+                for i in range(0, len(rows), _MSG_ROW_BATCH):
+                    await session.execute(ins(MsgRow), rows[i : i + _MSG_ROW_BATCH])
+                await _set_state(session, "message", str(batch[-1]["_id"]))
+                await session.commit()
+
+        stats.migrated += len(batch)
+        elapsed = time.time() - t0
+        rate = stats.migrated / elapsed if elapsed else 0
+        eta = (stats.total - stats.migrated) / rate if rate > 0 else 0
+        print(f"  [Message] {stats.migrated}/{stats.total} ({rate:.0f}/s, ETA {eta:.0f}s)", end="\r")
+
+    print(f"  [Message] {stats.migrated}/{stats.total} done (failed={stats.failed})")
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# BlackList / Config 系列（上游数据量小，单批搞定即可，仍走流式以防万一）
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_blacklist(db, sf, BLRow, ins, batch_size, dry_run) -> _TableStats:
+    col = db["blacklist"]
+    stats = _TableStats()
+    stats.total = await col.count_documents({})
+    print(f"\n[BlackList] total={stats.total}")
+
+    last_id_str: str | None = None
+    if not dry_run:
+        async with sf() as session:
+            last_id_str = await _get_state(session, "blacklist")
+
+    async for batch in _stream_batches(col, last_id_str, batch_size):
+        rows: list[dict] = []
+        for doc in batch:
+            try:
+                rows.append({
+                    "group_id": _as_int(doc.get("group_id")),
+                    "answers": [_strip_null(_as_str(x)) for x in _as_list(doc.get("answers"))],
+                    "answers_reserve": [_strip_null(_as_str(x)) for x in _as_list(doc.get("answers_reserve"))],
+                })
+            except Exception as e:
+                stats.warn(f"blacklist parse failed _id={doc.get('_id')}: {e}")
+
+        if rows and not dry_run:
+            rows = _dedupe_by_key(rows, ("group_id",))
+            async with sf() as session:
+                stmt = ins(BLRow).values(rows)
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["group_id"],
+                        set_={"answers": stmt.excluded.answers, "answers_reserve": stmt.excluded.answers_reserve},
+                    )
                 )
-            )
-            await session.commit()
-    print(f"  BlackList {len(docs)}/{total} ✓")
+                await _set_state(session, "blacklist", str(batch[-1]["_id"]))
+                await session.commit()
+
+        stats.migrated += len(batch)
+
+    print(f"  [BlackList] {stats.migrated}/{stats.total} done (failed={stats.failed})")
+    return stats
 
 
-async def _migrate_bot_config(BotConfigModule, sf, BCRow, ins, dry_run):
-    col = BotConfigModule.get_pymongo_collection()
-    total = await col.count_documents({})
-    print(f"\n📦 BotConfig: {total} 条")
-    raw_docs = await col.find({}).to_list(length=None)
-    if not raw_docs:
-        print("  BotConfig 0/0 ✓")
-        return
+async def _migrate_bot_config(db, sf, BCRow, ins, batch_size, dry_run) -> _TableStats:
+    col = db["config"]  # Mongo collection 名是 "config"
+    stats = _TableStats()
+    stats.total = await col.count_documents({})
+    print(f"\n[BotConfig] total={stats.total}")
 
-    rows = []
-    for raw in raw_docs:
-        try:
-            if "auto_accept" in raw and "auto_accept_group" not in raw:
-                ag, af = bool(raw["auto_accept"]), False
-            else:
-                ag = bool(raw.get("auto_accept_group", False))
-                af = bool(raw.get("auto_accept_friend", False))
-            admins = []
-            for x in raw.get("admins", []):
-                try:
-                    admins.append(int(x))
-                except (TypeError, ValueError):
-                    print(f"  ⚠️  BotConfig account={raw.get('account')} admins 跳过无效值: {x!r}")
-            tn = raw.get("taken_name", {})
-            dk = raw.get("drunk", {})
-            rows.append(
-                _strip_null({
-                    "account": int(raw["account"]),
+    last_id_str: str | None = None
+    if not dry_run:
+        async with sf() as session:
+            last_id_str = await _get_state(session, "botconfig")
+
+    async for batch in _stream_batches(col, last_id_str, batch_size):
+        rows: list[dict] = []
+        for raw in batch:
+            try:
+                # 兼容旧字段：auto_accept 仅对 group 生效
+                if "auto_accept" in raw and "auto_accept_group" not in raw:
+                    ag, af = _as_bool(raw.get("auto_accept")), False
+                else:
+                    ag = _as_bool(raw.get("auto_accept_group"))
+                    af = _as_bool(raw.get("auto_accept_friend"))
+                admins = []
+                for x in _as_list(raw.get("admins")):
+                    try:
+                        admins.append(int(x))
+                    except (TypeError, ValueError):
+                        stats.warn(f"botconfig account={raw.get('account')} admins 非法值: {x!r}")
+                tn = _as_dict(raw.get("taken_name"))
+                dk = _as_dict(raw.get("drunk"))
+                rows.append({
+                    "account": _as_int(raw.get("account")),
                     "admins": admins,
                     "auto_accept_friend": af,
                     "auto_accept_group": ag,
-                    "security": bool(raw.get("security", False)),
-                    "taken_name": {str(k): v for k, v in (tn.items() if isinstance(tn, dict) else {})},
-                    "drunk": {str(k): v for k, v in (dk.items() if isinstance(dk, dict) else {})},
-                    "disabled_plugins": raw.get("disabled_plugins", []),
+                    "security": _as_bool(raw.get("security")),
+                    "taken_name": {str(k): v for k, v in tn.items()},
+                    "drunk": {str(k): v for k, v in dk.items()},
+                    "disabled_plugins": [_strip_null(_as_str(x)) for x in _as_list(raw.get("disabled_plugins"))],
                 })
-            )
-        except Exception as e:
-            print(f"  ⚠️  BotConfig 跳过 account={raw.get('account')}: {e}")
+            except Exception as e:
+                stats.warn(f"botconfig parse failed _id={raw.get('_id')}: {e}")
 
+        if rows and not dry_run:
+            rows = _dedupe_by_key(rows, ("account",))
+            async with sf() as session:
+                stmt = ins(BCRow).values(rows)
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["account"],
+                        set_={
+                            f: getattr(stmt.excluded, f)
+                            for f in (
+                                "admins",
+                                "auto_accept_friend",
+                                "auto_accept_group",
+                                "security",
+                                "taken_name",
+                                "drunk",
+                                "disabled_plugins",
+                            )
+                        },
+                    )
+                )
+                await _set_state(session, "botconfig", str(batch[-1]["_id"]))
+                await session.commit()
+        stats.migrated += len(batch)
+
+    print(f"  [BotConfig] {stats.migrated}/{stats.total} done (failed={stats.failed})")
+    return stats
+
+
+async def _migrate_group_config(db, sf, GCRow, ins, batch_size, dry_run) -> _TableStats:
+    col = db["group_config"]
+    stats = _TableStats()
+    stats.total = await col.count_documents({})
+    print(f"\n[GroupConfig] total={stats.total}")
+
+    last_id_str: str | None = None
     if not dry_run:
         async with sf() as session:
-            stmt = ins(BCRow).values(rows)
-            await session.execute(
-                stmt.on_conflict_do_update(
-                    index_elements=["account"],
-                    set_={
-                        f: getattr(stmt.excluded, f)
-                        for f in [
-                            "admins",
-                            "auto_accept_friend",
-                            "auto_accept_group",
-                            "security",
-                            "taken_name",
-                            "drunk",
-                            "disabled_plugins",
-                        ]
-                    },
+            last_id_str = await _get_state(session, "groupconfig")
+
+    async for batch in _stream_batches(col, last_id_str, batch_size):
+        rows: list[dict] = []
+        for raw in batch:
+            try:
+                sing = raw.get("sing_progress")
+                rows.append({
+                    "group_id": _as_int(raw.get("group_id")),
+                    "roulette_mode": _as_int(raw.get("roulette_mode"), 1),
+                    "banned": _as_bool(raw.get("banned")),
+                    "sing_progress": _strip_null(sing) if isinstance(sing, dict) else None,
+                    "disabled_plugins": [_strip_null(_as_str(x)) for x in _as_list(raw.get("disabled_plugins"))],
+                })
+            except Exception as e:
+                stats.warn(f"groupconfig parse failed _id={raw.get('_id')}: {e}")
+
+        if rows and not dry_run:
+            rows = _dedupe_by_key(rows, ("group_id",))
+            async with sf() as session:
+                stmt = ins(GCRow).values(rows)
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["group_id"],
+                        set_={
+                            f: getattr(stmt.excluded, f)
+                            for f in ("roulette_mode", "banned", "sing_progress", "disabled_plugins")
+                        },
+                    )
                 )
-            )
-            await session.commit()
-    print(f"  BotConfig {len(rows)}/{total} ✓")
+                await _set_state(session, "groupconfig", str(batch[-1]["_id"]))
+                await session.commit()
+        stats.migrated += len(batch)
+
+    print(f"  [GroupConfig] {stats.migrated}/{stats.total} done (failed={stats.failed})")
+    return stats
 
 
-async def _migrate_group_config(GroupConfigModule, sf, GCRow, ins, dry_run):
-    total = await GroupConfigModule.count()
-    print(f"\n📦 GroupConfig: {total} 条")
-    docs = await GroupConfigModule.find_all().to_list()
-    if not docs:
-        print("  GroupConfig 0/0 ✓")
-        return
-    rows = [
-        _strip_null({
-            "group_id": int(d.group_id),
-            "roulette_mode": d.roulette_mode,
-            "banned": d.banned,
-            "sing_progress": json.loads(d.sing_progress.model_dump_json()) if d.sing_progress else None,
-            "disabled_plugins": d.disabled_plugins,
-        })
-        for d in docs
-    ]
+async def _migrate_user_config(db, sf, UCRow, ins, batch_size, dry_run) -> _TableStats:
+    col = db["user_config"]
+    stats = _TableStats()
+    stats.total = await col.count_documents({})
+    print(f"\n[UserConfig] total={stats.total}")
+
+    last_id_str: str | None = None
     if not dry_run:
         async with sf() as session:
-            stmt = ins(GCRow).values(rows)
-            await session.execute(
-                stmt.on_conflict_do_update(
-                    index_elements=["group_id"],
-                    set_={
-                        f: getattr(stmt.excluded, f)
-                        for f in ["roulette_mode", "banned", "sing_progress", "disabled_plugins"]
-                    },
-                )
-            )
-            await session.commit()
-    print(f"  GroupConfig {len(docs)}/{total} ✓")
+            last_id_str = await _get_state(session, "userconfig")
 
+    async for batch in _stream_batches(col, last_id_str, batch_size):
+        rows: list[dict] = []
+        for raw in batch:
+            try:
+                rows.append({
+                    "user_id": _as_int(raw.get("user_id")),
+                    "banned": _as_bool(raw.get("banned")),
+                })
+            except Exception as e:
+                stats.warn(f"userconfig parse failed _id={raw.get('_id')}: {e}")
 
-async def _migrate_user_config(UserConfigModule, sf, UCRow, ins, batch_size, dry_run):
-    total = await UserConfigModule.count()
-    print(f"\n📦 UserConfig: {total} 条")
-    migrated = skip = 0
-    while True:
-        batch = await UserConfigModule.find_all().skip(skip).limit(batch_size).to_list()
-        if not batch:
-            break
-        rows = [_strip_null({"user_id": int(d.user_id), "banned": d.banned}) for d in batch]
-        if not dry_run:
+        if rows and not dry_run:
+            rows = _dedupe_by_key(rows, ("user_id",))
             async with sf() as session:
                 stmt = ins(UCRow).values(rows)
                 await session.execute(
                     stmt.on_conflict_do_update(index_elements=["user_id"], set_={"banned": stmt.excluded.banned})
                 )
+                await _set_state(session, "userconfig", str(batch[-1]["_id"]))
                 await session.commit()
-        migrated += len(batch)
-        skip += batch_size
-        print(f"  UserConfig {migrated}/{total}", end="\r")
-    print(f"  UserConfig {migrated}/{total} ✓")
+        stats.migrated += len(batch)
+
+    print(f"  [UserConfig] {stats.migrated}/{stats.total} done (failed={stats.failed})")
+    return stats
 
 
-async def _migrate_image_cache(ImageCache, sf, ICRow, ins, batch_size, dry_run):
-    col = ImageCache.get_pymongo_collection()
-    total = await col.count_documents({})
-    print(f"\n📦 ImageCache: {total} 条")
-    migrated, batch = 0, []
+async def _migrate_image_cache(db, sf, ICRow, ins, batch_size, dry_run) -> _TableStats:
+    col = db["image_cache"]
+    stats = _TableStats()
+    stats.total = await col.count_documents({})
+    print(f"\n[ImageCache] total={stats.total}")
 
-    async for doc in col.find({}, batch_size=batch_size):
-        batch.append(
-            _strip_null({
-                "cq_code": doc.get("cq_code", ""),
-                "base64_data": doc.get("base64_data"),
-                "ref_times": int(doc.get("ref_times", 1)),
-                "date": int(doc.get("date", 0)),
-            })
-        )
-        if len(batch) >= _IC_BATCH:
-            if not dry_run:
-                async with sf() as session:
-                    stmt = ins(ICRow).values(batch)
+    last_id_str: str | None = None
+    if not dry_run:
+        async with sf() as session:
+            last_id_str = await _get_state(session, "imagecache")
+
+    async for batch in _stream_batches(col, last_id_str, max(batch_size, _IC_BATCH)):
+        rows: list[dict] = []
+        for doc in batch:
+            try:
+                cq = _as_str(doc.get("cq_code"))
+                if not cq:
+                    stats.warn(f"imagecache empty cq_code _id={doc.get('_id')}")
+                    continue
+                rows.append({
+                    "cq_code": _strip_null(cq),
+                    "base64_data": _strip_null(doc.get("base64_data")) if doc.get("base64_data") else None,
+                    "ref_times": _as_int(doc.get("ref_times"), 1),
+                    "date": _as_int(doc.get("date")),
+                })
+            except Exception as e:
+                stats.warn(f"imagecache parse failed _id={doc.get('_id')}: {e}")
+
+        if rows and not dry_run:
+            rows = _dedupe_by_key(rows, ("cq_code",))
+            async with sf() as session:
+                for i in range(0, len(rows), _IC_BATCH):
+                    stmt = ins(ICRow).values(rows[i : i + _IC_BATCH])
                     await session.execute(
                         stmt.on_conflict_do_update(
                             index_elements=["cq_code"],
-                            set_={f: getattr(stmt.excluded, f) for f in ["base64_data", "ref_times", "date"]},
+                            set_={f: getattr(stmt.excluded, f) for f in ("base64_data", "ref_times", "date")},
                         )
                     )
-                    await session.commit()
-            migrated += len(batch)
-            batch = []
-            print(f"  ImageCache {migrated}/{total}", end="\r")
-
-    if batch:
-        if not dry_run:
-            async with sf() as session:
-                stmt = ins(ICRow).values(batch)
-                await session.execute(
-                    stmt.on_conflict_do_update(
-                        index_elements=["cq_code"],
-                        set_={f: getattr(stmt.excluded, f) for f in ["base64_data", "ref_times", "date"]},
-                    )
-                )
+                await _set_state(session, "imagecache", str(batch[-1]["_id"]))
                 await session.commit()
-        migrated += len(batch)
-    print(f"  ImageCache {migrated}/{total} ✓")
+        stats.migrated += len(batch)
+
+    print(f"  [ImageCache] {stats.migrated}/{stats.total} done (failed={stats.failed})")
+    return stats
 
 
 # ---------------------------------------------------------------------------
@@ -463,30 +827,29 @@ async def _migrate_image_cache(ImageCache, sf, ICRow, ins, batch_size, dry_run):
 # ---------------------------------------------------------------------------
 
 
-async def migrate(batch_size: int, dry_run: bool, tables: set[str], pg_db: str | None = None) -> None:
+async def migrate(
+    batch_size: int,
+    dry_run: bool,
+    tables: set[str],
+    pg_db: str | None,
+    mongo_db: str | None,
+    restart: bool,
+) -> None:
     if pg_db:
         os.environ["PG_DB"] = pg_db
+    if mongo_db:
+        os.environ["MONGO_DB"] = mongo_db
+
     try:
         from sqlalchemy.ext.asyncio import create_async_engine
     except ImportError:
         print("❌ 缺少 SQLAlchemy/asyncpg，请执行：uv sync --extra pg")
         sys.exit(1)
 
-    from beanie import init_beanie
     from pymongo import AsyncMongoClient
-    from sqlalchemy import text as T
     from sqlalchemy.dialects.postgresql import insert as pg_insert
     from sqlalchemy.ext.asyncio import async_sessionmaker
 
-    from src.common.db.modules import (
-        BlackList,
-        BotConfigModule,
-        Context,
-        GroupConfigModule,
-        ImageCache,
-        Message,
-        UserConfigModule,
-    )
     from src.common.db.repository_pg import (
         BlackListRow,
         BotConfigRow,
@@ -501,60 +864,60 @@ async def migrate(batch_size: int, dry_run: bool, tables: set[str], pg_db: str |
         init_pg,
     )
 
-    print(f"🔗 连接 MongoDB: {_mongo_dsn()}")
+    print(f"[Mongo] {_mongo_dsn()} db={_mongo_db_name()}")
     mongo_client = AsyncMongoClient(_mongo_dsn(), unicode_decode_error_handler="ignore")
-    await init_beanie(
-        database=mongo_client["PallasBot"],
-        document_models=[Context, Message, BlackList, BotConfigModule, GroupConfigModule, UserConfigModule, ImageCache],
-    )
+    db = mongo_client[_mongo_db_name()]
 
-    print(f"🔗 连接 PostgreSQL: {_pg_dsn()}")
+    print(f"[PG] {_pg_dsn()}")
     if not dry_run:
         await _ensure_db()
 
     engine = create_async_engine(_pg_dsn(), echo=False)
     if not dry_run:
         await init_pg(engine)
-        async with engine.begin() as conn:
-            # 删除旧的 keywords 唯一约束（超长值会超出 btree 2704 字节限制）
-            await conn.execute(T("ALTER TABLE context DROP CONSTRAINT IF EXISTS context_keywords_key"))
-            await conn.execute(T("DROP INDEX IF EXISTS ix_context_keywords"))
-            await conn.execute(T("ALTER TABLE context ADD COLUMN IF NOT EXISTS keywords_hash TEXT"))
-            await conn.execute(T("UPDATE context SET keywords_hash = md5(keywords) WHERE keywords_hash IS NULL"))
-            await conn.execute(T("ALTER TABLE context ALTER COLUMN keywords_hash SET NOT NULL"))
-            await conn.execute(
-                T("CREATE UNIQUE INDEX IF NOT EXISTS ix_context_keywords_hash ON context (keywords_hash)")
-            )
+        await _ensure_state_table(engine)
+        if restart:
+            await _reset_state(engine)
 
     sf = async_sessionmaker(engine, expire_on_commit=False)
 
+    summaries: list[tuple[str, _TableStats]] = []
+
     if "context" in tables:
-        await _migrate_context(
-            Context,
-            sf,
-            ContextRow,
-            ContextAnswerRow,
-            ContextAnswerMessageRow,
-            ContextBanRow,
-            pg_insert,
-            batch_size,
-            dry_run,
+        s = await _migrate_context(
+            db, sf, ContextRow, ContextAnswerRow, ContextAnswerMessageRow, ContextBanRow, pg_insert, batch_size, dry_run
         )
+        summaries.append(("context", s))
     if "message" in tables:
-        await _migrate_message(Message, sf, MessageRow, pg_insert, batch_size, dry_run)
+        s = await _migrate_message(db, sf, MessageRow, pg_insert, batch_size, dry_run)
+        summaries.append(("message", s))
     if "blacklist" in tables:
-        await _migrate_blacklist(BlackList, sf, BlackListRow, pg_insert, dry_run)
+        s = await _migrate_blacklist(db, sf, BlackListRow, pg_insert, batch_size, dry_run)
+        summaries.append(("blacklist", s))
     if "botconfig" in tables:
-        await _migrate_bot_config(BotConfigModule, sf, BotConfigRow, pg_insert, dry_run)
+        s = await _migrate_bot_config(db, sf, BotConfigRow, pg_insert, batch_size, dry_run)
+        summaries.append(("botconfig", s))
     if "groupconfig" in tables:
-        await _migrate_group_config(GroupConfigModule, sf, GroupConfigRow, pg_insert, dry_run)
+        s = await _migrate_group_config(db, sf, GroupConfigRow, pg_insert, batch_size, dry_run)
+        summaries.append(("groupconfig", s))
     if "userconfig" in tables:
-        await _migrate_user_config(UserConfigModule, sf, UserConfigRow, pg_insert, batch_size, dry_run)
+        s = await _migrate_user_config(db, sf, UserConfigRow, pg_insert, batch_size, dry_run)
+        summaries.append(("userconfig", s))
     if "imagecache" in tables:
-        await _migrate_image_cache(ImageCache, sf, ImageCacheRow, pg_insert, batch_size, dry_run)
+        s = await _migrate_image_cache(db, sf, ImageCacheRow, pg_insert, batch_size, dry_run)
+        summaries.append(("imagecache", s))
 
     await engine.dispose()
-    print("\n✅ 迁移完成")
+
+    # 汇总
+    print("\n========== 迁移摘要 ==========")
+    total_failed = 0
+    for name, s in summaries:
+        print(f"  {name:<12} total={s.total:<10} migrated={s.migrated:<10} failed={s.failed:<6}")
+        total_failed += s.failed
+        for w in s.warnings[:5]:
+            print(f"      · {w}")
+    print(f"========== 完成（total_failed={total_failed}） ==========")
 
 
 if __name__ == "__main__":
@@ -565,16 +928,18 @@ if __name__ == "__main__":
     )
     parser.add_argument("--batch", type=int, default=1000, metavar="N", help="每批处理条数（默认 1000）")
     parser.add_argument("--dry-run", action="store_true", help="只统计数量，不写入 PostgreSQL")
-    parser.add_argument("--pg-db", metavar="NAME", help="目标 PostgreSQL 数据库名（覆盖 PG_DB 环境变量）")
+    parser.add_argument("--pg-db", metavar="NAME", help="目标 PG 库名，覆盖 PG_DB")
+    parser.add_argument("--mongo-db", metavar="NAME", help="源 Mongo 库名，覆盖 MONGO_DB")
     parser.add_argument(
         "--tables", nargs="+", choices=ALL_TABLES, metavar="TABLE", help="仅迁移指定表（空格分隔），不指定则迁移全部"
     )
+    parser.add_argument("--restart", action="store_true", help="清空 migration_state 从头迁移")
     args = parser.parse_args()
 
     selected = set(args.tables) if args.tables else set(ALL_TABLES)
     if args.dry_run:
         print("⚠️  dry-run 模式，不会写入 PostgreSQL")
     if args.tables:
-        print(f"📋 仅迁移：{', '.join(t for t in ALL_TABLES if t in selected)}")
+        print(f"仅迁移：{', '.join(t for t in ALL_TABLES if t in selected)}")
 
-    asyncio.run(migrate(args.batch, args.dry_run, selected, args.pg_db))
+    asyncio.run(migrate(args.batch, args.dry_run, selected, args.pg_db, args.mongo_db, args.restart))

--- a/tools/migrate_mongo_to_pg.py
+++ b/tools/migrate_mongo_to_pg.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""
+MongoDB → PostgreSQL 迁移脚本
+
+迁移范围：Context、Message、BlackList、BotConfig、GroupConfig、UserConfig、ImageCache
+
+用法：
+    uv run --extra pg python tools/migrate_mongo_to_pg.py
+
+选项：
+    --batch N       每批处理条数，默认 1000
+    --dry-run       只统计数量，不写入 PostgreSQL
+    --pg-db NAME    目标 PostgreSQL 数据库名，默认读取 PG_DB 环境变量（fallback: PallasBot）
+    --tables TABLE  仅迁移指定表（可多选），可选值：
+                      context message blacklist botconfig groupconfig userconfig imagecache
+
+示例：
+    # 全量迁移
+    uv run --extra pg python tools/migrate_mongo_to_pg.py
+
+    # 指定目标数据库名
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --pg-db MyBot
+
+    # 仅迁移消息和上下文，每批 500 条
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --tables context message --batch 500
+
+    # 预演（不写入数据库）
+    uv run --extra pg python tools/migrate_mongo_to_pg.py --dry-run
+
+环境变量（从 .env 读取，也可手动设置）：
+    MONGO_HOST / MONGO_PORT / MONGO_USER / MONGO_PASSWORD
+    PG_HOST / PG_PORT / PG_USER / PG_PASSWORD / PG_DB
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.parse import quote_plus
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(ROOT / ".env")
+except ImportError:
+    env_file = ROOT / ".env"
+    if env_file.exists():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, _, v = line.partition("=")
+                os.environ.setdefault(k.strip(), v.strip())
+
+ALL_TABLES = ["context", "message", "blacklist", "botconfig", "groupconfig", "userconfig", "imagecache"]
+
+# asyncpg 单语句参数上限 32767
+_ANS_BATCH = 6000  # ContextAnswerRow    5 列
+_MSG_BATCH = 16000  # ContextAnswerMsg    2 列
+_BAN_BATCH = 6000  # ContextBanRow       5 列
+_IC_BATCH = 6000  # ImageCacheRow       4 列
+_MSG_ROW_BATCH = 4000  # MessageRow       8 列
+
+
+def _mongo_dsn() -> str:
+    h, p = os.getenv("MONGO_HOST", "127.0.0.1"), int(os.getenv("MONGO_PORT", "27017"))
+    u, pw = os.getenv("MONGO_USER", ""), os.getenv("MONGO_PASSWORD", "")
+    return f"mongodb://{quote_plus(u)}:{quote_plus(pw)}@{h}:{p}" if u and pw else f"mongodb://{h}:{p}"
+
+
+def _pg_dsn() -> str:
+    h = os.getenv("PG_HOST", os.getenv("MONGO_HOST", "127.0.0.1"))
+    p = int(os.getenv("PG_PORT", "5432"))
+    u, pw = os.getenv("PG_USER", ""), os.getenv("PG_PASSWORD", "")
+    db = os.getenv("PG_DB", "PallasBot")
+    auth = f"{quote_plus(u)}:{quote_plus(pw)}@" if u and pw else ""
+    return f"postgresql+asyncpg://{auth}{h}:{p}/{db}"
+
+
+def _strip_null(obj):
+    """递归去除 PostgreSQL 不支持的 \\u0000 字符"""
+    if isinstance(obj, str):
+        return obj.replace("\x00", "")
+    if isinstance(obj, dict):
+        return {k: _strip_null(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_strip_null(i) for i in obj]
+    return obj
+
+
+def _kw_hash(keywords: str) -> str:
+    import hashlib
+
+    return hashlib.md5(keywords.encode("utf-8", errors="replace")).hexdigest()
+
+
+async def _ensure_db() -> None:
+    import re
+
+    import asyncpg
+
+    h = os.getenv("PG_HOST", os.getenv("MONGO_HOST", "127.0.0.1"))
+    p = int(os.getenv("PG_PORT", "5432"))
+    u, pw = os.getenv("PG_USER", "") or None, os.getenv("PG_PASSWORD", "") or None
+    db = os.getenv("PG_DB", "PallasBot")
+    if not re.match(r"^[A-Za-z0-9_\-]+$", db):
+        raise ValueError(f"非法数据库名: {db!r}")
+    conn = await asyncpg.connect(host=h, port=p, user=u, password=pw, database="postgres")
+    try:
+        if not await conn.fetchval("SELECT 1 FROM pg_database WHERE datname=$1", db):
+            await conn.execute(f'CREATE DATABASE "{db}"')
+            print(f"已创建数据库 {db}")
+        else:
+            print(f"数据库 {db} 已存在")
+    finally:
+        await conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 各表迁移函数
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_context(Context, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, batch_size, dry_run):
+    from sqlalchemy import delete as D
+    from sqlalchemy import select as S
+
+    total = await Context.count()
+    print(f"\n📦 Context: {total} 条")
+    migrated = skip = 0
+
+    while True:
+        batch = await Context.find_all().skip(skip).limit(batch_size).to_list()
+        if not batch:
+            break
+
+        seen: dict[str, tuple] = {}
+        for doc in batch:
+            h = _kw_hash(doc.keywords)
+            seen[h] = (
+                doc,
+                {
+                    "keywords": _strip_null(doc.keywords),
+                    "keywords_hash": h,
+                    "time": doc.time,
+                    "trigger_count": doc.trigger_count,
+                    "clear_time": doc.clear_time,
+                },
+            )
+
+        if not dry_run:
+            async with sf() as session:
+                stmt = ins(ContextRow).values([v[1] for v in seen.values()])
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["keywords_hash"],
+                        set_={
+                            "keywords": stmt.excluded.keywords,
+                            "time": stmt.excluded.time,
+                            "trigger_count": stmt.excluded.trigger_count,
+                            "clear_time": stmt.excluded.clear_time,
+                        },
+                    )
+                )
+                await session.commit()
+
+                result = await session.execute(
+                    S(ContextRow.id, ContextRow.keywords_hash).where(ContextRow.keywords_hash.in_(seen.keys()))
+                )
+                h2id = {r.keywords_hash: r.id for r in result}
+                ctx_ids = list(h2id.values())
+                await session.execute(D(AnsRow).where(AnsRow.context_id.in_(ctx_ids)))
+                await session.execute(D(BanRow).where(BanRow.context_id.in_(ctx_ids)))
+
+                ans_data, ban_rows = [], []
+                for h, (doc, _) in seen.items():
+                    cid = h2id.get(h)
+                    if cid is None:
+                        continue
+                    for a in doc.answers:
+                        ans_data.append({
+                            "context_id": cid,
+                            "keywords": _strip_null(a.keywords),
+                            "group_id": a.group_id,
+                            "count": a.count,
+                            "time": a.time,
+                            "_msgs": [_strip_null(m) for m in a.messages],
+                        })
+                    for b in doc.ban:
+                        ban_rows.append({
+                            "context_id": cid,
+                            "keywords": _strip_null(b.keywords),
+                            "group_id": b.group_id,
+                            "reason": _strip_null(b.reason),
+                            "time": b.time,
+                        })
+
+                if ans_data:
+                    no_msg = [{k: v for k, v in d.items() if k != "_msgs"} for d in ans_data]
+                    lookup: dict[tuple, list[int]] = {}
+                    for i in range(0, len(no_msg), _ANS_BATCH):
+                        ret = await session.execute(
+                            ins(AnsRow)
+                            .values(no_msg[i : i + _ANS_BATCH])
+                            .returning(AnsRow.id, AnsRow.context_id, AnsRow.group_id, AnsRow.keywords)
+                        )
+                        for r in ret.fetchall():
+                            lookup.setdefault((r.context_id, r.group_id, r.keywords), []).append(r.id)
+
+                    msg_rows = []
+                    for d in ans_data:
+                        ids = lookup.get((d["context_id"], d["group_id"], d["keywords"]), [])
+                        if ids:
+                            aid = ids.pop(0)
+                            msg_rows.extend({"answer_id": aid, "message": m} for m in d["_msgs"])
+                    for i in range(0, len(msg_rows), _MSG_BATCH):
+                        await session.execute(ins(AnsMsgRow).values(msg_rows[i : i + _MSG_BATCH]))
+
+                for i in range(0, len(ban_rows), _BAN_BATCH):
+                    await session.execute(ins(BanRow).values(ban_rows[i : i + _BAN_BATCH]))
+                await session.commit()
+
+        migrated += len(batch)
+        skip += batch_size
+        print(f"  Context {migrated}/{total}", end="\r")
+    print(f"  Context {migrated}/{total} ✓")
+
+
+async def _migrate_message(Message, sf, MsgRow, ins, batch_size, dry_run):
+    col = Message.get_pymongo_collection()
+    total = await col.count_documents({})
+    print(f"\n📦 Message: {total} 条")
+    migrated, batch = 0, []
+
+    async for doc in col.find({}, batch_size=batch_size):
+        raw = doc.get("raw_message", "")
+        batch.append(
+            _strip_null({
+                "group_id": int(doc.get("group_id", 0)),
+                "user_id": int(doc.get("user_id", 0)),
+                "bot_id": int(doc.get("bot_id", 0)),
+                "raw_message": raw,
+                "is_plain_text": doc.get("is_plain_text", True),
+                "plain_text": doc.get("plain_text", raw),
+                "keywords": doc.get("keywords", ""),
+                "time": doc.get("time", 0),
+            })
+        )
+        if len(batch) >= _MSG_ROW_BATCH:
+            if not dry_run:
+                async with sf() as session:
+                    await session.execute(ins(MsgRow).values(batch).on_conflict_do_nothing())
+                    await session.commit()
+            migrated += len(batch)
+            batch = []
+            print(f"  Message {migrated}/{total}", end="\r")
+
+    if batch:
+        if not dry_run:
+            async with sf() as session:
+                await session.execute(ins(MsgRow).values(batch).on_conflict_do_nothing())
+                await session.commit()
+        migrated += len(batch)
+    print(f"  Message {migrated}/{total} ✓")
+
+
+async def _migrate_blacklist(BlackList, sf, BLRow, ins, dry_run):
+    total = await BlackList.count()
+    print(f"\n📦 BlackList: {total} 条")
+    docs = await BlackList.find_all().to_list()
+    if not docs:
+        print("  BlackList 0/0 ✓")
+        return
+    rows = [
+        _strip_null({"group_id": int(d.group_id), "answers": d.answers, "answers_reserve": d.answers_reserve})
+        for d in docs
+    ]
+    if not dry_run:
+        async with sf() as session:
+            stmt = ins(BLRow).values(rows)
+            await session.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["group_id"],
+                    set_={"answers": stmt.excluded.answers, "answers_reserve": stmt.excluded.answers_reserve},
+                )
+            )
+            await session.commit()
+    print(f"  BlackList {len(docs)}/{total} ✓")
+
+
+async def _migrate_bot_config(BotConfigModule, sf, BCRow, ins, dry_run):
+    col = BotConfigModule.get_pymongo_collection()
+    total = await col.count_documents({})
+    print(f"\n📦 BotConfig: {total} 条")
+    raw_docs = await col.find({}).to_list(length=None)
+    if not raw_docs:
+        print("  BotConfig 0/0 ✓")
+        return
+
+    rows = []
+    for raw in raw_docs:
+        try:
+            if "auto_accept" in raw and "auto_accept_group" not in raw:
+                ag, af = bool(raw["auto_accept"]), False
+            else:
+                ag = bool(raw.get("auto_accept_group", False))
+                af = bool(raw.get("auto_accept_friend", False))
+            admins = []
+            for x in raw.get("admins", []):
+                try:
+                    admins.append(int(x))
+                except (TypeError, ValueError):
+                    print(f"  ⚠️  BotConfig account={raw.get('account')} admins 跳过无效值: {x!r}")
+            tn = raw.get("taken_name", {})
+            dk = raw.get("drunk", {})
+            rows.append(
+                _strip_null({
+                    "account": int(raw["account"]),
+                    "admins": admins,
+                    "auto_accept_friend": af,
+                    "auto_accept_group": ag,
+                    "security": bool(raw.get("security", False)),
+                    "taken_name": {str(k): v for k, v in (tn.items() if isinstance(tn, dict) else {})},
+                    "drunk": {str(k): v for k, v in (dk.items() if isinstance(dk, dict) else {})},
+                    "disabled_plugins": raw.get("disabled_plugins", []),
+                })
+            )
+        except Exception as e:
+            print(f"  ⚠️  BotConfig 跳过 account={raw.get('account')}: {e}")
+
+    if not dry_run:
+        async with sf() as session:
+            stmt = ins(BCRow).values(rows)
+            await session.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["account"],
+                    set_={
+                        f: getattr(stmt.excluded, f)
+                        for f in [
+                            "admins",
+                            "auto_accept_friend",
+                            "auto_accept_group",
+                            "security",
+                            "taken_name",
+                            "drunk",
+                            "disabled_plugins",
+                        ]
+                    },
+                )
+            )
+            await session.commit()
+    print(f"  BotConfig {len(rows)}/{total} ✓")
+
+
+async def _migrate_group_config(GroupConfigModule, sf, GCRow, ins, dry_run):
+    total = await GroupConfigModule.count()
+    print(f"\n📦 GroupConfig: {total} 条")
+    docs = await GroupConfigModule.find_all().to_list()
+    if not docs:
+        print("  GroupConfig 0/0 ✓")
+        return
+    rows = [
+        _strip_null({
+            "group_id": int(d.group_id),
+            "roulette_mode": d.roulette_mode,
+            "banned": d.banned,
+            "sing_progress": json.loads(d.sing_progress.model_dump_json()) if d.sing_progress else None,
+            "disabled_plugins": d.disabled_plugins,
+        })
+        for d in docs
+    ]
+    if not dry_run:
+        async with sf() as session:
+            stmt = ins(GCRow).values(rows)
+            await session.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["group_id"],
+                    set_={
+                        f: getattr(stmt.excluded, f)
+                        for f in ["roulette_mode", "banned", "sing_progress", "disabled_plugins"]
+                    },
+                )
+            )
+            await session.commit()
+    print(f"  GroupConfig {len(docs)}/{total} ✓")
+
+
+async def _migrate_user_config(UserConfigModule, sf, UCRow, ins, batch_size, dry_run):
+    total = await UserConfigModule.count()
+    print(f"\n📦 UserConfig: {total} 条")
+    migrated = skip = 0
+    while True:
+        batch = await UserConfigModule.find_all().skip(skip).limit(batch_size).to_list()
+        if not batch:
+            break
+        rows = [_strip_null({"user_id": int(d.user_id), "banned": d.banned}) for d in batch]
+        if not dry_run:
+            async with sf() as session:
+                stmt = ins(UCRow).values(rows)
+                await session.execute(
+                    stmt.on_conflict_do_update(index_elements=["user_id"], set_={"banned": stmt.excluded.banned})
+                )
+                await session.commit()
+        migrated += len(batch)
+        skip += batch_size
+        print(f"  UserConfig {migrated}/{total}", end="\r")
+    print(f"  UserConfig {migrated}/{total} ✓")
+
+
+async def _migrate_image_cache(ImageCache, sf, ICRow, ins, batch_size, dry_run):
+    col = ImageCache.get_pymongo_collection()
+    total = await col.count_documents({})
+    print(f"\n📦 ImageCache: {total} 条")
+    migrated, batch = 0, []
+
+    async for doc in col.find({}, batch_size=batch_size):
+        batch.append(
+            _strip_null({
+                "cq_code": doc.get("cq_code", ""),
+                "base64_data": doc.get("base64_data"),
+                "ref_times": int(doc.get("ref_times", 1)),
+                "date": int(doc.get("date", 0)),
+            })
+        )
+        if len(batch) >= _IC_BATCH:
+            if not dry_run:
+                async with sf() as session:
+                    stmt = ins(ICRow).values(batch)
+                    await session.execute(
+                        stmt.on_conflict_do_update(
+                            index_elements=["cq_code"],
+                            set_={f: getattr(stmt.excluded, f) for f in ["base64_data", "ref_times", "date"]},
+                        )
+                    )
+                    await session.commit()
+            migrated += len(batch)
+            batch = []
+            print(f"  ImageCache {migrated}/{total}", end="\r")
+
+    if batch:
+        if not dry_run:
+            async with sf() as session:
+                stmt = ins(ICRow).values(batch)
+                await session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=["cq_code"],
+                        set_={f: getattr(stmt.excluded, f) for f in ["base64_data", "ref_times", "date"]},
+                    )
+                )
+                await session.commit()
+        migrated += len(batch)
+    print(f"  ImageCache {migrated}/{total} ✓")
+
+
+# ---------------------------------------------------------------------------
+# 主入口
+# ---------------------------------------------------------------------------
+
+
+async def migrate(batch_size: int, dry_run: bool, tables: set[str], pg_db: str | None = None) -> None:
+    if pg_db:
+        os.environ["PG_DB"] = pg_db
+    try:
+        from sqlalchemy.ext.asyncio import create_async_engine
+    except ImportError:
+        print("❌ 缺少 SQLAlchemy/asyncpg，请执行：uv sync --extra pg")
+        sys.exit(1)
+
+    from beanie import init_beanie
+    from pymongo import AsyncMongoClient
+    from sqlalchemy import text as T
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from src.common.db.modules import (
+        BlackList,
+        BotConfigModule,
+        Context,
+        GroupConfigModule,
+        ImageCache,
+        Message,
+        UserConfigModule,
+    )
+    from src.common.db.repository_pg import (
+        BlackListRow,
+        BotConfigRow,
+        ContextAnswerMessageRow,
+        ContextAnswerRow,
+        ContextBanRow,
+        ContextRow,
+        GroupConfigRow,
+        ImageCacheRow,
+        MessageRow,
+        UserConfigRow,
+        init_pg,
+    )
+
+    print(f"🔗 连接 MongoDB: {_mongo_dsn()}")
+    mongo_client = AsyncMongoClient(_mongo_dsn(), unicode_decode_error_handler="ignore")
+    await init_beanie(
+        database=mongo_client["PallasBot"],
+        document_models=[Context, Message, BlackList, BotConfigModule, GroupConfigModule, UserConfigModule, ImageCache],
+    )
+
+    print(f"🔗 连接 PostgreSQL: {_pg_dsn()}")
+    if not dry_run:
+        await _ensure_db()
+
+    engine = create_async_engine(_pg_dsn(), echo=False)
+    if not dry_run:
+        await init_pg(engine)
+        async with engine.begin() as conn:
+            # 删除旧的 keywords 唯一约束（超长值会超出 btree 2704 字节限制）
+            await conn.execute(T("ALTER TABLE context DROP CONSTRAINT IF EXISTS context_keywords_key"))
+            await conn.execute(T("DROP INDEX IF EXISTS ix_context_keywords"))
+            await conn.execute(T("ALTER TABLE context ADD COLUMN IF NOT EXISTS keywords_hash TEXT"))
+            await conn.execute(T("UPDATE context SET keywords_hash = md5(keywords) WHERE keywords_hash IS NULL"))
+            await conn.execute(T("ALTER TABLE context ALTER COLUMN keywords_hash SET NOT NULL"))
+            await conn.execute(
+                T("CREATE UNIQUE INDEX IF NOT EXISTS ix_context_keywords_hash ON context (keywords_hash)")
+            )
+
+    sf = async_sessionmaker(engine, expire_on_commit=False)
+
+    if "context" in tables:
+        await _migrate_context(
+            Context,
+            sf,
+            ContextRow,
+            ContextAnswerRow,
+            ContextAnswerMessageRow,
+            ContextBanRow,
+            pg_insert,
+            batch_size,
+            dry_run,
+        )
+    if "message" in tables:
+        await _migrate_message(Message, sf, MessageRow, pg_insert, batch_size, dry_run)
+    if "blacklist" in tables:
+        await _migrate_blacklist(BlackList, sf, BlackListRow, pg_insert, dry_run)
+    if "botconfig" in tables:
+        await _migrate_bot_config(BotConfigModule, sf, BotConfigRow, pg_insert, dry_run)
+    if "groupconfig" in tables:
+        await _migrate_group_config(GroupConfigModule, sf, GroupConfigRow, pg_insert, dry_run)
+    if "userconfig" in tables:
+        await _migrate_user_config(UserConfigModule, sf, UserConfigRow, pg_insert, batch_size, dry_run)
+    if "imagecache" in tables:
+        await _migrate_image_cache(ImageCache, sf, ImageCacheRow, pg_insert, batch_size, dry_run)
+
+    await engine.dispose()
+    print("\n✅ 迁移完成")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="MongoDB → PostgreSQL 数据迁移",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"可迁移的表：{', '.join(ALL_TABLES)}",
+    )
+    parser.add_argument("--batch", type=int, default=1000, metavar="N", help="每批处理条数（默认 1000）")
+    parser.add_argument("--dry-run", action="store_true", help="只统计数量，不写入 PostgreSQL")
+    parser.add_argument("--pg-db", metavar="NAME", help="目标 PostgreSQL 数据库名（覆盖 PG_DB 环境变量）")
+    parser.add_argument(
+        "--tables", nargs="+", choices=ALL_TABLES, metavar="TABLE", help="仅迁移指定表（空格分隔），不指定则迁移全部"
+    )
+    args = parser.parse_args()
+
+    selected = set(args.tables) if args.tables else set(ALL_TABLES)
+    if args.dry_run:
+        print("⚠️  dry-run 模式，不会写入 PostgreSQL")
+    if args.tables:
+        print(f"📋 仅迁移：{', '.join(t for t in ALL_TABLES if t in selected)}")
+
+    asyncio.run(migrate(args.batch, args.dry_run, selected, args.pg_db))

--- a/tools/migrate_mongo_to_pg.py
+++ b/tools/migrate_mongo_to_pg.py
@@ -77,7 +77,7 @@ except ImportError:
 ALL_TABLES = ["context", "message", "blacklist", "botconfig", "groupconfig", "userconfig", "imagecache"]
 
 # asyncpg 单语句参数上限 32767
-_ANS_BATCH = 6000  # ContextAnswerRow    5 列
+_ANS_BATCH = 5000  # ContextAnswerRow    6 列（含 keywords_hash）
 _MSG_BATCH = 16000  # ContextAnswerMessageRow 2 列
 _BAN_BATCH = 6000  # ContextBanRow       5 列
 _IC_BATCH = 6000  # ImageCacheRow       4 列
@@ -459,16 +459,18 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                         stats.warn(f"context_id missing after upsert: hash={h}")
                         continue
                     for a in _dedupe_answers(g["answers"]):
+                        kh = _kw_hash(a["keywords"])
                         ans_rows.append({
                             "context_id": cid,
                             "keywords": a["keywords"],
+                            "keywords_hash": kh,
                             "group_id": a["group_id"],
                             "count": a["count"],
                             "time": a["time"],
                         })
                         if a["messages"]:
                             ans_msg_pending.append(
-                                (cid, (cid, a["group_id"], a["keywords"]), a["messages"])
+                                (cid, (cid, a["group_id"], kh), a["messages"])
                             )
                     for b in g["bans"]:
                         ban_rows.append({
@@ -480,15 +482,17 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                         })
 
                 # 4. 批量插 answer 并拿回 id（走 RETURNING）
+                # 键 = (context_id, group_id, keywords_hash) 对齐 UNIQUE 约束，
+                # 避免用 TEXT keywords 作 key 时超长字符串带来的内存开销
                 key2aid: dict[tuple[int, int, str], int] = {}
                 for i in range(0, len(ans_rows), _ANS_BATCH):
                     ret = await session.execute(
                         ins(AnsRow)
                         .values(ans_rows[i : i + _ANS_BATCH])
-                        .returning(AnsRow.id, AnsRow.context_id, AnsRow.group_id, AnsRow.keywords)
+                        .returning(AnsRow.id, AnsRow.context_id, AnsRow.group_id, AnsRow.keywords_hash)
                     )
                     for r in ret.fetchall():
-                        key2aid[(r.context_id, r.group_id, r.keywords)] = int(r.id)
+                        key2aid[(r.context_id, r.group_id, r.keywords_hash)] = int(r.id)
 
                 # 5. 关联 messages
                 msg_rows: list[dict] = []

--- a/tools/migrate_mongo_to_pg.py
+++ b/tools/migrate_mongo_to_pg.py
@@ -6,8 +6,8 @@ MongoDB → PostgreSQL 迁移脚本
 
 特性：
 - 基于 Mongo `_id` 游标流式读取，不走 skip/limit，千万级数据也不会退化成 O(n)
-- migration_state 表记录每张表的 last_id；中断后重跑自动断点续传，不会重复写入
-- 批级 commit 与 migration_state 在同一事务内原子写入，保证"恰好一次"
+- pallas_migration_state 表记录每张表的 last_id；中断后重跑自动断点续传，不会重复写入
+- 批级 commit 与 pallas_migration_state 在同一事务内原子写入，保证"恰好一次"
 - 逐条 defensive 解析，脏数据（缺字段 / 非法类型 / NUL 字符）跳过并计入汇总，不阻断
 - Context 聚合同 batch 内相同 keywords_hash 的 answers / bans，不再丢数据
 - upsert 依赖 `repository_pg` 里定义的唯一约束（含复合 upsert_answer 约束），新字段自动加到 PG
@@ -21,7 +21,7 @@ MongoDB → PostgreSQL 迁移脚本
     --pg-db NAME    目标 PG 库名，覆盖 PG_DB 环境变量
     --mongo-db NAME 源 Mongo 库名，覆盖 MONGO_DB 环境变量（默认 PallasBot）
     --tables TABLE  仅迁移指定表，可选：context message blacklist botconfig groupconfig userconfig imagecache
-    --restart       清空 migration_state 重新从头迁移
+    --restart       清空 pallas_migration_state 重新从头迁移
 
 示例：
     # 全量迁移（自动续传）
@@ -196,10 +196,20 @@ async def _ensure_db() -> None:
     db = os.getenv("PG_DB", "PallasBot")
     if not re.match(r"^[A-Za-z0-9_\-]+$", db):
         raise ValueError(f"非法数据库名: {db!r}")
-    conn = await asyncpg.connect(host=h, port=p, user=u, password=pw, database="postgres")
+    # 未显式指定 PG_USER/PG_PASSWORD 时省掉这两个参数，让 libpq 走默认用户
+    # （PGUSER / 当前 OS 用户）和 .pgpass，否则很多本地 trust / peer 鉴权环境
+    # 会因为 user=None 直接连不上。
+    conn_kwargs: dict[str, object] = {"host": h, "port": p, "database": "postgres"}
+    if u is not None:
+        conn_kwargs["user"] = u
+    if pw is not None:
+        conn_kwargs["password"] = pw
+    conn = await asyncpg.connect(**conn_kwargs)
     try:
         if not await conn.fetchval("SELECT 1 FROM pg_database WHERE datname=$1", db):
-            await conn.execute(f'CREATE DATABASE "{db}"')
+            # PG 不支持用占位符绑定 identifier，只能拼接；上面的正则已保证 db 仅含
+            # [A-Za-z0-9_-]，不存在注入风险。
+            await conn.execute(f'CREATE DATABASE "{db}"')  # noqa: S608
             print(f"已创建数据库 {db}")
         else:
             print(f"数据库 {db} 已存在")
@@ -208,8 +218,13 @@ async def _ensure_db() -> None:
 
 
 # ---------------------------------------------------------------------------
-# migration_state：断点续传
+# pallas_migration_state：断点续传
+#
+# 表名加 pallas_ 前缀，避免与用户已有共享库里的同名 migration_state 冲突。
 # ---------------------------------------------------------------------------
+
+
+_STATE_TABLE = "pallas_migration_state"
 
 
 async def _ensure_state_table(engine) -> None:
@@ -218,8 +233,8 @@ async def _ensure_state_table(engine) -> None:
     async with engine.begin() as conn:
         await conn.execute(
             T(
-                """
-                CREATE TABLE IF NOT EXISTS migration_state (
+                f"""
+                CREATE TABLE IF NOT EXISTS {_STATE_TABLE} (
                     table_name TEXT PRIMARY KEY,
                     last_id TEXT NOT NULL,
                     updated_at TIMESTAMPTZ DEFAULT NOW()
@@ -233,15 +248,15 @@ async def _reset_state(engine) -> None:
     from sqlalchemy import text as T
 
     async with engine.begin() as conn:
-        await conn.execute(T("DELETE FROM migration_state"))
-    print("已清空 migration_state，将从头迁移")
+        await conn.execute(T(f"DELETE FROM {_STATE_TABLE}"))
+    print(f"已清空 {_STATE_TABLE}，将从头迁移")
 
 
 async def _get_state(session, table: str) -> str | None:
     from sqlalchemy import text as T
 
     result = await session.execute(
-        T("SELECT last_id FROM migration_state WHERE table_name = :t"), {"t": table}
+        T(f"SELECT last_id FROM {_STATE_TABLE} WHERE table_name = :t"), {"t": table}
     )
     return result.scalar_one_or_none()
 
@@ -251,8 +266,8 @@ async def _set_state(session, table: str, last_id: str) -> None:
 
     await session.execute(
         T(
-            """
-            INSERT INTO migration_state (table_name, last_id, updated_at)
+            f"""
+            INSERT INTO {_STATE_TABLE} (table_name, last_id, updated_at)
             VALUES (:t, :id, NOW())
             ON CONFLICT (table_name) DO UPDATE
                 SET last_id = EXCLUDED.last_id, updated_at = NOW()
@@ -508,7 +523,7 @@ async def _migrate_context(db, sf, ContextRow, AnsRow, AnsMsgRow, BanRow, ins, b
                 for i in range(0, len(ban_rows), _BAN_BATCH):
                     await session.execute(ins(BanRow).values(ban_rows[i : i + _BAN_BATCH]))
 
-                # 7. 更新 migration_state 并一并 commit
+                # 7. 更新 pallas_migration_state 并一并 commit
                 await _set_state(session, "context", str(batch[-1]["_id"]))
                 await session.commit()
 
@@ -937,7 +952,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tables", nargs="+", choices=ALL_TABLES, metavar="TABLE", help="仅迁移指定表（空格分隔），不指定则迁移全部"
     )
-    parser.add_argument("--restart", action="store_true", help="清空 migration_state 从头迁移")
+    parser.add_argument("--restart", action="store_true", help="清空 pallas_migration_state 从头迁移")
     args = parser.parse_args()
 
     selected = set(args.tables) if args.tables else set(ALL_TABLES)


### PR DESCRIPTION
## 背景

为牛牛补齐一个可选的 PostgreSQL 数据库后端，兼顾以下目标：

- 与现有 MongoDB 后端共用同一套 `Repository` 抽象，业务层零感知切换
- 高频写入（`upsert_answer` / 黑名单 / 图缓存 / 配置）在 PG 上并发安全且不丢计数
- 现存 MongoDB 数据可无痛迁移，包括千万级规模与长期累积的脏数据
- 新增后端不打扰只跑 MongoDB 的用户

## 主要特性

### 1. PostgreSQL Repository 实现

- 新增 `src/common/db/repository_pg.py`，覆盖 `Context` / `Message` / `BlackList` / `ImageCache` / `BotConfig` / `GroupConfig` / `UserConfig` 全套 Repository
- `init_postgresql_db()` 支持自动 `CREATE DATABASE`、PG_DB 合法字符校验、连接池参数化（`PG_POOL_SIZE` / `PG_MAX_OVERFLOW` / `PG_POOL_RECYCLE`）、`pool_pre_ping`
- 所有 TEXT/JSONB 入口统一 `_s` / `_strip_null_deep`，避免 Mongo 上游 `\x00` 带来的 `StringDataError`

### 2. 业务正确性对齐 Mongo

- `find_for_cleanup` 由 AND 改为 OR，避免误清理
- `upsert_answer` 改为单事务 `INSERT ... ON CONFLICT DO UPDATE ... RETURNING (xmax=0)`，基于 `UNIQUE(context_id, group_id, keywords_hash)` 原子完成 answer upsert + message 条件插入 + `ContextRow.trigger_count` 自增
- `BlackList.upsert_answers` / `ImageCache.save` 同步原子化
- `keywords_hash` 先 strip `\x00` 再哈希，与 `ContextRow.keywords` 实际存储值保持一致

### 3. 表结构与性能

- `Message` / `Context` / `ContextAnswer` / `ContextBan` / `BlackList` / `ImageCache` 主键与外键一律 `BigInteger`
- 去掉 unique 列上的冗余显式索引，新增 `Message.time` 索引对齐 Mongo `time_index`
- `bulk_insert` 走 Core executemany；`find_for_cleanup` 基于主键 id 游标流式；`delete_expired` 子查询分块，避免千万级长时间锁
- `PgConfigRepository` 内置 60s / 10000 条 TTL 缓存，支持 `ignore_cache` 回源与写入失效，对齐 Mongo `ConfigRepository`

### 4. `ContextAnswer.keywords` btree 2704 字节问题

Mongo 侧 `answer.keywords` 常达数 KB，直接把 TEXT 塞进 btree 会抛 `ProgramLimitExceededError`。本 PR 给 `ContextAnswerRow` 新增 `keywords_hash` 列（md5，32 字符定长），把 UNIQUE 改为 `(context_id, group_id, keywords_hash)`，沿用原 constraint 名，`upsert_answer` / `_insert_answers_batched` 复用现有 `keywords_hash()` 自动承接 strip 语义。

### 5. Mongo → PG 迁移脚本（`tools/migrate_mongo_to_pg.py`）

- 基于 `_id` 升序游标分批拉取（替代 skip/limit），千万级数据不再退化为 O(n²)
- 新增 `migration_state` 表记录每张表 `last_id`，中断后重跑自动断点续传；`--restart` 清空状态
- 每批 upsert 与 `migration_state` 写入在同一事务内原子 commit，保证"恰好一次"
- `_prepare_context_batch` 按 `keywords_hash` 聚合同 key 的 answers/bans（count 累加 / time 取 max / messages 合并），上游重复文档不丢数据
- 其它表按唯一键 `_dedupe_by_key` 去重，规避 `ON CONFLICT` 批内重复命中
- defensive helpers（`_as_int / _as_str / _as_bool / _as_list / _as_dict / _strip_null`）统一兜底缺字段、错类型、NUL 字节；逐文档 try/except 累计到 `_TableStats`
- BotConfig 兼容旧 `auto_accept` 字段；`admins` 非法项跳过并告警
- 进度显示 ETA 与速率，结束打印 total/migrated/failed 汇总与样本 warning

## 使用方式

```bash
# 1. 安装 PG 依赖（可选）
uv sync --extra pg

# 2. 配置 .env
DB_BACKEND=postgresql
PG_HOST=127.0.0.1
PG_USER=pallas
PG_PASSWORD=...
PG_DB=PallasBot

# 3. 从 Mongo 迁过来（可选）
python tools/migrate_mongo_to_pg.py

## Summary by Sourcery

在保留现有 API 接口兼容性的前提下，新增与 MongoDB 并行的、功能完整的 PostgreSQL 数据库后端，包括初始化、仓库实现，以及从 Mongo→PostgreSQL 的迁移路径。

New Features:
- 为上下文、消息、黑名单、配置和图片缓存引入具体的 PostgreSQL 仓库实现，并复用现有的 Repository 抽象。
- 新增基于环境变量驱动的 MongoDB 和 PostgreSQL 初始化逻辑，包括自动创建 PostgreSQL 数据库以及连接池配置。
- 提供 MongoDB 到 PostgreSQL 的流式迁移脚本，支持分批迁移、去重、检查点机制以及防御性数据清洗。

Enhancements:
- 对齐 MongoDB 与 PostgreSQL 之间的业务语义，包括原子 upsert、清理查询，以及对超长或包含 NUL 字符文本字段的处理。
- 更新配置和媒体相关的代码路径，更显式地构造仓库模型，并更健壮地处理带类型的负载数据。
- 改进数据库后端选择逻辑，同时从 NoneBot driver 配置和环境变量中读取配置，从而简化初始化 API。

Documentation:
- 修订 README 以介绍 Pallas-Bot 3.0，重点说明新的 PostgreSQL 后端、迁移工具以及性能改进。

Tests:
- 新增 PostgreSQL 仓库集成测试，覆盖清理语义、原子 upsert、NUL 字节剥离、配置缓存行为以及图片缓存语义。
- 为迁移脚本新增鲁棒性测试，使用伪造的 Mongo 集合与真实 PostgreSQL，覆盖分批迁移、去重以及错误容忍能力。
- 调整后端切换测试，以适配新的初始化签名和双来源后端配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a fully functional PostgreSQL database backend alongside MongoDB, including initialization, repositories, and a Mongo→PostgreSQL migration path, while keeping the existing API surface compatible.

New Features:
- Introduce concrete PostgreSQL repository implementations for contexts, messages, blacklists, configs, and image cache sharing the existing Repository abstractions.
- Add environment-driven initialization for MongoDB and PostgreSQL, including automatic PostgreSQL database creation and connection pooling configuration.
- Provide a MongoDB-to-PostgreSQL streaming migration script with batching, deduplication, checkpointing, and defensive data cleaning.

Enhancements:
- Align business semantics between MongoDB and PostgreSQL, including atomic upserts, cleanup queries, and handling of oversized or NUL-containing text fields.
- Update configuration and media-related code paths to construct repository models explicitly and handle typed payloads more robustly.
- Improve database backend selection to read from both NoneBot driver config and environment variables, simplifying initialization API.

Documentation:
- Revise README to describe Pallas-Bot 3.0, highlighting the new PostgreSQL backend, migration tooling, and performance improvements.

Tests:
- Add PostgreSQL repository integration tests covering cleanup semantics, atomic upserts, NUL-byte stripping, config caching behavior, and image cache semantics.
- Add robustness tests for the migration script using fake Mongo collections and real PostgreSQL, including batching, deduplication, and error tolerance.
- Adjust backend switching tests to work with the new initialization signatures and dual-source backend configuration.

</details>