### PR TITLE
fix(db): Learner 避免重复全量加载 Context，缓解连接池压力

### DIFF
--- a/src/common/db/__init__.py
+++ b/src/common/db/__init__.py
@@ -21,6 +21,7 @@ from .repository import (
     BlackListRepository,
     ConfigRepository,
     ContextRepository,
+    ContextRepositoryExistenceMixin,
     ImageCacheRepository,
     MessageRepository,
 )

--- a/src/common/db/repository.py
+++ b/src/common/db/repository.py
@@ -12,6 +12,10 @@ class ContextRepository(Protocol):
         """根据 keywords 查找 Context 文档"""
         ...
 
+    async def context_exists_by_keywords(self, keywords: str) -> bool:
+        """是否已有 Context(keywords)；用于仅需分支判断时避免全量加载。"""
+        ...
+
     async def save(self, context: Context) -> None:
         """保存/更新已有的 Context 文档（整文档覆盖写）
 
@@ -51,7 +55,7 @@ class ContextRepository(Protocol):
 
         要求实现具备并发原子性（Mongo 可用 $inc/$push + positional 更新；PG 用事务 + upsert）。
         前置条件：Context(keywords=keywords) 必须已存在，否则行为未定义 —— 调用方
-        应先 find_by_keywords，不存在时走 insert(Context(...)) 路径。
+        应先 context_exists_by_keywords / find_by_keywords，不存在时走 insert(Context(...)) 路径。
         """
         ...
 

--- a/src/common/db/repository.py
+++ b/src/common/db/repository.py
@@ -13,7 +13,11 @@ class ContextRepository(Protocol):
         ...
 
     async def context_exists_by_keywords(self, keywords: str) -> bool:
-        """是否已有 Context(keywords)；用于仅需分支判断时避免全量加载。"""
+        """是否已有 Context(keywords)；用于仅需分支判断时避免全量加载。
+
+        自定义后端若暂无轻量查询，可混入 `ContextRepositoryExistenceMixin`，
+        由 `find_by_keywords` 推导存在性（仍会全量加载）。
+        """
         ...
 
     async def save(self, context: Context) -> None:
@@ -72,6 +76,13 @@ class ContextRepository(Protocol):
         若 Context(keywords=keywords) 不存在，则应为 no-op。
         """
         ...
+
+
+class ContextRepositoryExistenceMixin:
+    """为已实现 `find_by_keywords` 的仓储提供 `context_exists_by_keywords` 默认实现。"""
+
+    async def context_exists_by_keywords(self, keywords: str) -> bool:
+        return (await self.find_by_keywords(keywords)) is not None
 
 
 @runtime_checkable

--- a/src/common/db/repository_impl.py
+++ b/src/common/db/repository_impl.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 class MongoContextRepository:
     """MongoDB 版 ContextRepository 实现"""
 
+    async def context_exists_by_keywords(self, keywords: str) -> bool:
+        coll = Context.get_pymongo_collection()
+        doc = await coll.find_one({"keywords": keywords}, projection={"_id": 1})
+        return doc is not None
+
     async def find_by_keywords(self, keywords: str) -> Context | None:
         return await Context.find_one(Context.keywords == keywords)
 

--- a/src/common/db/repository_pg.py
+++ b/src/common/db/repository_pg.py
@@ -354,6 +354,12 @@ def row_to_image_cache(row: ImageCacheRow) -> ImageCache:
 
 
 class PgContextRepository:
+    async def context_exists_by_keywords(self, keywords: str) -> bool:
+        khash = keywords_hash(keywords)
+        async with get_session() as session:
+            result = await session.execute(select(ContextRow.id).where(ContextRow.keywords_hash == khash).limit(1))
+            return result.scalar_one_or_none() is not None
+
     async def find_by_keywords(self, keywords: str) -> Context | None:
         khash = keywords_hash(keywords)
         async with get_session() as session:

--- a/src/plugins/repeater/learner.py
+++ b/src/plugins/repeater/learner.py
@@ -86,8 +86,7 @@ class Learner:
         pre_keywords = pre_msg.keywords
         cur_time = chat_data.time
 
-        context = await context_repo.find_by_keywords(pre_keywords)
-        if context:
+        if await context_repo.context_exists_by_keywords(pre_keywords):
             # 使用细粒度 upsert_answer：原子地 inc count / set time / 可选 push message
             # append_on_existing 保留原有 "仅 plain text 才追加 message" 的语义
             await context_repo.upsert_answer(

--- a/tests/common/test_backend_switching.py
+++ b/tests/common/test_backend_switching.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 
 import pytest
 
+from src.common.db.repository import ContextRepositoryExistenceMixin
 
-class _FakeContextRepo:
+
+class _FakeContextRepo(ContextRepositoryExistenceMixin):
     async def find_by_keywords(self, keywords):  # noqa: ARG002
         return None
-
-    async def context_exists_by_keywords(self, keywords):  # noqa: ARG002
-        return False
 
     async def save(self, context):  # noqa: ARG002
         return None

--- a/tests/common/test_backend_switching.py
+++ b/tests/common/test_backend_switching.py
@@ -12,6 +12,9 @@ class _FakeContextRepo:
     async def find_by_keywords(self, keywords):  # noqa: ARG002
         return None
 
+    async def context_exists_by_keywords(self, keywords):  # noqa: ARG002
+        return False
+
     async def save(self, context):  # noqa: ARG002
         return None
 

--- a/tests/common/test_repository_impl.py
+++ b/tests/common/test_repository_impl.py
@@ -70,6 +70,14 @@ async def test_context_repo_find_not_found(beanie_fixture):
 
 
 @pytest.mark.asyncio
+async def test_context_repo_exists_by_keywords(beanie_fixture):
+    repo = MongoContextRepository()
+    assert await repo.context_exists_by_keywords("ghost") is False
+    await repo.insert(Context(keywords="live", time=0, trigger_count=1, answers=[]))  # type: ignore
+    assert await repo.context_exists_by_keywords("live") is True
+
+
+@pytest.mark.asyncio
 async def test_context_repo_delete_expired(beanie_fixture):
     """Test delete_expired removes old low-count contexts."""
     repo = MongoContextRepository()

--- a/tests/common/test_repository_pg.py
+++ b/tests/common/test_repository_pg.py
@@ -46,6 +46,20 @@ async def test_find_for_cleanup_or_semantics(pg_engine):
 
 
 @pytest.mark.asyncio
+async def test_context_exists_by_keywords(pg_engine):
+    """Learner仅需分支判断时应只查 id，避免误用全量 find_by_keywords。"""
+    from src.common.db.modules import Context
+    from src.common.db.repository_pg import PgContextRepository
+
+    repo = PgContextRepository()
+    assert await repo.context_exists_by_keywords("absent_kw") is False
+    await repo.insert(
+        Context.model_construct(keywords="present_kw", time=0, trigger_count=1, answers=[], ban=[], clear_time=0)
+    )
+    assert await repo.context_exists_by_keywords("present_kw") is True
+
+
+@pytest.mark.asyncio
 async def test_upsert_answer_is_atomic(pg_engine):
     """并发 50 次 upsert_answer 只产生 1 条 Answer、count=50、trigger_count 精确累加。"""
     from src.common.db.modules import Context

--- a/tests/common/test_repository_protocol.py
+++ b/tests/common/test_repository_protocol.py
@@ -11,6 +11,9 @@ class MockContextRepo:
     async def find_by_keywords(self, keywords):
         return None
 
+    async def context_exists_by_keywords(self, keywords):  # noqa: ARG002
+        return False
+
     async def save(self, context):
         pass
 

--- a/tests/common/test_repository_protocol.py
+++ b/tests/common/test_repository_protocol.py
@@ -1,18 +1,18 @@
 """Tests for Repository Protocol interfaces."""
 
+import pytest
+
 from src.common.db.repository import (
     BlackListRepository,
     ContextRepository,
+    ContextRepositoryExistenceMixin,
     MessageRepository,
 )
 
 
-class MockContextRepo:
-    async def find_by_keywords(self, keywords):
+class MockContextRepo(ContextRepositoryExistenceMixin):
+    async def find_by_keywords(self, keywords):  # noqa: ARG002
         return None
-
-    async def context_exists_by_keywords(self, keywords):  # noqa: ARG002
-        return False
 
     async def save(self, context):
         pass
@@ -55,6 +55,17 @@ class MockBlackListRepo:
 def test_context_repo_protocol():
     repo = MockContextRepo()
     assert isinstance(repo, ContextRepository)
+
+
+@pytest.mark.asyncio
+async def test_existence_mixin_delegates_to_find():
+    class _Repo(ContextRepositoryExistenceMixin):
+        async def find_by_keywords(self, kw: str):
+            return object() if kw == "hit" else None
+
+    repo = _Repo()
+    assert await repo.context_exists_by_keywords("hit") is True
+    assert await repo.context_exists_by_keywords("miss") is False
 
 
 def test_message_repo_protocol():

--- a/tests/plugins/repeater/test_learner.py
+++ b/tests/plugins/repeater/test_learner.py
@@ -6,7 +6,7 @@ Tests learning logic, context insertion, and filtering (repeat/reply skipping).
 
 import asyncio
 from collections import defaultdict, deque
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -59,7 +59,9 @@ async def test_learn_basic_flow(beanie_fixture):
 
         with (
             patch(
-                "src.plugins.repeater.learner.context_repo.find_by_keywords", new_callable=AsyncMock, return_value=None
+                "src.plugins.repeater.learner.context_repo.context_exists_by_keywords",
+                new_callable=AsyncMock,
+                return_value=False,
             ),
             patch("src.plugins.repeater.learner.context_repo.insert", new_callable=AsyncMock) as mock_insert,
         ):
@@ -121,8 +123,8 @@ async def test_learn_skips_repeat_ignore_user_ids(beanie_fixture):
                 return_value={ignored_uid},
             ),
             patch(
-                "src.plugins.repeater.learner.context_repo.find_by_keywords", new_callable=AsyncMock
-            ) as mock_find,
+                "src.plugins.repeater.learner.context_repo.context_exists_by_keywords", new_callable=AsyncMock
+            ) as mock_exists,
             patch("src.plugins.repeater.learner.context_repo.insert", new_callable=AsyncMock) as mock_insert,
             patch(
                 "src.plugins.repeater.message_store.MessageStore.message_insert",
@@ -132,7 +134,7 @@ async def test_learn_skips_repeat_ignore_user_ids(beanie_fixture):
             result = await Learner.learn(chat_data, topics_lock, recent_topics)
 
             assert result is False
-            mock_find.assert_not_called()
+            mock_exists.assert_not_called()
             mock_insert.assert_not_called()
             mock_insert_msg.assert_not_called()
             assert len(MessageStore._message_dict[group_id]) == 1
@@ -213,9 +215,9 @@ async def test_topics_callback_filters_niuniu_keywords(beanie_fixture):
 
         with (
             patch(
-                "src.plugins.repeater.learner.context_repo.find_by_keywords",
+                "src.plugins.repeater.learner.context_repo.context_exists_by_keywords",
                 new_callable=AsyncMock,
-                return_value=None,
+                return_value=False,
             ),
             patch("src.plugins.repeater.learner.context_repo.insert", new_callable=AsyncMock),
         ):
@@ -264,11 +266,11 @@ async def test_context_insert_skip_repeat(beanie_fixture):
         time=1000,
     )
 
-    with patch("src.plugins.repeater.learner.context_repo.find_by_keywords") as mock_find:
+    with patch("src.plugins.repeater.learner.context_repo.context_exists_by_keywords") as mock_exists:
         # Call context_insert
         await Learner._context_insert(chat_data, pre_msg)
 
-        assert mock_find.call_count == 0, "Should skip repeats without querying Context"
+        assert mock_exists.call_count == 0, "Should skip repeats without querying Context"
 
 
 @pytest.mark.asyncio
@@ -301,11 +303,11 @@ async def test_context_insert_skip_reply(beanie_fixture):
         time=1000,
     )
 
-    with patch("src.plugins.repeater.learner.context_repo.find_by_keywords") as mock_find:
+    with patch("src.plugins.repeater.learner.context_repo.context_exists_by_keywords") as mock_exists:
         # Call context_insert
         await Learner._context_insert(chat_data, pre_msg)
 
-        assert mock_find.call_count == 0, "Should skip replies without querying Context"
+        assert mock_exists.call_count == 0, "Should skip replies without querying Context"
 
 
 @pytest.mark.asyncio
@@ -325,11 +327,11 @@ async def test_context_insert_skip_none(beanie_fixture):
         bot_id=11111,
     )
 
-    with patch("src.plugins.repeater.learner.context_repo.find_by_keywords") as mock_find:
+    with patch("src.plugins.repeater.learner.context_repo.context_exists_by_keywords") as mock_exists:
         # Call context_insert with None
         await Learner._context_insert(chat_data, None)
 
-        assert mock_find.call_count == 0, "Should skip None pre_msg without querying Context"
+        assert mock_exists.call_count == 0, "Should skip None pre_msg without querying Context"
 
 
 @pytest.mark.asyncio
@@ -362,14 +364,11 @@ async def test_context_insert_calls_upsert_answer_when_context_exists(beanie_fix
         time=1000,
     )
 
-    mock_context = MagicMock()
-    mock_context.keywords = "Trigger message"
-
     with (
         patch(
-            "src.plugins.repeater.learner.context_repo.find_by_keywords",
+            "src.plugins.repeater.learner.context_repo.context_exists_by_keywords",
             new_callable=AsyncMock,
-            return_value=mock_context,
+            return_value=True,
         ),
         patch("src.plugins.repeater.learner.context_repo.upsert_answer", new_callable=AsyncMock) as mock_upsert,
         patch("src.plugins.repeater.learner.context_repo.insert", new_callable=AsyncMock) as mock_insert,
@@ -422,13 +421,11 @@ async def test_context_insert_no_append_when_non_plain_text(beanie_fixture):
         time=1000,
     )
 
-    mock_context = MagicMock()
-
     with (
         patch(
-            "src.plugins.repeater.learner.context_repo.find_by_keywords",
+            "src.plugins.repeater.learner.context_repo.context_exists_by_keywords",
             new_callable=AsyncMock,
-            return_value=mock_context,
+            return_value=True,
         ),
         patch("src.plugins.repeater.learner.context_repo.upsert_answer", new_callable=AsyncMock) as mock_upsert,
     ):
@@ -467,9 +464,9 @@ async def test_context_insert_creates_new_context_when_missing(beanie_fixture):
 
     with (
         patch(
-            "src.plugins.repeater.learner.context_repo.find_by_keywords",
+            "src.plugins.repeater.learner.context_repo.context_exists_by_keywords",
             new_callable=AsyncMock,
-            return_value=None,
+            return_value=False,
         ),
         patch("src.plugins.repeater.learner.context_repo.insert", new_callable=AsyncMock) as mock_insert,
         patch("src.plugins.repeater.learner.context_repo.upsert_answer", new_callable=AsyncMock) as mock_upsert,
@@ -569,7 +566,9 @@ async def test_learn_user_backtracking(beanie_fixture):
 
         with (
             patch(
-                "src.plugins.repeater.learner.context_repo.find_by_keywords", new_callable=AsyncMock, return_value=None
+                "src.plugins.repeater.learner.context_repo.context_exists_by_keywords",
+                new_callable=AsyncMock,
+                return_value=False,
             ),
             patch("src.plugins.repeater.learner.context_repo.insert", new_callable=AsyncMock) as mock_insert,
         ):


### PR DESCRIPTION
## Summary by Sourcery

引入一个轻量级的上下文存在性检查机制，以避免在 Learner 流程和仓储中加载完整的 Context，从而在保持行为不变的前提下减少数据库负载。

Enhancements:
- 在 `ContextRepository` 接口中添加 `context_exists_by_keywords`，并在 Mongo 和 PostgreSQL 后端中实现该方法，仅通过标识符根据关键字检查上下文是否存在。
- 更新 Learner 的上下文插入逻辑，在 upsert 答案之前使用新的存在性检查，而不是加载完整的 `Context` 文档。
- 扩展 fake 和 mock 的上下文仓储实现，以支持新的存在性检查方法，用于协议和后端切换测试。

Tests:
- 调整 Learner 测试以使用新的 `context_exists_by_keywords` API，并验证在跳过场景中不会调用该方法，同时在上下文存在或缺失时会被正确调用。
- 为 Mongo 和 PostgreSQL 实现添加仓储测试，以断言 `context_exists_by_keywords` 的行为正确。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a lightweight context existence check to avoid full Context loads in Learner flows and repositories, reducing database load while keeping behavior unchanged.

Enhancements:
- Add context_exists_by_keywords to the ContextRepository interface and implement it for Mongo and PostgreSQL backends to check for existing contexts by keywords using only identifiers.
- Update Learner context insertion logic to use the new existence check before upserting answers, instead of loading full Context documents.
- Extend fake and mock context repository implementations to support the new existence check method for protocol and backend switching tests.

Tests:
- Adjust Learner tests to use the new context_exists_by_keywords API and verify it is not called in skip scenarios and is used when contexts exist or are missing.
- Add repository tests for Mongo and PostgreSQL implementations to assert correct behavior of context_exists_by_keywords.

</details>