### PR TITLE
feat(extended_api): 增强 WebUI 更新逻辑，确保版本信息同步

### DIFF
--- a/src/plugins/pallas_webui/extended_api.py
+++ b/src/plugins/pallas_webui/extended_api.py
@@ -2308,6 +2308,7 @@ def register_extended_api(
         from .manager import (
             download_and_extract_dist_zip,
             fetch_latest_webui_release,
+            get_webui_dist_version,
             resolve_github_release_asset_urls,
             save_installed_webui_version,
             webui_public_path,
@@ -2340,8 +2341,11 @@ def register_extended_api(
             except Exception:  # noqa: BLE001
                 new_tag = tag
             save_installed_webui_version(new_tag, succeeded_url)
-            logger.info("Pallas 控制台: WebUI 已更新至 {}", new_tag)
-            return JSONResponse({"ok": True, "data": {"tag": new_tag, "message": "更新成功"}})
+            # 更新成功后同步刷新内存里的 console 版本，避免必须重启后前端才显示新版本。
+            effective_version = get_webui_dist_version() or new_tag or "unknown"
+            set_console_meta({**_CONSOLE_EXTRA, "version": effective_version})
+            logger.info("Pallas 控制台: WebUI 已更新至 {}", effective_version)
+            return JSONResponse({"ok": True, "data": {"tag": effective_version, "message": "更新成功"}})
         except HTTPException:
             raise
         except Exception as e:  # noqa: BLE001

--- a/src/plugins/pallas_webui/extended_api.py
+++ b/src/plugins/pallas_webui/extended_api.py
@@ -2342,10 +2342,21 @@ def register_extended_api(
                 new_tag = tag
             save_installed_webui_version(new_tag, succeeded_url)
             # 更新成功后同步刷新内存里的 console 版本，避免必须重启后前端才显示新版本。
-            effective_version = get_webui_dist_version() or new_tag or "unknown"
+            try:
+                dist_ver = get_webui_dist_version()
+            except Exception:  # noqa: BLE001
+                dist_ver = ""
+            effective_version = (dist_ver or "").strip() or new_tag or "unknown"
             set_console_meta({**_CONSOLE_EXTRA, "version": effective_version})
-            logger.info("Pallas 控制台: WebUI 已更新至 {}", effective_version)
-            return JSONResponse({"ok": True, "data": {"tag": effective_version, "message": "更新成功"}})
+            logger.info("Pallas 控制台: WebUI 已更新至 {}（发布 tag: {}）", effective_version, new_tag)
+            return JSONResponse({
+                "ok": True,
+                "data": {
+                    "tag": new_tag,
+                    "version": effective_version,
+                    "message": "更新成功",
+                },
+            })
         except HTTPException:
             raise
         except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
- 新增 get_webui_dist_version 函数以获取当前 WebUI 版本
- 更新成功后，刷新内存中的控制台版本，避免重启后前端不显示新版本
- 日志记录更新后的有效版本信息

Close #156 