### PR TITLE
feat(repeater): 增加群消息去重机制以避免重复处理

### DIFF
--- a/src/plugins/repeater/__init__.py
+++ b/src/plugins/repeater/__init__.py
@@ -108,6 +108,32 @@ __plugin_meta__ = PluginMetadata(
 message_id_lock = asyncio.Lock()
 message_id_dict = defaultdict(lambda: deque(maxlen=100))
 
+# 多 Bot 同群时，协议可能对同一条群消息向每个连接各上报一次
+# 不合并会在 MessageStore 里堆出多条「连续相同句」，误触复读。
+_GROUP_EVENT_DEDUP_MAX = 4000
+_group_event_dedup_lock = asyncio.Lock()
+_group_event_sigs: deque[tuple[int, int, str, int]] = deque()
+_group_event_sig_set: set[tuple[int, int, str, int]] = set()
+
+
+def _normalize_group_raw_message(raw_message: str) -> str:
+    # 与 ChatData / learn 侧一致，避免图片子类型差异导致去重失败
+    return re.sub(r"\.image,.+?\]", ".image]", raw_message)
+
+
+async def _should_skip_duplicate_group_event(group_id: int, user_id: int, norm_raw: str, time: int) -> bool:
+    sig = (group_id, user_id, norm_raw, time)
+    async with _group_event_dedup_lock:
+        if sig in _group_event_sig_set:
+            return True
+        while len(_group_event_sigs) >= _GROUP_EVENT_DEDUP_MAX:
+            old = _group_event_sigs.popleft()
+            _group_event_sig_set.discard(old)
+        _group_event_sigs.append(sig)
+        _group_event_sig_set.add(sig)
+        return False
+
+
 driver = get_driver()
 
 
@@ -182,19 +208,19 @@ any_msg = on_message(
 
 @any_msg.handle()
 async def _(bot: Bot, event: GroupMessageEvent):
-    to_learn = True
     # 多账号登陆，且在同一群中时；避免一条消息被处理多次
     async with message_id_lock:
         message_id = event.message_id
         group_id = event.group_id
-        if group_id in message_id_dict:
-            if message_id in message_id_dict[group_id]:
-                to_learn = False
-        else:
+        if group_id not in message_id_dict:
             message_id_dict[group_id] = deque(maxlen=100)
+        if message_id in message_id_dict[group_id]:
+            return
+        message_id_dict[group_id].append(message_id)
 
-        group_message = message_id_dict[group_id]
-        group_message.append(message_id)
+    norm_raw = _normalize_group_raw_message(event.raw_message)
+    if await _should_skip_duplicate_group_event(event.group_id, event.user_id, norm_raw, event.time):
+        return
 
     chat: Chat = Chat(event)
 
@@ -203,12 +229,11 @@ async def _(bot: Bot, event: GroupMessageEvent):
     if await config.is_cooldown("repeat"):
         answers = await chat.answer()
 
-    if to_learn:
-        for seg in event.message:
-            if seg.type == "image":
-                await insert_image(seg)
+    for seg in event.message:
+        if seg.type == "image":
+            await insert_image(seg)
 
-        await chat.learn()
+    await chat.learn()
 
     if not answers:
         return

--- a/src/plugins/repeater/test_group_event_dedup.py
+++ b/src/plugins/repeater/test_group_event_dedup.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_should_skip_duplicate_group_event_same_sig_only_once():
+    import src.plugins.repeater as repeater_pkg
+
+    gid, uid, raw, t = 733291779, 1234567890, "[CQ:at,qq=1] 问你晚饭吃什么", 1746358610
+    assert await repeater_pkg._should_skip_duplicate_group_event(gid, uid, raw, t) is False
+    assert await repeater_pkg._should_skip_duplicate_group_event(gid, uid, raw, t) is True
+    assert await repeater_pkg._should_skip_duplicate_group_event(gid, uid, raw, t) is True
+
+
+@pytest.mark.asyncio
+async def test_should_skip_duplicate_group_event_different_time_not_skipped():
+    import src.plugins.repeater as repeater_pkg
+
+    gid, uid, raw = 1, 2, "你好"
+    assert await repeater_pkg._should_skip_duplicate_group_event(gid, uid, raw, 100) is False
+    assert await repeater_pkg._should_skip_duplicate_group_event(gid, uid, raw, 101) is False
+
+
+def test_normalize_group_raw_message_matches_chatdata_pattern():
+    import src.plugins.repeater as repeater_pkg
+
+    # 与 ChatData 一致：去掉 `.image,...]` 中的可变片段（若存在）
+    raw = "prefix.image,subtype=9]"
+    assert repeater_pkg._normalize_group_raw_message(raw) == "prefix.image]"


### PR DESCRIPTION
## Summary by Sourcery

为多机器人环境中的重复群消息添加去重机制，避免冗余处理和意外复读。

Bug Fixes:
- 防止复读插件对通过不同机器人连接多次上报的相同群事件进行重复处理。

Enhancements:
- 规范化群原始消息以生成一致的签名，并将新的去重逻辑集成到复读消息处理器中以跳过重复消息。

Tests:
- 添加异步测试，用于验证群事件去重行为和消息规范化逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a deduplication mechanism for repeated group messages across multiple bots to avoid redundant processing and unintended repeats.

Bug Fixes:
- Prevent the repeater plugin from reprocessing identical group events reported multiple times via different bot connections.

Enhancements:
- Normalize group raw messages for consistent signature generation and integrate the new dedup logic into the repeater message handler to skip duplicates.

Tests:
- Add async tests to verify group event deduplication behavior and message normalization logic.

</details>