### PR TITLE
feat(repeater): 复读忽略 Bot 与配置 QQ，并跳过其学习写入

### DIFF
--- a/.env
+++ b/.env
@@ -64,6 +64,9 @@ MONGO_PASSWORD=
 # 复读的阈值，群里连续多少次有相同的发言，就复读
 #REPEAT_THRESHOLD=3
 
+# 复读判定与学习均忽略的第三方 QQ，如 [123456789,987654321]；
+#REPEAT_IGNORE_USER_IDS=
+
 # 主动发言的阈值，越小废话越多
 #SPEAK_THRESHOLD=5
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "nonebot2[fastapi]>=2.4.4",
     "nvidia-ml-py>=13.595.45",
     "pillowmd>=0.7.3",
-    "pyncm-async>=1.8.2",
+    # PyPI/镜像常不可解析该包，固定已校验的发行包地址（issue #166）
+    "pyncm-async @ https://files.pythonhosted.org/packages/52/14/8892c8bef54293eaf13c3ff95685a097d8a48272ce07b8600138f5c24d3e/pyncm_async-1.8.2.tar.gz",
     "pypinyin>=0.55.0",
     "python-multipart>=0.0.20",
     "python-ulid>=3.1.0",

--- a/src/plugins/repeater/config.py
+++ b/src/plugins/repeater/config.py
@@ -14,6 +14,8 @@ class Config(BaseModel, extra="ignore"):
     cross_group_threshold: int = 2
     # 复读的阈值，群里连续多少次有相同的发言，就复读
     repeat_threshold: int = 3
+    # 复读判定与学习均忽略的 QQ（如非本进程登录的第三方 Bot），与 get_bots() 的 self_id 一并排除；这些用户的发言不会写入消息缓存、也不会写入语料
+    repeat_ignore_user_ids: list[int] = []
     # 主动发言的阈值，越小废话越多
     speak_threshold: int = 5
     # 说过的话，接下来多少次不再说

--- a/src/plugins/repeater/config.py
+++ b/src/plugins/repeater/config.py
@@ -14,7 +14,7 @@ class Config(BaseModel, extra="ignore"):
     cross_group_threshold: int = 2
     # 复读的阈值，群里连续多少次有相同的发言，就复读
     repeat_threshold: int = 3
-    # 复读判定与学习均忽略的 QQ（如非本进程登录的第三方 Bot），与 get_bots() 的 self_id 一并排除；这些用户的发言不会写入消息缓存、也不会写入语料
+    # 复读判定与学习均忽略的第三方 QQ
     repeat_ignore_user_ids: list[int] = []
     # 主动发言的阈值，越小废话越多
     speak_threshold: int = 5

--- a/src/plugins/repeater/learner.py
+++ b/src/plugins/repeater/learner.py
@@ -32,6 +32,11 @@ class Learner:
         if len(chat_data.raw_message.strip()) == 0:
             return False
 
+        from .responder import Responder
+
+        if chat_data.user_id in Responder._repeat_ignore_user_ids():
+            return False
+
         group_id = chat_data.group_id
         if group_id in MessageStore._message_dict:
             group_msgs = MessageStore._message_dict[group_id]

--- a/src/plugins/repeater/responder.py
+++ b/src/plugins/repeater/responder.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING
 
-from nonebot import get_plugin_config
+from nonebot import get_bots, get_plugin_config
 from nonebot.adapters.onebot.v11 import Message
 
 from src.common.config import BotConfig
@@ -43,6 +43,17 @@ class Responder:
     )
     BLACKLIST_FLAG = 114514
     REPLY_FLAG = "[PallasBot: Reply]"
+
+    @staticmethod
+    def _repeat_ignore_user_ids() -> set[int]:
+        ids = {int(b.self_id) for b in get_bots().values()}
+        ids.update(plugin_config.repeat_ignore_user_ids)
+        return ids
+
+    @staticmethod
+    def _human_messages_for_repeat(group_msgs: list) -> list:
+        ignore = Responder._repeat_ignore_user_ids()
+        return [m for m in group_msgs if (uid := getattr(m, "user_id", None)) is None or uid not in ignore]
 
     @staticmethod
     async def answer(
@@ -145,12 +156,13 @@ class Responder:
         keywords = chat_data.keywords
         bot_id = chat_data.bot_id
 
-        # 复读！
-        if group_id in message_dict:
+        # 复读！（只统计非本进程 Bot / 配置忽略账号，避免多 Bot 同句堆叠误判）
+        rt = Responder.REPEAT_THRESHOLD
+        if rt >= 2 and group_id in message_dict:
             group_msgs = message_dict[group_id]
-            if len(group_msgs) >= Responder.REPEAT_THRESHOLD and all(
-                item.raw_message == raw_message for item in group_msgs[-Responder.REPEAT_THRESHOLD + 1 :]
-            ):
+            human_msgs = Responder._human_messages_for_repeat(group_msgs)
+            tail = rt - 1
+            if len(human_msgs) >= tail and all(item.raw_message == raw_message for item in human_msgs[-tail:]):
                 # 到这里说明当前群里是在复读
                 group_bot_replies = reply_dict[group_id][bot_id]
                 if len(group_bot_replies) and group_bot_replies[-1]["reply"] != raw_message:

--- a/tests/plugins/repeater/test_learner.py
+++ b/tests/plugins/repeater/test_learner.py
@@ -75,6 +75,73 @@ async def test_learn_basic_flow(beanie_fixture):
 
 
 @pytest.mark.asyncio
+async def test_learn_skips_repeat_ignore_user_ids(beanie_fixture):
+    """repeat_ignore / 本进程 Bot QQ 不参与学习：不插库、不写上下文。"""
+    from src.common.db import Message as MessageModel
+    from src.plugins.repeater.learner import Learner
+    from src.plugins.repeater.message_store import MessageStore
+    from src.plugins.repeater.model import ChatData
+
+    MessageStore._message_lock = asyncio.Lock()
+    MessageStore._message_dict = defaultdict(list)
+    MessageStore._late_save_time = 0
+
+    topics_lock = asyncio.Lock()
+    recent_topics = defaultdict(lambda: deque(maxlen=10))
+
+    try:
+        group_id = 55501
+        ignored_uid = 888001
+        bot_id = 11111
+
+        prev_msg = MessageModel(
+            group_id=group_id,
+            user_id=99999,
+            bot_id=bot_id,
+            raw_message="before",
+            is_plain_text=True,
+            plain_text="before",
+            keywords="before",
+            time=1000,
+        )
+        MessageStore._message_dict[group_id].append(prev_msg)
+
+        chat_data = ChatData(
+            group_id=group_id,
+            user_id=ignored_uid,
+            raw_message="ignored user says",
+            plain_text="ignored user says",
+            time=2000,
+            bot_id=bot_id,
+        )
+
+        with (
+            patch(
+                "src.plugins.repeater.responder.Responder._repeat_ignore_user_ids",
+                return_value={ignored_uid},
+            ),
+            patch(
+                "src.plugins.repeater.learner.context_repo.find_by_keywords", new_callable=AsyncMock
+            ) as mock_find,
+            patch("src.plugins.repeater.learner.context_repo.insert", new_callable=AsyncMock) as mock_insert,
+            patch(
+                "src.plugins.repeater.message_store.MessageStore.message_insert",
+                new_callable=AsyncMock,
+            ) as mock_insert_msg,
+        ):
+            result = await Learner.learn(chat_data, topics_lock, recent_topics)
+
+            assert result is False
+            mock_find.assert_not_called()
+            mock_insert.assert_not_called()
+            mock_insert_msg.assert_not_called()
+            assert len(MessageStore._message_dict[group_id]) == 1
+    finally:
+        MessageStore._message_dict.clear()
+        MessageStore._late_save_time = 0
+
+
+@pytest.mark.asyncio
 async def test_learn_empty_message(beanie_fixture):
     """
     Test that learn() returns False for empty messages.

--- a/tests/plugins/repeater/test_responder.py
+++ b/tests/plugins/repeater/test_responder.py
@@ -36,17 +36,21 @@ async def test_context_find_repeat_detection():
     reply_dict = defaultdict(lambda: defaultdict(list))
     reply_dict[group_id][bot_id] = [{"reply": "other", "reply_keywords": "other"}]
     message_dict = defaultdict(list)
+    human = 90001
     message_dict[group_id] = [
-        SimpleNamespace(raw_message="x"),
-        SimpleNamespace(raw_message=raw_message),
-        SimpleNamespace(raw_message=raw_message),
+        SimpleNamespace(raw_message="x", user_id=human),
+        SimpleNamespace(raw_message=raw_message, user_id=human),
+        SimpleNamespace(raw_message=raw_message, user_id=human),
     ]
     recent_topics = defaultdict(lambda: deque(maxlen=16))
 
     try:
-        with patch(
-            "src.plugins.repeater.responder.context_repo.find_by_keywords", new_callable=AsyncMock
-        ) as mock_find_one:
+        with (
+            patch("src.plugins.repeater.responder.get_bots", return_value={}),
+            patch(
+                "src.plugins.repeater.responder.context_repo.find_by_keywords", new_callable=AsyncMock
+            ) as mock_find_one,
+        ):
             result = await Responder._context_find(
                 cast("Any", chat_data),
                 cast("Any", config),
@@ -56,6 +60,119 @@ async def test_context_find_repeat_detection():
             )
             assert result == ([raw_message], keywords)
             mock_find_one.assert_not_called()
+    finally:
+        reply_dict.clear()
+        message_dict.clear()
+        recent_topics.clear()
+
+
+@pytest.mark.asyncio
+async def test_context_find_repeat_not_triggered_when_tail_is_only_bots():
+    """尾部相同句来自本进程其它 Bot QQ 时不应判为复读。"""
+    from src.plugins.repeater.responder import Responder
+
+    group_id = 201
+    bot_id = 202
+    other_bot_qq = 203
+    raw_message = "same_line"
+    keywords = "kw"
+    chat_data = SimpleNamespace(
+        group_id=group_id,
+        raw_message=raw_message,
+        keywords=keywords,
+        bot_id=bot_id,
+        keywords_len=1,
+        to_me=False,
+        is_image=False,
+    )
+    config = _Config(0)
+    reply_dict = defaultdict(lambda: defaultdict(list))
+    reply_dict[group_id][bot_id] = [{"reply": "other", "reply_keywords": "other"}]
+    human = 90002
+    message_dict = defaultdict(list)
+    message_dict[group_id] = [
+        SimpleNamespace(raw_message="noise", user_id=human),
+        SimpleNamespace(raw_message=raw_message, user_id=other_bot_qq),
+        SimpleNamespace(raw_message=raw_message, user_id=other_bot_qq),
+    ]
+    recent_topics = defaultdict(lambda: deque(maxlen=16))
+    fake_bot = SimpleNamespace(self_id=other_bot_qq)
+
+    try:
+        with (
+            patch("src.plugins.repeater.responder.get_bots", return_value={"b1": fake_bot}),
+            patch(
+                "src.plugins.repeater.responder.context_repo.find_by_keywords",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_find,
+        ):
+            result = await Responder._context_find(
+                cast("Any", chat_data),
+                cast("Any", config),
+                reply_dict,
+                message_dict,
+                recent_topics,
+            )
+            assert result is None
+            mock_find.assert_called_once()
+    finally:
+        reply_dict.clear()
+        message_dict.clear()
+        recent_topics.clear()
+
+
+@pytest.mark.asyncio
+async def test_context_find_repeat_skips_repeat_ignore_user_ids_config():
+    """配置 repeat_ignore_user_ids 中的 QQ 不计入复读条数。"""
+    from src.plugins.repeater import responder as responder_mod
+    from src.plugins.repeater.responder import Responder
+
+    group_id = 301
+    bot_id = 302
+    external_bot = 303303
+    raw_message = "line"
+    keywords = "kw2"
+    chat_data = SimpleNamespace(
+        group_id=group_id,
+        raw_message=raw_message,
+        keywords=keywords,
+        bot_id=bot_id,
+        keywords_len=1,
+        to_me=False,
+        is_image=False,
+    )
+    config = _Config(0)
+    reply_dict = defaultdict(lambda: defaultdict(list))
+    reply_dict[group_id][bot_id] = [{"reply": "other", "reply_keywords": "other"}]
+    human = 90003
+    message_dict = defaultdict(list)
+    message_dict[group_id] = [
+        SimpleNamespace(raw_message="noise", user_id=human),
+        SimpleNamespace(raw_message=raw_message, user_id=external_bot),
+        SimpleNamespace(raw_message=raw_message, user_id=external_bot),
+    ]
+    recent_topics = defaultdict(lambda: deque(maxlen=16))
+
+    try:
+        with (
+            patch.object(responder_mod.plugin_config, "repeat_ignore_user_ids", [external_bot]),
+            patch("src.plugins.repeater.responder.get_bots", return_value={}),
+            patch(
+                "src.plugins.repeater.responder.context_repo.find_by_keywords",
+                new_callable=AsyncMock,
+                return_value=None,
+            ) as mock_find,
+        ):
+            result = await Responder._context_find(
+                cast("Any", chat_data),
+                cast("Any", config),
+                reply_dict,
+                message_dict,
+                recent_topics,
+            )
+            assert result is None
+            mock_find.assert_called_once()
     finally:
         reply_dict.clear()
         message_dict.clear()
@@ -119,7 +236,9 @@ async def test_context_find_threshold_filtering():
     config = _Config(0)
     low_answer = Answer(keywords="ans_low", group_id=group_id, count=1, time=1, messages=["low_msg"])
     high_answer = Answer(keywords="ans_high", group_id=group_id, count=3, time=1, messages=["high_msg"])
-    context = Context(keywords="ctx_kw", time=1, answers=[low_answer, high_answer])
+    context = Context.model_construct(
+        keywords="ctx_kw", time=1, trigger_count=1, answers=[low_answer, high_answer], ban=[], clear_time=0
+    )
     reply_dict = defaultdict(lambda: defaultdict(list))
     message_dict = defaultdict(list)
     message_dict[group_id] = []


### PR DESCRIPTION
复读判定仅统计非本进程 Bot 与 repeat_ignore_user_ids 中的发言，
避免多 Bot 同句堆叠误判；repeat_threshold < 2 时不走复读分支。
Learner 对同一忽略集合直接跳过，不写消息缓存与语料上下文。
.env 增加 REPEAT_IGNORE_USER_IDS 说明项。

## Summary by Sourcery

调整复读机行为，在复读检测和学习时忽略已配置和机器人用户 ID，并收紧复读触发条件。

新功能：
- 新增配置项 `repeat_ignore_user_ids`，用于在复读检测和学习中排除指定的 QQ 账号。

漏洞修复：
- 防止仅由当前进程中的机器人账号发送的消息就触发复读检测，避免在多机器人场景中出现误判。

改进：
- 更新复读检测逻辑，仅当 `repeat_threshold` 至少为 2 时才运行，并且只统计非忽略用户的消息。
- 确保学习器在处理来自被忽略或机器人用户 ID 的消息时跳过消息缓存和上下文更新。

测试：
- 扩展复读响应器测试，用于覆盖在复读检测中忽略机器人和已配置用户 ID 的情况，并与更新后的 Context 模型结构保持一致。
- 新增学习器测试，验证被忽略和机器人用户 ID 不会产生数据库插入或上下文更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust repeater behavior to ignore configured and bot user IDs in repeat detection and learning while tightening repeat trigger conditions.

New Features:
- Add configuration option repeat_ignore_user_ids to exclude specified QQ accounts from repeater detection and learning.

Bug Fixes:
- Prevent repeat detection from being triggered solely by messages from this process's bot accounts, avoiding false positives in multi-bot scenarios.

Enhancements:
- Update repeat detection to only run when the repeat_threshold is at least 2 and to count only non-ignored user messages.
- Ensure the learner skips message caching and context updates for messages from ignored or bot user IDs.

Tests:
- Extend repeater responder tests to cover ignoring bot and configured user IDs in repeat detection and to align with the updated Context model shape.
- Add learner tests verifying that ignored and bot user IDs do not result in DB inserts or context updates.

</details>