### PR TITLE
feat(release): GitHub Release 共用化与 dist.zip 发布

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,16 +94,18 @@ jobs:
           export BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           npm run build:ci
 
+      # zip 根目录为 public/，在 Bot 侧解压到 data/pallas_webui 即得到 public/index.html（与插件默认路径一致）。
       - name: Pack dist artifact
         run: |
-          cd pallas-webui/dist
-          zip -r ../../pallas-webui-dist.zip .
+          mkdir -p webui-zip-root/public
+          cp -a pallas-webui/dist/. webui-zip-root/public/
+          (cd webui-zip-root && zip -r ../dist.zip public)
 
       - name: Upload WebUI artifact
         uses: actions/upload-artifact@v4
         with:
-          name: pallas-webui-dist
-          path: pallas-webui-dist.zip
+          name: webui-dist-zip
+          path: dist.zip
 
   create-release:
     runs-on: ubuntu-latest
@@ -165,7 +167,7 @@ jobs:
       - name: Download WebUI artifact
         uses: actions/download-artifact@v4
         with:
-          name: pallas-webui-dist
+          name: webui-dist-zip
           path: .
 
       - name: Create Release
@@ -194,9 +196,9 @@ jobs:
             本 Release 附件中的静态资源基于 WebUI 仓库检出：**`${{ needs.build-webui-dist.outputs.webui_git_ref }}`**（`console-version.json` 中 `version`：**`${{ needs.build-webui-dist.outputs.webui_console_version }}`**）。
 
             默认无需手动配置，首次启用时会自动下载并部署 WebUI 静态资源。
-            如需手动部署，可下载 Release 附件中的 `pallas-webui-dist.zip`（即 `dist.zip`），解压到 `data/pallas_webui/public`。
+            手动部署：下载附件 **`dist.zip`**，解压到 **`data/pallas_webui`**（得到 `data/pallas_webui/public/index.html` 等，无需改 zip 内目录名）。
           files: |
-            pallas-webui-dist.zip
+            dist.zip
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,20 @@ on:
         description: 'Release version (e.g., v2.0.0-beta.1)'
         required: true
         type: string
+      webui_tag:
+        description: '可选：捆绑的 WebUI 仓库 tag（默认取当前 main 上可达的最新 v* tag）'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build-webui-dist:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      webui_console_version: ${{ steps.webui_ref.outputs.console_version }}
+      webui_git_ref: ${{ steps.webui_ref.outputs.resolved_ref }}
 
     steps:
       - name: Checkout WebUI repo
@@ -24,6 +32,37 @@ jobs:
           repository: PallasBot/Pallas-Bot-WebUI
           ref: main
           path: pallas-webui
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve WebUI release tag
+        id: webui_ref
+        working-directory: pallas-webui
+        env:
+          PIN_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.webui_tag || '' }}
+        run: |
+          set -euo pipefail
+          git fetch origin --tags --force
+          if [ -n "${PIN_TAG}" ]; then
+            git checkout "${PIN_TAG}"
+            echo "console_version=${PIN_TAG}" >> "$GITHUB_OUTPUT"
+            echo "resolved_ref=${PIN_TAG}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TAG=$(git tag -l 'v*' --merged HEAD --sort=-version:refname | head -n1)
+          if [ -z "${TAG}" ]; then
+            TAG=$(git tag -l 'v*' --sort=-version:refname | head -n1)
+          fi
+          if [ -n "${TAG}" ]; then
+            git checkout "${TAG}"
+            echo "console_version=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "resolved_ref=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::WebUI 仓库无 v* tag，使用 main；console 版本取自 package.json"
+            VER=$(node -p "require('./package.json').version")
+            echo "console_version=${VER}" >> "$GITHUB_OUTPUT"
+            echo "resolved_ref=main" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Get version
         id: get_version
@@ -45,30 +84,15 @@ jobs:
         run: npm ci
         working-directory: pallas-webui
 
+      # console-version.json：version = 上游 WebUI 发版 tag（或手动 PIN / 无 tag 时 package.json）。
       - name: Build WebUI
-        run: npm run build:ci
         working-directory: pallas-webui
-
-      - name: Write console version metadata
+        env:
+          CONSOLE_VERSION: ${{ steps.webui_ref.outputs.console_version }}
         run: |
-          BUILD_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          if [ -f pallas-webui/scripts/write-console-version.mjs ]; then
-            (
-              cd pallas-webui
-              CONSOLE_VERSION="${{ steps.get_version.outputs.version }}" \
-              GIT_COMMIT="${{ github.sha }}" \
-              BUILD_TIME="${BUILD_TIME}" \
-              node ./scripts/write-console-version.mjs
-            )
-          else
-            mkdir -p pallas-webui/dist
-            printf '%s\n' \
-              '{' \
-              '  "version": "${{ steps.get_version.outputs.version }}",' \
-              '  "commit": "${{ github.sha }}",' \
-              "  \"build_time\": \"${BUILD_TIME}\"" \
-              '}' > pallas-webui/dist/console-version.json
-          fi
+          export GIT_COMMIT="$(git rev-parse HEAD)"
+          export BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          npm run build:ci
 
       - name: Pack dist artifact
         run: |
@@ -166,6 +190,8 @@ jobs:
             - 前端仓库说明（开发/发版/对接）：[PallasBot/Pallas-Bot-WebUI README](https://github.com/PallasBot/Pallas-Bot-WebUI/blob/main/README.md)
 
             ## WebUI 使用说明
+
+            本 Release 附件中的静态资源基于 WebUI 仓库检出：**`${{ needs.build-webui-dist.outputs.webui_git_ref }}`**（`console-version.json` 中 `version`：**`${{ needs.build-webui-dist.outputs.webui_console_version }}`**）。
 
             默认无需手动配置，首次启用时会自动下载并部署 WebUI 静态资源。
             如需手动部署，可下载 Release 附件中的 `pallas-webui-dist.zip`（即 `dist.zip`），解压到 `data/pallas_webui/public`。

--- a/docs/plugins/pallas_webui/README.md
+++ b/docs/plugins/pallas_webui/README.md
@@ -22,7 +22,7 @@ PALLAS_WEBUI_API_TOKEN=你的控制台口令
 
 默认无需手动配置。启动时如果不存在 `data/pallas_webui/public/index.html`，插件会自动下载并解压 WebUI 产物。
 
-如需手动部署，可下载 `Pallas-Bot-WebUI` Release 中的 `dist.zip`，解压到 `data/pallas_webui/public`。
+如需手动部署，推荐下载 **本仓库（Pallas-Bot）对应版本的 Release 附件 `dist.zip`**（与当次 Bot 发版一并构建）；亦可使用 `Pallas-Bot-WebUI` 仓库 Release 中的 `dist.zip`。将 zip **解压到 `data/pallas_webui`**（内含 `public/` 目录，将得到 `data/pallas_webui/public/index.html` 等）。
 
 ## 下载高级配置（按需）
 

--- a/src/common/utils/format_exception.py
+++ b/src/common/utils/format_exception.py
@@ -1,0 +1,29 @@
+"""将异常格式化为单行摘要（日志 / API error 字段）。"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def format_exception_for_log(exc: BaseException) -> str:
+    """勿把裸 ``Exception`` 传入 loguru 的「{}」占位：部分环境下会得到空白输出。"""
+    if isinstance(exc, httpx.HTTPStatusError):
+        resp = exc.response
+        url = str(resp.request.url)
+        reason = (getattr(resp, "reason_phrase", None) or "").strip()
+        head = f"{resp.status_code}"
+        if reason:
+            head = f"{head} {reason}"
+        text = (resp.text or "").replace("\r", "").strip().replace("\n", " ")
+        if len(text) > 400:
+            text = text[:397] + "..."
+        return f"HTTPStatusError {head} url={url}" + (f" body={text!r}" if text else "")
+    if isinstance(exc, httpx.RequestError):
+        url = str(exc.request.url) if exc.request is not None else ""
+        suffix = f" url={url}" if url else ""
+        detail = str(exc).strip() or repr(exc)
+        return f"{type(exc).__name__}{suffix}: {detail}"
+    msg = str(exc).strip()
+    if msg:
+        return f"{type(exc).__name__}: {msg}"
+    return f"{type(exc).__name__}: {exc!r}"

--- a/src/common/utils/github_release.py
+++ b/src/common/utils/github_release.py
@@ -2,6 +2,10 @@
 
 提供：
 - :func:`github_release_api_url` — 构造 GitHub Releases API URL
+- :func:`github_auth_headers` — Bearer 鉴权头（API / 网页下载链可选）
+- :func:`github_release_asset_url` / :func:`github_release_asset_url_candidates` — releases/download 直链
+- :func:`release_tag_from_github_final_url` — 从 ``…/releases/tag/{tag}`` 解析 tag
+- :func:`fetch_latest_release_tag_via_github_web` — API 不可用时经 github.com 跳转解析最新 tag
 - :func:`fetch_github_releases` — 获取 release 列表（含 assets）
 - :func:`fetch_latest_release` — 获取最新单条 release 摘要
 """
@@ -9,6 +13,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import quote, unquote, urlparse
 
 import httpx
 
@@ -28,12 +33,82 @@ def github_release_api_url(repo: str, tag: str = "") -> str:
     return f"https://api.github.com/repos/{owner}/{name}/releases/tags/{tag.strip()}"
 
 
-def _github_auth_headers(token: str = "") -> dict[str, str]:
+def github_auth_headers(token: str = "") -> dict[str, str]:
     """构造 GitHub API 鉴权头；token 为空时返回空字典。"""
     t = (token or "").strip()
     if not t:
         return {}
     return {"Authorization": f"Bearer {t}"}
+
+
+_github_auth_headers = github_auth_headers
+
+
+def github_release_asset_url(repo: str, asset_name: str, tag: str = "") -> str:
+    """GitHub Releases 网页直链（latest/download 或 tag/download）。"""
+    owner_part, _, name_part = (repo or "").strip().partition("/")
+    if not owner_part or not name_part:
+        msg = f"无效的 GitHub 仓库名: {repo!r}，应为 Owner/Repo"
+        raise ValueError(msg)
+    encoded = quote((asset_name or "").strip(), safe=".")
+    if not encoded:
+        raise ValueError("发布资产名不能为空")
+    if not (tag or "").strip():
+        return f"https://github.com/{owner_part}/{name_part}/releases/latest/download/{encoded}"
+    return f"https://github.com/{owner_part}/{name_part}/releases/download/{(tag or '').strip()}/{encoded}"
+
+
+def github_release_asset_url_candidates(repo: str, asset_name: str, tag: str = "") -> list[str]:
+    """返回可尝试的下载地址：优先固定 tag，其次 latest。"""
+    out: list[str] = []
+    tag_clean = (tag or "").strip()
+    if tag_clean:
+        out.append(github_release_asset_url(repo, asset_name, tag_clean))
+    out.append(github_release_asset_url(repo, asset_name, ""))
+    dedup: list[str] = []
+    seen: set[str] = set()
+    for u in out:
+        if u in seen:
+            continue
+        seen.add(u)
+        dedup.append(u)
+    return dedup
+
+
+def release_tag_from_github_final_url(url: str) -> str:
+    """从跳转后的 GitHub releases 页 URL 解析 tag（``…/releases/tag/{tag}``）。"""
+    segments = [s for s in urlparse(url).path.split("/") if s]
+    for i, seg in enumerate(segments):
+        if seg == "tag" and i + 1 < len(segments):
+            return unquote(segments[i + 1])
+    return ""
+
+
+async def fetch_latest_release_tag_via_github_web(
+    repo: str,
+    *,
+    token: str = "",
+    user_agent: str = "Pallas-Bot/1.0",
+    client_timeout: httpx.Timeout | None = None,
+) -> dict[str, str]:
+    """GET ``github.com/{owner}/{repo}/releases/latest`` 并跟随跳转，解析当前最新 tag。"""
+    owner_part, _, name_part = (repo or "").strip().partition("/")
+    if not owner_part or not name_part:
+        msg = f"无效的 GitHub 仓库名: {repo!r}，应为 Owner/Repo"
+        raise ValueError(msg)
+    page_url = f"https://github.com/{owner_part}/{name_part}/releases/latest"
+    eff_timeout = client_timeout or httpx.Timeout(15.0, connect=8.0)
+    headers: dict[str, str] = {"User-Agent": user_agent}
+    headers.update(github_auth_headers(token))
+    async with httpx.AsyncClient(follow_redirects=True, timeout=eff_timeout, headers=headers) as client:
+        resp = await client.get(page_url)
+        resp.raise_for_status()
+    final_url = str(resp.url)
+    tag = release_tag_from_github_final_url(final_url)
+    if not tag:
+        msg = f"无法从 GitHub 网页解析 release tag: {final_url!r}"
+        raise ValueError(msg)
+    return {"tag": tag, "html_url": final_url}
 
 
 async def fetch_github_releases(
@@ -52,7 +127,7 @@ async def fetch_github_releases(
     if not owner or not name:
         return []
     api_url = f"https://api.github.com/repos/{owner}/{name}/releases?per_page={limit}"
-    auth_headers = _github_auth_headers(token)
+    auth_headers = github_auth_headers(token)
     try:
         resp = await client.get(api_url, headers=auth_headers)
     except Exception:  # noqa: BLE001
@@ -90,15 +165,19 @@ async def fetch_latest_release(
     *,
     user_agent: str = "Pallas-Bot/1.0",
     token: str = "",
+    preferred_asset_name: str | None = None,
+    include_asset_url: bool = True,
 ) -> dict[str, Any]:
     """获取指定仓库最新 release 的摘要信息。
 
-    返回 ``{tag, html_url, asset_url}``，其中 ``asset_url`` 为第一个
-    ``.zip`` 资产的下载地址（不存在时为空字符串）。
+    返回 ``{tag, html_url, asset_url}``。``asset_url``：
+
+    - ``include_asset_url=False`` 时恒为空（适合仅需对比 tag 的场景）。
+    - 否则优先匹配 ``preferred_asset_name``（忽略大小写），否则取第一个 ``.zip`` 资产。
     """
     api_url = github_release_api_url(repo)
     headers: dict[str, str] = {"User-Agent": user_agent}
-    headers.update(_github_auth_headers(token))
+    headers.update(github_auth_headers(token))
     async with httpx.AsyncClient(
         follow_redirects=True,
         timeout=httpx.Timeout(15.0, connect=8.0),
@@ -109,10 +188,21 @@ async def fetch_latest_release(
         data = resp.json()
     tag = str(data.get("tag_name") or "").strip()
     html_url = str(data.get("html_url") or "").strip()
-    assets = data.get("assets") or []
     asset_url = ""
-    for item in assets:
-        if isinstance(item, dict) and str(item.get("name", "")).lower().endswith(".zip"):
-            asset_url = str(item.get("browser_download_url", "")).strip()
-            break
+    if include_asset_url:
+        assets = data.get("assets") or []
+        pref = (preferred_asset_name or "").strip().lower()
+        if pref:
+            for item in assets:
+                if not isinstance(item, dict):
+                    continue
+                name = str(item.get("name", "")).strip()
+                if name.lower() == pref:
+                    asset_url = str(item.get("browser_download_url", "") or "").strip()
+                    break
+        if not asset_url:
+            for item in assets:
+                if isinstance(item, dict) and str(item.get("name", "")).lower().endswith(".zip"):
+                    asset_url = str(item.get("browser_download_url", "") or "").strip()
+                    break
     return {"tag": tag, "html_url": html_url, "asset_url": asset_url}

--- a/src/common/utils/stream_download.py
+++ b/src/common/utils/stream_download.py
@@ -14,6 +14,13 @@ DEFAULT_PROGRESS_BYTES_STEP = 5 * 1024 * 1024
 DEFAULT_STREAM_DOWNLOAD_TIMEOUT = httpx.Timeout(300.0, connect=60.0)
 
 
+def _unlink_quiet(path: Path) -> None:
+    try:
+        path.unlink()
+    except OSError:
+        pass
+
+
 class StreamDownloadProgressPercent(TypedDict):
     event: Literal["percent"]
     milestone_percent: int
@@ -70,41 +77,51 @@ def sync_stream_download_to_file(
     received = 0
     last_pct_logged = 0
     next_bytes_log = progress_bytes_step
+    part = dest.with_name(dest.name + ".download")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    _unlink_quiet(part)
 
-    with httpx.Client(follow_redirects=follow_redirects, timeout=eff_timeout, headers=hdrs) as client:
-        with client.stream("GET", url) as resp:
-            resp.raise_for_status()
-            raw_len = resp.headers.get("content-length")
-            total: int | None = int(raw_len) if raw_len and raw_len.isdigit() else None
+    try:
+        with httpx.Client(follow_redirects=follow_redirects, timeout=eff_timeout, headers=hdrs) as client:
+            with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                raw_len = resp.headers.get("content-length")
+                total: int | None = int(raw_len) if raw_len and raw_len.isdigit() else None
 
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            with dest.open("wb") as out:
-                for chunk in resp.iter_bytes(chunk_size=chunk_size):
-                    if not chunk:
-                        continue
-                    out.write(chunk)
-                    received += len(chunk)
-                    if on_progress is None:
-                        continue
-                    if total and total > 0:
-                        pct_now = min(100, int(received * 100 / total))
-                        while last_pct_logged + progress_percent_step <= pct_now:
-                            last_pct_logged += progress_percent_step
-                            if last_pct_logged >= 100:
-                                break
-                            on_progress(
-                                {
-                                    "event": "percent",
-                                    "milestone_percent": last_pct_logged,
-                                    "received": received,
-                                    "total": total,
-                                },
-                            )
-                    elif received >= next_bytes_log:
-                        on_progress({"event": "unknown_step", "received": received})
-                        next_bytes_log = received + progress_bytes_step
+                with part.open("wb") as out:
+                    for chunk in resp.iter_bytes(chunk_size=chunk_size):
+                        if not chunk:
+                            continue
+                        out.write(chunk)
+                        received += len(chunk)
+                        if on_progress is None:
+                            continue
+                        if total and total > 0:
+                            pct_now = min(100, int(received * 100 / total))
+                            while last_pct_logged + progress_percent_step <= pct_now:
+                                last_pct_logged += progress_percent_step
+                                if last_pct_logged >= 100:
+                                    break
+                                on_progress(
+                                    {
+                                        "event": "percent",
+                                        "milestone_percent": last_pct_logged,
+                                        "received": received,
+                                        "total": total,
+                                    },
+                                )
+                        elif received >= next_bytes_log:
+                            on_progress({"event": "unknown_step", "received": received})
+                            next_bytes_log = received + progress_bytes_step
 
-            if on_progress is not None:
-                on_progress({"event": "complete", "received": received, "total": total})
+        dest.unlink(missing_ok=True)
+        part.replace(dest)
+
+        if on_progress is not None:
+            on_progress({"event": "complete", "received": received, "total": total})
+
+    except BaseException:
+        _unlink_quiet(part)
+        raise
 
     return received

--- a/src/common/utils/stream_download.py
+++ b/src/common/utils/stream_download.py
@@ -1,0 +1,110 @@
+"""HTTP 流式下载与进度回调（同步 Client，供 asyncio.to_thread 或非异步场景复用）。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable  # noqa: TC003
+from pathlib import Path  # noqa: TC003
+from typing import Literal, TypedDict
+
+import httpx
+
+DEFAULT_STREAM_DOWNLOAD_CHUNK = 256 * 1024
+DEFAULT_PROGRESS_PERCENT_STEP = 10
+DEFAULT_PROGRESS_BYTES_STEP = 5 * 1024 * 1024
+DEFAULT_STREAM_DOWNLOAD_TIMEOUT = httpx.Timeout(300.0, connect=60.0)
+
+
+class StreamDownloadProgressPercent(TypedDict):
+    event: Literal["percent"]
+    milestone_percent: int
+    received: int
+    total: int
+
+
+class StreamDownloadProgressUnknownStep(TypedDict):
+    event: Literal["unknown_step"]
+    received: int
+
+
+class StreamDownloadProgressComplete(TypedDict):
+    event: Literal["complete"]
+    received: int
+    total: int | None
+
+
+StreamDownloadProgress = (
+    StreamDownloadProgressPercent | StreamDownloadProgressUnknownStep | StreamDownloadProgressComplete
+)
+
+
+def format_download_byte_size(num_bytes: int) -> str:
+    """人类可读的字节大小（B / KiB / MiB）。"""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    if num_bytes < 1024 * 1024:
+        return f"{num_bytes / 1024:.1f} KiB"
+    return f"{num_bytes / (1024 * 1024):.1f} MiB"
+
+
+def sync_stream_download_to_file(
+    url: str,
+    dest: Path,
+    *,
+    follow_redirects: bool = True,
+    timeout: httpx.Timeout | None = None,
+    chunk_size: int = DEFAULT_STREAM_DOWNLOAD_CHUNK,
+    headers: dict[str, str] | None = None,
+    progress_percent_step: int = DEFAULT_PROGRESS_PERCENT_STEP,
+    progress_bytes_step: int = DEFAULT_PROGRESS_BYTES_STEP,
+    on_progress: Callable[[StreamDownloadProgress], None] | None = None,
+) -> int:
+    """同步流式 GET 写入 ``dest``；返回写入字节数。
+
+    - 有 ``Content-Length``：按 ``progress_percent_step`` 汇报百分比里程碑
+      （不含 100% 里程碑，由 ``complete`` 事件收尾）。
+    - 否则按 ``progress_bytes_step`` 汇报已下载量。
+    """
+    eff_timeout = timeout or DEFAULT_STREAM_DOWNLOAD_TIMEOUT
+    hdrs = dict(headers) if headers else {}
+
+    received = 0
+    last_pct_logged = 0
+    next_bytes_log = progress_bytes_step
+
+    with httpx.Client(follow_redirects=follow_redirects, timeout=eff_timeout, headers=hdrs) as client:
+        with client.stream("GET", url) as resp:
+            resp.raise_for_status()
+            raw_len = resp.headers.get("content-length")
+            total: int | None = int(raw_len) if raw_len and raw_len.isdigit() else None
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with dest.open("wb") as out:
+                for chunk in resp.iter_bytes(chunk_size=chunk_size):
+                    if not chunk:
+                        continue
+                    out.write(chunk)
+                    received += len(chunk)
+                    if on_progress is None:
+                        continue
+                    if total and total > 0:
+                        pct_now = min(100, int(received * 100 / total))
+                        while last_pct_logged + progress_percent_step <= pct_now:
+                            last_pct_logged += progress_percent_step
+                            if last_pct_logged >= 100:
+                                break
+                            on_progress(
+                                {
+                                    "event": "percent",
+                                    "milestone_percent": last_pct_logged,
+                                    "received": received,
+                                    "total": total,
+                                },
+                            )
+                    elif received >= next_bytes_log:
+                        on_progress({"event": "unknown_step", "received": received})
+                        next_bytes_log = received + progress_bytes_step
+
+            if on_progress is not None:
+                on_progress({"event": "complete", "received": received, "total": total})
+
+    return received

--- a/src/plugins/pallas_protocol/runtime/installer.py
+++ b/src/plugins/pallas_protocol/runtime/installer.py
@@ -468,6 +468,8 @@ class NapCatRuntimeStore:
                 f"下载中 {ev['milestone_percent']}% "
                 f"({format_download_byte_size(ev['received'])}/{format_download_byte_size(ev['total'])})",
             )
+        elif ev["event"] == "complete":
+            self._set_job("downloading", "下载完成，准备解压…")
         elif ev["event"] == "unknown_step":
             self._set_job(
                 "downloading",

--- a/src/plugins/pallas_protocol/runtime/installer.py
+++ b/src/plugins/pallas_protocol/runtime/installer.py
@@ -17,27 +17,26 @@ from datetime import UTC, datetime
 from pathlib import Path
 from stat import S_IXGRP, S_IXOTH, S_IXUSR
 from typing import Any, Literal
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
 import httpx
 
-from src.common.utils.github_release import fetch_github_releases, github_release_api_url
+from src.common.utils.github_release import (
+    fetch_github_releases,
+    github_auth_headers,
+    github_release_api_url,
+    github_release_asset_url,
+)
+from src.common.utils.stream_download import (
+    StreamDownloadProgress,
+    format_download_byte_size,
+    sync_stream_download_to_file,
+)
 
 JobStatus = Literal["idle", "downloading", "extracting", "installing", "done", "error"]
 
 # 一键安装超时秒数
 _INSTALLER_TIMEOUT_SEC = 7200
-
-
-def _github_release_asset_url(repo: str, asset_name: str, tag: str = "") -> str:
-    owner_part, _, name_part = repo.partition("/")
-    if not owner_part or not name_part:
-        msg = f"无效的 GitHub 仓库名: {repo!r}，应为 Owner/Repo"
-        raise ValueError(msg)
-    encoded = quote(asset_name, safe=".")
-    if not tag.strip():
-        return f"https://github.com/{owner_part}/{name_part}/releases/latest/download/{encoded}"
-    return f"https://github.com/{owner_part}/{name_part}/releases/download/{tag.strip()}/{encoded}"
 
 
 def _looks_like_http_url(value: str) -> bool:
@@ -462,6 +461,19 @@ class NapCatRuntimeStore:
     def _release_tag(self) -> str:
         return str(getattr(self._config, "pallas_protocol_release_tag", "")).strip()
 
+    def _on_stream_download_progress(self, ev: StreamDownloadProgress) -> None:
+        if ev["event"] == "percent":
+            self._set_job(
+                "downloading",
+                f"下载中 {ev['milestone_percent']}% "
+                f"({format_download_byte_size(ev['received'])}/{format_download_byte_size(ev['total'])})",
+            )
+        elif ev["event"] == "unknown_step":
+            self._set_job(
+                "downloading",
+                f"下载中… ({format_download_byte_size(ev['received'])})",
+            )
+
     async def download_and_install(
         self, *, client: httpx.AsyncClient | None = None, tag: str | None = None, target_platform: str = "auto"
     ) -> RuntimeManifest:
@@ -478,7 +490,7 @@ class NapCatRuntimeStore:
                 raise ValueError(msg)
             self._set_job("downloading", "准备下载…")
             repo = self._repo(target_platform)
-            url = direct_asset_url or _github_release_asset_url(repo, asset_name, release_tag)
+            url = direct_asset_url or github_release_asset_url(repo, asset_name, release_tag)
             self._dist_dir.mkdir(parents=True, exist_ok=True)
             dist_file = self._dist_dir / asset_name
 
@@ -497,9 +509,7 @@ class NapCatRuntimeStore:
                     tag_candidates = [release_tag] if release_tag else [""]
                     if release_tag:
                         tag_candidates.append("")
-                    from src.common.utils.github_release import _github_auth_headers
-
-                    _gh_headers = _github_auth_headers(github_token)
+                    _gh_headers = github_auth_headers(github_token)
                     for repo_try in self._repo_candidates(target_platform):
                         for tag_try in tag_candidates:
                             rel_api = github_release_api_url(repo_try, tag_try)
@@ -528,7 +538,7 @@ class NapCatRuntimeStore:
                         download_candidates.append((
                             repo,
                             asset_name,
-                            _github_release_asset_url(repo, asset_name, release_tag),
+                            github_release_asset_url(repo, asset_name, release_tag),
                         ))
 
                 errors: list[str] = []
@@ -541,31 +551,34 @@ class NapCatRuntimeStore:
                     seen.add(sig)
                     deduped.append(cand)
 
+                download_headers: dict[str, str] = {
+                    "User-Agent": "Pallas-Bot-PallasProtocol/1.0",
+                    **github_auth_headers(github_token),
+                }
+
                 success = False
                 for repo_try, name_try, url_try in deduped:
-                    async with hc.stream("GET", url_try) as resp:
-                        if resp.status_code != 200:
-                            errors.append(f"{name_try} @ {repo_try} -> HTTP {resp.status_code}")
-                            continue
-                        repo = repo_try
-                        asset_name = name_try
-                        url = url_try
-                        dist_file = self._dist_dir / asset_name
-                        success = True
-                        total = int(resp.headers.get("content-length") or 0)
-                        received = 0
-                        with dist_file.open("wb") as out:
-                            async for chunk in resp.aiter_bytes(1024 * 256):
-                                if not chunk:
-                                    continue
-                                out.write(chunk)
-                                received += len(chunk)
-                                if total > 0:
-                                    pct = min(99, int(received * 100 / total))
-                                    self._set_job("downloading", f"下载中 {pct}% ({received // (1024 * 1024)} MiB)")
-                                else:
-                                    self._set_job("downloading", f"下载中… ({received // (1024 * 1024)} MiB)")
-                        break
+                    cand_dist = self._dist_dir / name_try
+                    try:
+                        await asyncio.to_thread(
+                            sync_stream_download_to_file,
+                            url_try,
+                            cand_dist,
+                            follow_redirects=True,
+                            timeout=httpx.Timeout(600.0, connect=30.0),
+                            headers=download_headers,
+                            on_progress=self._on_stream_download_progress,
+                        )
+                    except httpx.HTTPStatusError as e:
+                        code = e.response.status_code if e.response is not None else "?"
+                        errors.append(f"{name_try} @ {repo_try} -> HTTP {code}")
+                        continue
+                    repo = repo_try
+                    asset_name = name_try
+                    url = url_try
+                    dist_file = cand_dist
+                    success = True
+                    break
                 if not success:
                     msg = f"下载失败，候选均不可用: {' | '.join(errors)}"
                     raise RuntimeError(msg)
@@ -722,7 +735,7 @@ class NapCatRuntimeStore:
                 )
             if program_dir is None:
                 continue
-            url = _github_release_asset_url(self._repo(), self._asset_name(), self._release_tag())
+            url = github_release_asset_url(self._repo(), self._asset_name(), self._release_tag())
             manifest = RuntimeManifest(
                 program_dir=str(program_dir.resolve()),
                 extract_root=str(folder.resolve()),

--- a/src/plugins/pallas_webui/__init__.py
+++ b/src/plugins/pallas_webui/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 from nonebot import get_app, get_driver, get_plugin_config, logger
 from nonebot.plugin import PluginMetadata
 
+from src.common.utils.format_exception import format_exception_for_log
 from src.common.web import public_base_url
 
 from .api import register_api
@@ -14,7 +15,6 @@ from .manager import (
     download_and_extract_dist_zip,
     fetch_latest_bot_release,
     fetch_latest_webui_release,
-    format_exception_for_log,
     get_bot_current_version,
     get_installed_webui_version,
     get_webui_dist_version,
@@ -127,12 +127,11 @@ async def _pallas_webui_startup() -> None:
     async def _bootstrap_webui_dist() -> None:
         if check_webui_exists(public):
             return
-        logger.info(
-            "Pallas 控制台: 首次部署，后台拉取 WebUI 静态资源；就绪后请刷新控制台"
-        )
+        logger.info("Pallas 控制台: 首次部署，后台拉取 WebUI 静态资源；就绪后请刷新控制台")
         tok = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
         url = (plugin_config.pallas_webui_dist_zip_url or "").strip()
         url_candidates: list[str] = []
+        resolve_err = ""
         if not url:
             try:
                 repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "")
@@ -144,15 +143,22 @@ async def _pallas_webui_startup() -> None:
                     str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or ""),
                     str(getattr(plugin_config, "pallas_webui_dist_zip_tag", "") or ""),
                 )
-            except Exception:
+            except Exception as e:
+                resolve_err = format_exception_for_log(e)
                 url = ""
                 url_candidates = []
         else:
             url_candidates = [url]
         if not url:
-            logger.error(
-                "Pallas 控制台: 无法解析 WebUI 下载地址，请配置 dist zip 直链或手动放置构建产物到 data/pallas_webui/public"
-            )
+            if resolve_err:
+                logger.error(
+                    "Pallas 控制台: 无法解析 WebUI 下载地址（{}），请配置 dist zip 直链或手动放置构建产物到 data/pallas_webui/public",
+                    resolve_err,
+                )
+            else:
+                logger.error(
+                    "Pallas 控制台: 无法解析 WebUI 下载地址，请配置 dist zip 直链或手动放置构建产物到 data/pallas_webui/public"
+                )
             return
         errors: list[str] = []
         succeeded_url = ""
@@ -225,6 +231,12 @@ async def _pallas_webui_startup() -> None:
         except Exception as e:
             logger.debug("Pallas 控制台: 检查 Bot 更新失败: {}", format_exception_for_log(e))
 
+    async def _guarded(name: str, fn):
+        try:
+            await fn()
+        except Exception as e:
+            logger.error("Pallas 控制台: 后台任务「{}」异常: {}", name, format_exception_for_log(e))
+
     if not check_webui_exists(public):
-        asyncio.create_task(_bootstrap_webui_dist())
-    asyncio.create_task(_background_release_checks())
+        asyncio.create_task(_guarded("webui-dist-bootstrap", _bootstrap_webui_dist))
+    asyncio.create_task(_guarded("release-version-check", _background_release_checks))

--- a/src/plugins/pallas_webui/__init__.py
+++ b/src/plugins/pallas_webui/__init__.py
@@ -1,4 +1,6 @@
 # ruff: noqa: E501
+import asyncio
+
 from nonebot import get_app, get_driver, get_plugin_config, logger
 from nonebot.plugin import PluginMetadata
 
@@ -12,6 +14,7 @@ from .manager import (
     download_and_extract_dist_zip,
     fetch_latest_bot_release,
     fetch_latest_webui_release,
+    format_exception_for_log,
     get_bot_current_version,
     get_installed_webui_version,
     get_webui_dist_version,
@@ -95,53 +98,6 @@ async def _pallas_webui_startup() -> None:
             "请在 .env 中设置 PALLAS_WEBUI_API_TOKEN 后重启"
         )
     public = webui_public_path()
-    url = (plugin_config.pallas_webui_dist_zip_url or "").strip()
-    url_candidates: list[str] = []
-    github_token = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
-    if not url:
-        # 自动解析发布资产下载地址
-        try:
-            repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "")
-            asset = str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or "")
-            tag = str(getattr(plugin_config, "pallas_webui_dist_zip_tag", "") or "")
-            url_candidates = await resolve_github_release_asset_urls(repo, asset, tag, token=github_token)
-            url = github_release_asset_url(
-                str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or ""),
-                str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or ""),
-                str(getattr(plugin_config, "pallas_webui_dist_zip_tag", "") or ""),
-            )
-        except Exception:
-            url = ""
-            url_candidates = []
-    elif url:
-        url_candidates = [url]
-    if url and not check_webui_exists(public):
-        errors: list[str] = []
-        succeeded_url = ""
-        for candidate in url_candidates or [url]:
-            try:
-                await download_and_extract_dist_zip(public, candidate)
-                succeeded_url = candidate
-                errors.clear()
-                break
-            except Exception as e:
-                errors.append(f"{candidate} -> {e}")
-        if errors:
-            logger.error("Pallas 控制台: 下载或解压 dist zip 失败，已尝试: {}", " | ".join(errors))
-        elif succeeded_url:
-            # 记录已安装版本
-            try:
-                tag = str(getattr(plugin_config, "pallas_webui_dist_zip_tag", "") or "").strip()
-                if not tag:
-                    try:
-                        repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "")
-                        info = await fetch_latest_webui_release(repo, token=github_token)
-                        tag = info.get("tag", "")
-                    except Exception:
-                        tag = ""
-                save_installed_webui_version(tag, succeeded_url)
-            except Exception:
-                pass
     base = (plugin_config.pallas_webui_http_base or "/pallas").strip()
     if not base.startswith("/"):
         base = "/" + base
@@ -167,41 +123,108 @@ async def _pallas_webui_startup() -> None:
         port=getattr(dconf, "port", None),
     )
     logger.info(f"Pallas 控制台 | WebUI={open_base}{base}/")
-    # 启动时检查 WebUI 更新
-    try:
-        repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "PallasBot/Pallas-Bot-WebUI")
-        installed = get_installed_webui_version()
-        current_tag = str(installed.get("tag", "") or "").strip()
-        latest_info = await fetch_latest_webui_release(repo, token=github_token)
-        latest_tag = str(latest_info.get("tag", "") or "").strip()
-        if latest_tag and current_tag != latest_tag:
-            release_url = str(latest_info.get("html_url", "") or "").strip()
-            logger.info(
-                f"Pallas 控制台: 发现新版本 WebUI {latest_tag}（当前: {current_tag or '未知'}）"
-                + (f" → {release_url}" if release_url else "")
-                + "，可在控制台更新页面一键更新"
-            )
+
+    async def _bootstrap_webui_dist() -> None:
+        if check_webui_exists(public):
+            return
+        logger.info(
+            "Pallas 控制台: 首次部署，后台拉取 WebUI 静态资源；就绪后请刷新控制台"
+        )
+        tok = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
+        url = (plugin_config.pallas_webui_dist_zip_url or "").strip()
+        url_candidates: list[str] = []
+        if not url:
+            try:
+                repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "")
+                asset = str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or "")
+                tag = str(getattr(plugin_config, "pallas_webui_dist_zip_tag", "") or "")
+                url_candidates = await resolve_github_release_asset_urls(repo, asset, tag, token=tok)
+                url = github_release_asset_url(
+                    str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or ""),
+                    str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or ""),
+                    str(getattr(plugin_config, "pallas_webui_dist_zip_tag", "") or ""),
+                )
+            except Exception:
+                url = ""
+                url_candidates = []
         else:
-            logger.info(f"Pallas 控制台: WebUI 已是最新版本（{current_tag or '未知'}）")
-    except Exception as _upd_err:
-        logger.debug(f"Pallas 控制台: 检查 WebUI 更新失败: {_upd_err}")
-    # 启动时检查 Bot 更新
-    try:
-        bot_current = get_bot_current_version()
-        bot_current_tag = bot_current.get("tag", "")
-        bot_current_commit = bot_current.get("commit", "")
-        bot_latest_info = await fetch_latest_bot_release("PallasBot/Pallas-Bot", token=github_token)
-        bot_latest_tag = str(bot_latest_info.get("tag", "") or "").strip()
-        if bot_latest_tag and bot_current_tag and bot_current_tag != bot_latest_tag:
-            bot_release_url = str(bot_latest_info.get("html_url", "") or "").strip()
-            logger.info(
-                f"Pallas 控制台: 发现新版本 Bot {bot_latest_tag}（当前: {bot_current_tag}）"
-                + (f" → {bot_release_url}" if bot_release_url else "")
-                + "，可在控制台查看更新"
+            url_candidates = [url]
+        if not url:
+            logger.error(
+                "Pallas 控制台: 无法解析 WebUI 下载地址，请配置 dist zip 直链或手动放置构建产物到 data/pallas_webui/public"
             )
-        elif bot_current_tag:
-            logger.info(f"Pallas 控制台: Bot 已是最新版本（{bot_current_tag}）")
-        else:
-            logger.info(f"Pallas 控制台: Bot under development,commit={bot_current_commit or '未知'}")
-    except Exception as _bot_upd_err:
-        logger.debug(f"Pallas 控制台: 检查 Bot 更新失败: {_bot_upd_err}")
+            return
+        errors: list[str] = []
+        succeeded_url = ""
+        for candidate in url_candidates or [url]:
+            try:
+                await download_and_extract_dist_zip(public, candidate)
+                succeeded_url = candidate
+                errors.clear()
+                break
+            except Exception as e:
+                err_msg = format_exception_for_log(e)
+                errors.append(f"{candidate} -> {err_msg}")
+        if errors:
+            logger.error("Pallas 控制台: 下载或解压 dist zip 失败，已尝试: {}", " | ".join(errors))
+        elif succeeded_url:
+            try:
+                tag = str(getattr(plugin_config, "pallas_webui_dist_zip_tag", "") or "").strip()
+                if not tag:
+                    try:
+                        repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "")
+                        asset_fb = str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or "dist.zip")
+                        info = await fetch_latest_webui_release(repo, token=tok, asset_name=asset_fb)
+                        tag = info.get("tag", "")
+                    except Exception:
+                        tag = ""
+                save_installed_webui_version(tag, succeeded_url)
+            except Exception:
+                pass
+            logger.info("Pallas 控制台: WebUI 静态资源后台部署完成，请刷新控制台页面")
+        webui_ver = get_webui_dist_version() or get_installed_webui_version().get("tag", "")
+        set_console_meta({"static_root": str(public), "http_base": base, "version": webui_ver})
+
+    async def _background_release_checks() -> None:
+        tok = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
+        try:
+            repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "PallasBot/Pallas-Bot-WebUI")
+            asset_chk = str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or "dist.zip")
+            installed = get_installed_webui_version()
+            current_tag = str(installed.get("tag", "") or "").strip()
+            latest_info = await fetch_latest_webui_release(repo, token=tok, asset_name=asset_chk)
+            latest_tag = str(latest_info.get("tag", "") or "").strip()
+            if latest_tag and current_tag != latest_tag:
+                release_url = str(latest_info.get("html_url", "") or "").strip()
+                logger.info(
+                    f"Pallas 控制台: 发现新版本 WebUI {latest_tag}（当前: {current_tag or '未知'}）"
+                    + (f" → {release_url}" if release_url else "")
+                    + "，可在控制台更新页面一键更新"
+                )
+            else:
+                logger.info(f"Pallas 控制台: WebUI 已是最新版本（{current_tag or '未知'}）")
+        except Exception as e:
+            logger.debug("Pallas 控制台: 检查 WebUI 更新失败: {}", format_exception_for_log(e))
+        try:
+            bot_current = get_bot_current_version()
+            bot_current_tag = bot_current.get("tag", "")
+            bot_current_commit = bot_current.get("commit", "")
+            bot_latest_info = await fetch_latest_bot_release("PallasBot/Pallas-Bot", token=tok)
+            bot_latest_tag = str(bot_latest_info.get("tag", "") or "").strip()
+            if bot_latest_tag and bot_current_tag and bot_current_tag != bot_latest_tag:
+                bot_release_url = str(bot_latest_info.get("html_url", "") or "").strip()
+                logger.info(
+                    f"Pallas 控制台: 发现新版本 Bot {bot_latest_tag}（当前: {bot_current_tag}）"
+                    + (f" → {bot_release_url}" if bot_release_url else "")
+                    + "，可在控制台查看更新"
+                )
+            elif bot_current_tag:
+                logger.info(f"Pallas 控制台: Bot 已是最新版本（{bot_current_tag}）")
+            else:
+                logger.info(f"Pallas 控制台: Bot under development,commit={bot_current_commit or '未知'}")
+        except Exception as e:
+            logger.debug("Pallas 控制台: 检查 Bot 更新失败: {}", format_exception_for_log(e))
+
+    if not check_webui_exists(public):
+        asyncio.create_task(_bootstrap_webui_dist())
+    asyncio.create_task(_background_release_checks())

--- a/src/plugins/pallas_webui/extended_api.py
+++ b/src/plugins/pallas_webui/extended_api.py
@@ -2222,18 +2222,21 @@ def register_extended_api(
 
     @router.get(f"{x}/update/check", include_in_schema=True)
     async def _update_check() -> JSONResponse:
-        from .manager import fetch_latest_webui_release, get_installed_webui_version
+        from .manager import fetch_latest_webui_release, format_exception_for_log, get_installed_webui_version
 
         repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "PallasBot/Pallas-Bot-WebUI")
+        asset = str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or "dist.zip")
         github_token = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
         installed = get_installed_webui_version()
         current_tag = str(installed.get("tag", "") or "").strip()
         try:
-            latest = await fetch_latest_webui_release(repo, token=github_token)
+            latest = await fetch_latest_webui_release(repo, token=github_token, asset_name=asset)
             latest_tag = str(latest.get("tag", "") or "").strip()
             release_url = str(latest.get("html_url", "") or "").strip()
             asset_url = str(latest.get("asset_url", "") or "").strip()
         except Exception as e:  # noqa: BLE001
+            err_msg = format_exception_for_log(e)
+            logger.warning("Pallas 控制台: WebUI 更新检查失败（GitHub），repo={} err={}", repo, err_msg)
             return JSONResponse({
                 "ok": True,
                 "data": {
@@ -2242,7 +2245,7 @@ def register_extended_api(
                     "has_update": False,
                     "release_url": "",
                     "asset_url": "",
-                    "error": str(e),
+                    "error": err_msg,
                     "checked_at": time.time(),
                 },
             })
@@ -2262,7 +2265,7 @@ def register_extended_api(
 
     @router.get(f"{x}/update/bot/check", include_in_schema=True)
     async def _bot_update_check() -> JSONResponse:
-        from .manager import fetch_latest_bot_release, get_bot_current_version
+        from .manager import fetch_latest_bot_release, format_exception_for_log, get_bot_current_version
 
         github_token = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
         current = get_bot_current_version()
@@ -2273,6 +2276,8 @@ def register_extended_api(
             latest_tag = str(latest.get("tag", "") or "").strip()
             release_url = str(latest.get("html_url", "") or "").strip()
         except Exception as e:  # noqa: BLE001
+            err_msg = format_exception_for_log(e)
+            logger.warning("Pallas 控制台: Bot 版本更新检查失败（GitHub） err={}", err_msg)
             return JSONResponse({
                 "ok": True,
                 "data": {
@@ -2281,7 +2286,7 @@ def register_extended_api(
                     "latest_tag": None,
                     "has_update": False,
                     "release_url": "",
-                    "error": str(e),
+                    "error": err_msg,
                     "checked_at": time.time(),
                 },
             })
@@ -2308,6 +2313,7 @@ def register_extended_api(
         from .manager import (
             download_and_extract_dist_zip,
             fetch_latest_webui_release,
+            format_exception_for_log,
             get_webui_dist_version,
             resolve_github_release_asset_urls,
             save_installed_webui_version,
@@ -2320,25 +2326,42 @@ def register_extended_api(
         github_token = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
         public = webui_public_path()
         try:
+            logger.info(
+                "Pallas 控制台: WebUI 在线更新开始 repo={} asset={} tag={}",
+                repo,
+                asset,
+                tag or "(latest)",
+            )
             url_candidates = await resolve_github_release_asset_urls(repo, asset, tag, token=github_token)
             if not url_candidates:
+                logger.warning("Pallas 控制台: WebUI 更新未得到任何下载 URL（resolve 为空）")
                 raise ValueError("未找到可用的下载地址")
+            logger.info("Pallas 控制台: WebUI 更新候选地址 {} 条", len(url_candidates))
             errors: list[str] = []
             succeeded_url = ""
-            for candidate in url_candidates:
+            for i, candidate in enumerate(url_candidates, start=1):
+                short = candidate if len(candidate) <= 160 else candidate[:157] + "..."
+                logger.info("Pallas 控制台: WebUI 更新尝试 {}/{} {}", i, len(url_candidates), short)
                 try:
                     await download_and_extract_dist_zip(public, candidate)
                     succeeded_url = candidate
                     errors.clear()
                     break
                 except Exception as e:  # noqa: BLE001
-                    errors.append(f"{candidate} -> {e}")
+                    err_msg = format_exception_for_log(e)
+                    errors.append(f"{candidate} -> {err_msg}")
+                    logger.warning("Pallas 控制台: WebUI 下载/解压失败 {}", err_msg)
             if errors:
                 raise ValueError("下载失败: " + " | ".join(errors))
             try:
-                info = await fetch_latest_webui_release(repo, token=github_token)
+                info = await fetch_latest_webui_release(repo, token=github_token, asset_name=asset)
                 new_tag = str(info.get("tag", "") or tag).strip()
-            except Exception:  # noqa: BLE001
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Pallas 控制台: 获取 WebUI release 元数据失败，使用配置 tag={} err={}",
+                    tag or "(空)",
+                    format_exception_for_log(e),
+                )
                 new_tag = tag
             save_installed_webui_version(new_tag, succeeded_url)
             # 更新成功后同步刷新内存里的 console 版本，避免必须重启后前端才显示新版本。
@@ -2361,6 +2384,6 @@ def register_extended_api(
             raise
         except Exception as e:  # noqa: BLE001
             logger.exception("Pallas 控制台: WebUI 更新失败")
-            raise HTTPException(status_code=500, detail=str(e)) from e
+            raise HTTPException(status_code=500, detail=format_exception_for_log(e)) from e
 
     app.include_router(router)

--- a/src/plugins/pallas_webui/extended_api.py
+++ b/src/plugins/pallas_webui/extended_api.py
@@ -2222,7 +2222,9 @@ def register_extended_api(
 
     @router.get(f"{x}/update/check", include_in_schema=True)
     async def _update_check() -> JSONResponse:
-        from .manager import fetch_latest_webui_release, format_exception_for_log, get_installed_webui_version
+        from src.common.utils.format_exception import format_exception_for_log
+
+        from .manager import fetch_latest_webui_release, get_installed_webui_version
 
         repo = str(getattr(plugin_config, "pallas_webui_dist_zip_repo", "") or "PallasBot/Pallas-Bot-WebUI")
         asset = str(getattr(plugin_config, "pallas_webui_dist_zip_asset", "") or "dist.zip")
@@ -2265,7 +2267,9 @@ def register_extended_api(
 
     @router.get(f"{x}/update/bot/check", include_in_schema=True)
     async def _bot_update_check() -> JSONResponse:
-        from .manager import fetch_latest_bot_release, format_exception_for_log, get_bot_current_version
+        from src.common.utils.format_exception import format_exception_for_log
+
+        from .manager import fetch_latest_bot_release, get_bot_current_version
 
         github_token = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
         current = get_bot_current_version()
@@ -2310,10 +2314,11 @@ def register_extended_api(
         x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
     ) -> JSONResponse:
         _check_pallas_write_token(plugin_config, x_pallas_token=x_pallas_token, token=token)
+        from src.common.utils.format_exception import format_exception_for_log
+
         from .manager import (
             download_and_extract_dist_zip,
             fetch_latest_webui_release,
-            format_exception_for_log,
             get_webui_dist_version,
             resolve_github_release_asset_urls,
             save_installed_webui_version,

--- a/src/plugins/pallas_webui/manager.py
+++ b/src/plugins/pallas_webui/manager.py
@@ -3,63 +3,56 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import shutil
 import tempfile
 import zipfile
 from pathlib import Path
-from urllib.parse import quote
 
 import httpx
 from nonebot import logger
 
 from src.common.paths import plugin_data_dir
+from src.common.utils.github_release import (
+    fetch_latest_release,
+    fetch_latest_release_tag_via_github_web,
+    github_auth_headers,
+    github_release_api_url,
+    github_release_asset_url,
+    github_release_asset_url_candidates,
+)
+from src.common.utils.stream_download import (
+    StreamDownloadProgress,
+    format_download_byte_size,
+    sync_stream_download_to_file,
+)
 
 
-def _github_auth_headers(token: str = "") -> dict[str, str]:
-    t = (token or "").strip()
-    if not t:
-        return {}
-    return {"Authorization": f"Bearer {t}"}
+def format_exception_for_log(exc: BaseException) -> str:
+    """将异常格式化为单行摘要（日志 / API error 字段）。
 
-
-def github_release_asset_url(repo: str, asset_name: str, tag: str = "") -> str:
-    owner_part, _, name_part = (repo or "").strip().partition("/")
-    if not owner_part or not name_part:
-        msg = f"无效的 GitHub 仓库名: {repo!r}，应为 Owner/Repo"
-        raise ValueError(msg)
-    encoded = quote((asset_name or "").strip(), safe=".")
-    if not encoded:
-        raise ValueError("发布资产名不能为空")
-    if not (tag or "").strip():
-        return f"https://github.com/{owner_part}/{name_part}/releases/latest/download/{encoded}"
-    return f"https://github.com/{owner_part}/{name_part}/releases/download/{(tag or '').strip()}/{encoded}"
-
-
-def github_release_asset_url_candidates(repo: str, asset_name: str, tag: str = "") -> list[str]:
-    """返回可尝试的下载地址：优先 tag，其次 latest。"""
-    out: list[str] = []
-    tag_clean = (tag or "").strip()
-    if tag_clean:
-        out.append(github_release_asset_url(repo, asset_name, tag_clean))
-    out.append(github_release_asset_url(repo, asset_name, ""))
-    dedup: list[str] = []
-    seen: set[str] = set()
-    for u in out:
-        if u in seen:
-            continue
-        seen.add(u)
-        dedup.append(u)
-    return dedup
-
-
-def _github_release_api_url(repo: str, tag: str = "") -> str:
-    owner_part, _, name_part = (repo or "").strip().partition("/")
-    if not owner_part or not name_part:
-        msg = f"无效的 GitHub 仓库名: {repo!r}，应为 Owner/Repo"
-        raise ValueError(msg)
-    if not (tag or "").strip():
-        return f"https://api.github.com/repos/{owner_part}/{name_part}/releases/latest"
-    return f"https://api.github.com/repos/{owner_part}/{name_part}/releases/tags/{(tag or '').strip()}"
+    勿把裸 ``Exception`` 传入 loguru 的「{}」占位：部分环境下会得到空白输出。
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        resp = exc.response
+        url = str(resp.request.url)
+        reason = (getattr(resp, "reason_phrase", None) or "").strip()
+        head = f"{resp.status_code}"
+        if reason:
+            head = f"{head} {reason}"
+        text = (resp.text or "").replace("\r", "").strip().replace("\n", " ")
+        if len(text) > 400:
+            text = text[:397] + "..."
+        return f"HTTPStatusError {head} url={url}" + (f" body={text!r}" if text else "")
+    if isinstance(exc, httpx.RequestError):
+        url = str(exc.request.url) if exc.request is not None else ""
+        suffix = f" url={url}" if url else ""
+        detail = str(exc).strip() or repr(exc)
+        return f"{type(exc).__name__}{suffix}: {detail}"
+    msg = str(exc).strip()
+    if msg:
+        return f"{type(exc).__name__}: {msg}"
+    return f"{type(exc).__name__}: {exc!r}"
 
 
 async def resolve_github_release_asset_urls(
@@ -74,21 +67,32 @@ async def resolve_github_release_asset_urls(
     if not preferred:
         raise ValueError("发布资产名不能为空")
     candidates: list[str] = []
-    release_apis = [_github_release_api_url(repo, tag)]
+    release_apis = [github_release_api_url(repo, tag)]
     if (tag or "").strip():
-        release_apis.append(_github_release_api_url(repo, ""))
+        release_apis.append(github_release_api_url(repo, ""))
     async with httpx.AsyncClient(
         follow_redirects=True,
         timeout=httpx.Timeout(30.0, connect=10.0),
         headers={"User-Agent": "Pallas-Bot-PallasWebUI/1.0"},
     ) as client:
-        auth_headers = _github_auth_headers(token)
+        auth_headers = github_auth_headers(token)
         for api in release_apis:
             try:
                 resp = await client.get(api, headers=auth_headers)
-            except Exception:
+            except Exception as e:
+                # API 失败仍会追加 releases/download 直链候选，默认不打 WARNING 以免刷屏
+                logger.debug(
+                    "Pallas 控制台: GitHub Release API 请求异常（将尝试直链）api={} err={}",
+                    api,
+                    format_exception_for_log(e),
+                )
                 continue
             if resp.status_code != 200:
+                logger.debug(
+                    "Pallas 控制台: GitHub Release API 非 200（将尝试直链）status={} api={}",
+                    resp.status_code,
+                    api,
+                )
                 continue
             data = resp.json()
             assets = data.get("assets")
@@ -164,15 +168,13 @@ def _safe_extract_zip(zf: zipfile.ZipFile, extract_root: Path) -> None:
             shutil.copyfileobj(src, dst)
 
 
-def _sync_write_dist_from_zip_bytes(public_dir: Path, content: bytes) -> None:
+def _sync_extract_dist_zip_file(zip_path: Path, public_dir: Path) -> None:
     public_dir.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory() as tmp:
         tpath = Path(tmp)
-        zip_path = tpath / "webui.zip"
-        zip_path.write_bytes(content)
+        extract_root = tpath / "extracted"
+        extract_root.mkdir()
         with zipfile.ZipFile(zip_path) as zf:
-            extract_root = tpath / "extracted"
-            extract_root.mkdir()
             _safe_extract_zip(zf, extract_root)
         source = _resolved_extract_root(extract_root)
         if public_dir.exists():
@@ -181,16 +183,75 @@ def _sync_write_dist_from_zip_bytes(public_dir: Path, content: bytes) -> None:
         shutil.copytree(source, public_dir, dirs_exist_ok=True)
 
 
+def _sync_write_dist_from_zip_bytes(public_dir: Path, content: bytes) -> None:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as tf:
+        tf.write(content)
+        zip_path = Path(tf.name)
+    try:
+        _sync_extract_dist_zip_file(zip_path, public_dir)
+    finally:
+        zip_path.unlink(missing_ok=True)
+
+
+def _unlink_ignore_missing(path: Path) -> None:
+    path.unlink(missing_ok=True)
+
+
+def _webui_download_progress_log(ev: StreamDownloadProgress) -> None:
+    if ev["event"] == "percent":
+        logger.info(
+            "Pallas 控制台: WebUI dist 下载进度 {}%（{}/{}）",
+            ev["milestone_percent"],
+            format_download_byte_size(ev["received"]),
+            format_download_byte_size(ev["total"]),
+        )
+    elif ev["event"] == "unknown_step":
+        logger.info(
+            "Pallas 控制台: WebUI dist 已下载 {}（服务器未提供文件大小）",
+            format_download_byte_size(ev["received"]),
+        )
+    elif ev["event"] == "complete":
+        if ev["total"] is not None:
+            logger.info(
+                "Pallas 控制台: WebUI dist 下载完成 {} / {}",
+                format_download_byte_size(ev["received"]),
+                format_download_byte_size(ev["total"]),
+            )
+        elif ev["received"] > 0:
+            logger.info(
+                "Pallas 控制台: WebUI dist 下载完成 {}",
+                format_download_byte_size(ev["received"]),
+            )
+
+
+def _sync_download_webui_zip(url: str, dest: Path, *, follow_redirects: bool) -> None:
+    sync_stream_download_to_file(
+        url,
+        dest,
+        follow_redirects=follow_redirects,
+        timeout=httpx.Timeout(300.0, connect=60.0),
+        on_progress=_webui_download_progress_log,
+    )
+
+
 async def download_and_extract_dist_zip(public_dir: Path, url: str, *, follow_redirects: bool = True) -> bool:
     url = (url or "").strip()
     if not url:
         return False
-    async with httpx.AsyncClient(follow_redirects=follow_redirects, timeout=300.0) as c:
-        r = await c.get(url)
-        r.raise_for_status()
-        content = r.content
-    await asyncio.to_thread(_sync_write_dist_from_zip_bytes, public_dir, content)
-    logger.info("Pallas 控制台: 已解压 dist 到 data/pallas_webui/public")
+    preview = url if len(url) <= 200 else url[:197] + "..."
+    logger.info("Pallas 控制台: 正在下载 WebUI dist {}", preview)
+
+    tmp_zip = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+    zip_path = Path(tmp_zip.name)
+    tmp_zip.close()
+
+    try:
+        await asyncio.to_thread(_sync_download_webui_zip, url, zip_path, follow_redirects=follow_redirects)
+        await asyncio.to_thread(_sync_extract_dist_zip_file, zip_path, public_dir)
+        logger.info("Pallas 控制台: 已解压 dist 到 data/pallas_webui/public")
+    finally:
+        await asyncio.to_thread(_unlink_ignore_missing, zip_path)
+
     return True
 
 
@@ -278,36 +339,53 @@ def get_bot_current_version() -> dict:
 
 
 async def fetch_latest_bot_release(repo: str = "PallasBot/Pallas-Bot", *, token: str = "") -> dict:
-    api_url = _github_release_api_url(repo)
-    async with httpx.AsyncClient(
-        follow_redirects=True,
-        timeout=httpx.Timeout(15.0, connect=8.0),
-        headers={"User-Agent": "Pallas-Bot-PallasWebUI/1.0"},
-    ) as client:
-        resp = await client.get(api_url, headers=_github_auth_headers(token))
-        resp.raise_for_status()
-        data = resp.json()
-    tag = str(data.get("tag_name") or "").strip()
-    html_url = str(data.get("html_url") or "").strip()
-    return {"tag": tag, "html_url": html_url}
+    try:
+        data = await fetch_latest_release(
+            repo,
+            user_agent="Pallas-Bot-PallasWebUI/1.0",
+            token=token,
+            include_asset_url=False,
+        )
+        return {"tag": data["tag"], "html_url": data["html_url"]}
+    except (httpx.HTTPError, json.JSONDecodeError, TypeError, ValueError) as first_err:
+        try:
+            fb = await fetch_latest_release_tag_via_github_web(
+                repo,
+                token=token,
+                user_agent="Pallas-Bot-PallasWebUI/1.0",
+            )
+            logger.info(
+                "Pallas 控制台: GitHub Release API 不可用，已用 github.com/releases/latest 兜底 tag={}",
+                fb["tag"],
+            )
+            return {"tag": fb["tag"], "html_url": fb["html_url"]}
+        except Exception:
+            raise first_err from None
 
 
-async def fetch_latest_webui_release(repo: str, *, token: str = "") -> dict:
-    api_url = _github_release_api_url(repo)
-    async with httpx.AsyncClient(
-        follow_redirects=True,
-        timeout=httpx.Timeout(15.0, connect=8.0),
-        headers={"User-Agent": "Pallas-Bot-PallasWebUI/1.0"},
-    ) as client:
-        resp = await client.get(api_url, headers=_github_auth_headers(token))
-        resp.raise_for_status()
-        data = resp.json()
-    tag = str(data.get("tag_name") or "").strip()
-    html_url = str(data.get("html_url") or "").strip()
-    assets = data.get("assets") or []
-    asset_url = ""
-    for item in assets:
-        if isinstance(item, dict) and str(item.get("name", "")).lower().endswith(".zip"):
-            asset_url = str(item.get("browser_download_url", "")).strip()
-            break
-    return {"tag": tag, "html_url": html_url, "asset_url": asset_url}
+async def fetch_latest_webui_release(repo: str, *, token: str = "", asset_name: str = "dist.zip") -> dict:
+    asset_clean = (asset_name or "").strip() or "dist.zip"
+    try:
+        return await fetch_latest_release(
+            repo,
+            user_agent="Pallas-Bot-PallasWebUI/1.0",
+            token=token,
+            preferred_asset_name=asset_clean,
+            include_asset_url=True,
+        )
+    except (httpx.HTTPError, json.JSONDecodeError, TypeError, ValueError) as first_err:
+        try:
+            fb = await fetch_latest_release_tag_via_github_web(
+                repo,
+                token=token,
+                user_agent="Pallas-Bot-PallasWebUI/1.0",
+            )
+            tag_fb = fb["tag"]
+            asset_url_fb = github_release_asset_url(repo, asset_clean, tag_fb)
+            logger.info(
+                "Pallas 控制台: GitHub Release API 不可用，已用 github.com/releases/latest 兜底 tag={}",
+                tag_fb,
+            )
+            return {"tag": tag_fb, "html_url": fb["html_url"], "asset_url": asset_url_fb}
+        except Exception:
+            raise first_err from None

--- a/src/plugins/pallas_webui/manager.py
+++ b/src/plugins/pallas_webui/manager.py
@@ -13,6 +13,7 @@ import httpx
 from nonebot import logger
 
 from src.common.paths import plugin_data_dir
+from src.common.utils.format_exception import format_exception_for_log
 from src.common.utils.github_release import (
     fetch_latest_release,
     fetch_latest_release_tag_via_github_web,
@@ -26,33 +27,6 @@ from src.common.utils.stream_download import (
     format_download_byte_size,
     sync_stream_download_to_file,
 )
-
-
-def format_exception_for_log(exc: BaseException) -> str:
-    """将异常格式化为单行摘要（日志 / API error 字段）。
-
-    勿把裸 ``Exception`` 传入 loguru 的「{}」占位：部分环境下会得到空白输出。
-    """
-    if isinstance(exc, httpx.HTTPStatusError):
-        resp = exc.response
-        url = str(resp.request.url)
-        reason = (getattr(resp, "reason_phrase", None) or "").strip()
-        head = f"{resp.status_code}"
-        if reason:
-            head = f"{head} {reason}"
-        text = (resp.text or "").replace("\r", "").strip().replace("\n", " ")
-        if len(text) > 400:
-            text = text[:397] + "..."
-        return f"HTTPStatusError {head} url={url}" + (f" body={text!r}" if text else "")
-    if isinstance(exc, httpx.RequestError):
-        url = str(exc.request.url) if exc.request is not None else ""
-        suffix = f" url={url}" if url else ""
-        detail = str(exc).strip() or repr(exc)
-        return f"{type(exc).__name__}{suffix}: {detail}"
-    msg = str(exc).strip()
-    if msg:
-        return f"{type(exc).__name__}: {msg}"
-    return f"{type(exc).__name__}: {exc!r}"
 
 
 async def resolve_github_release_asset_urls(

--- a/tests/common/test_stream_download.py
+++ b/tests/common/test_stream_download.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+from src.common.utils import stream_download
+from src.common.utils.stream_download import format_download_byte_size, sync_stream_download_to_file
+
+
+class _FakeStreamCtx:
+    def __init__(self, chunks: list[bytes], content_length: int | None, *, boom_after_chunks: int | None = None):
+        self.headers: dict[str, str] = {}
+        if content_length is not None:
+            self.headers["content-length"] = str(content_length)
+        self._chunks = chunks
+        self._boom_after_chunks = boom_after_chunks
+
+    def __enter__(self) -> _FakeStreamCtx:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def iter_bytes(self, chunk_size: int = 8192) -> Iterator[bytes]:
+        for i, chunk in enumerate(self._chunks, start=1):
+            yield chunk
+            if self._boom_after_chunks is not None and i >= self._boom_after_chunks:
+                raise RuntimeError("boom")
+
+
+class _FakeHttpClientCtx:
+    def __init__(self, stream: _FakeStreamCtx):
+        self._stream = stream
+
+    def __enter__(self) -> _FakeHttpClientCtx:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def stream(self, _method: str, _url: str, **_kwargs: Any) -> _FakeStreamCtx:
+        return self._stream
+
+
+def _patch_httpx_client(monkeypatch: pytest.MonkeyPatch, stream: _FakeStreamCtx) -> None:
+    def _client_factory(**_kwargs: Any) -> _FakeHttpClientCtx:
+        return _FakeHttpClientCtx(stream)
+
+    monkeypatch.setattr(stream_download.httpx, "Client", _client_factory)
+
+
+def test_sync_stream_download_with_content_length_percent_milestones(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    total_size = 10 * 1024
+    chunk = b"x" * 1024
+    chunks = [chunk] * 10
+    stream = _FakeStreamCtx(chunks, total_size)
+    _patch_httpx_client(monkeypatch, stream)
+
+    events: list[dict[str, Any]] = []
+    dest = tmp_path / "out.bin"
+    sync_stream_download_to_file(
+        "https://example.com/file.bin",
+        dest,
+        progress_percent_step=10,
+        progress_bytes_step=1024,
+        on_progress=lambda ev: events.append(dict(ev)),
+    )
+
+    assert dest.is_file()
+    assert dest.stat().st_size == total_size
+    assert not dest.with_name(dest.name + ".download").exists()
+
+    percent_events = [e for e in events if e["event"] == "percent"]
+    assert [e["milestone_percent"] for e in percent_events] == [10, 20, 30, 40, 50, 60, 70, 80, 90]
+
+    complete_events = [e for e in events if e["event"] == "complete"]
+    assert len(complete_events) == 1
+    assert complete_events[0]["received"] == total_size
+    assert complete_events[0]["total"] == total_size
+
+
+def test_sync_stream_download_without_content_length_unknown_steps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chunk = b"y" * 1024
+    chunks = [chunk] * 5
+    stream = _FakeStreamCtx(chunks, None)
+    _patch_httpx_client(monkeypatch, stream)
+
+    events: list[dict[str, Any]] = []
+    dest = tmp_path / "out.bin"
+    sync_stream_download_to_file(
+        "https://example.com/file.bin",
+        dest,
+        progress_percent_step=10,
+        progress_bytes_step=1024,
+        on_progress=lambda ev: events.append(dict(ev)),
+    )
+
+    assert dest.stat().st_size == 5 * 1024
+    unknown_events = [e for e in events if e["event"] == "unknown_step"]
+    assert [e["received"] for e in unknown_events] == [1024, 2048, 3072, 4096, 5120]
+
+    complete_events = [e for e in events if e["event"] == "complete"]
+    assert len(complete_events) == 1
+    assert complete_events[0]["received"] == 5 * 1024
+    assert complete_events[0]["total"] is None
+
+
+def test_sync_stream_download_failure_removes_partial_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    chunk = b"z" * 1024
+    stream = _FakeStreamCtx([chunk, chunk], content_length=2048, boom_after_chunks=1)
+    _patch_httpx_client(monkeypatch, stream)
+
+    dest = tmp_path / "out.bin"
+    part = dest.with_name(dest.name + ".download")
+    with pytest.raises(RuntimeError, match="boom"):
+        sync_stream_download_to_file("https://example.com/file.bin", dest, on_progress=lambda _ev: None)
+
+    assert not dest.exists()
+    assert not part.exists()
+
+
+@pytest.mark.parametrize(
+    ("num_bytes", "expected_substrings"),
+    [
+        (0, ("0", "B")),
+        (1, ("1", "B")),
+        (1023, ("1023", "B")),
+        (1024, ("1.0", "KiB")),
+        (1536, ("1.5", "KiB")),
+        (1024 * 1024, ("1.0", "MiB")),
+    ],
+)
+def test_format_download_byte_size(num_bytes: int, expected_substrings: tuple[str, ...]) -> None:
+    got = format_download_byte_size(num_bytes)
+    for frag in expected_substrings:
+        assert frag in got

--- a/tests/plugins/test_pallas_protocol_runtime_installer.py
+++ b/tests/plugins/test_pallas_protocol_runtime_installer.py
@@ -2,9 +2,9 @@ import zipfile
 from pathlib import Path
 from unittest.mock import patch
 
+from src.common.utils.github_release import github_release_asset_url
 from src.plugins.pallas_protocol.runtime.installer import (
     _asset_name_from_url,
-    _github_release_asset_url,
     _looks_like_http_url,
     _pick_appimage_asset_from_release,
     _pick_appimage_asset_from_release_html,
@@ -20,12 +20,12 @@ from src.plugins.pallas_protocol.runtime.installer import (
 
 
 def test_github_release_asset_url_latest() -> None:
-    u = _github_release_asset_url("NapNeko/NapCatQQ", "NapCat.Shell.zip", "")
+    u = github_release_asset_url("NapNeko/NapCatQQ", "NapCat.Shell.zip", "")
     assert u.endswith("/NapNeko/NapCatQQ/releases/latest/download/NapCat.Shell.zip")
 
 
 def test_github_release_asset_url_tagged() -> None:
-    u = _github_release_asset_url("NapNeko/NapCatQQ", "NapCat.Shell.zip", "v1.2.3")
+    u = github_release_asset_url("NapNeko/NapCatQQ", "NapCat.Shell.zip", "v1.2.3")
     assert "releases/download/v1.2.3/NapCat.Shell.zip" in u
 
 


### PR DESCRIPTION
- common：`stream_download`；`github_release`（资产直链候选、网页兜底 tag、`fetch_latest_release` 可选参数）。
- protocol：运行时下载复用上述工具。
- webui：更新检查网页兜底、启动异步化、日志与 dist 下载体验优化。
- ci：Release WebUI 打包/上传与 **`dist.zip`** 约定一致；与上游 **`v*`** tag / console-version 对齐。
- docs：优先使用主仓 Release 附件 **`dist.zip`**。

## Summary by Sourcery

统一 GitHub Release 处理方式以及 WebUI `dist.zip` 的分发逻辑，在 bot 运行时、控制台插件和 CI 发布流程中保持一致。

New Features:
- 引入共享的 HTTP 流式下载工具，用于大体积资源下载，并支持进度回调。
- 新增 GitHub Release 辅助工具，用于构建资源 URL、认证请求头，以及在 GitHub API 失效时通过 GitHub 网页接口解析最新标签。
- 支持 WebUI 首次自动部署 `dist` 资源，以及在 WebUI 启动时异步后台检查更新。

Bug Fixes:
- 提高 WebUI 和 Bot 更新检查的健壮性，在 GitHub API 失败时使用基于网页的回退方案，并将错误更好地传播到日志和 HTTP 响应中。

Enhancements:
- 优化 WebUI 和运行时安装器的下载日志与进度上报，使状态与错误信息更加清晰。
- 将 GitHub Release 资源 URL 的构建逻辑集中到共享工具中，并在协议运行时安装器和 WebUI 管理器中复用。
- 统一 WebUI `dist` 构建产物的打包方式，使其作为根目录下的 `dist.zip`，其内部结构与插件所期望的 `public` 目录布局一致。

Build:
- 更新 GitHub Actions 发布工作流，从解析出的 `v*` 标签（或固定标签）构建 WebUI，将其打包为 `dist.zip`，并附加到 Release 中，同时包含控制台版本元数据。

Documentation:
- 明确 WebUI 手动部署文档，引导优先使用主仓库 Release 中的 `dist.zip`，并记录新的解压路径 `data/pallas_webui`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify GitHub release handling and WebUI dist.zip distribution across bot runtime, console plugin, and CI release workflow.

New Features:
- Introduce a shared HTTP stream download utility with progress callbacks for large asset downloads.
- Add GitHub release helpers for constructing asset URLs, auth headers, and resolving latest tags via the GitHub web interface as API fallback.
- Support automatic first-time WebUI dist deployment and asynchronous background update checks at WebUI startup.

Bug Fixes:
- Improve robustness of WebUI and Bot update checks by handling GitHub API failures with web-based fallbacks and better error propagation to logs and HTTP responses.

Enhancements:
- Refine WebUI and runtime installer download logging and progress reporting for clearer status and error messages.
- Centralize GitHub release asset URL construction in shared utilities and reuse them in the protocol runtime installer and WebUI manager.
- Align WebUI dist artifact packaging as a root-level dist.zip whose structure matches the plugin’s expected public directory layout.

Build:
- Update the GitHub Actions release workflow to build the WebUI from a resolved v* tag (or pinned tag), package it as dist.zip, and attach it to releases with console version metadata.

Documentation:
- Clarify WebUI manual deployment docs to prefer the main repo’s Release dist.zip and document the new extraction path under data/pallas_webui.

</details>