### PR TITLE
fix(request_handler): 被过滤好友 API 解析与批量拒绝

### DIFF
--- a/src/plugins/pallas_webui/extended_api.py
+++ b/src/plugins/pallas_webui/extended_api.py
@@ -639,22 +639,40 @@ async def _call_get_friend_list(
     return out, None, truncated
 
 
+def _rows_from_doubt_friends_api(raw: object) -> list[dict[str, Any]]:
+    if isinstance(raw, list):
+        return [x for x in raw if isinstance(x, dict)]
+    if isinstance(raw, dict):
+        data = raw.get("data")
+        if isinstance(data, list):
+            return [x for x in data if isinstance(x, dict)]
+    return []
+
+
 async def _call_get_doubt_friends(bot: object) -> list[dict[str, Any]]:
     try:
         raw = await bot.call_api("get_doubt_friends_add_request", count=50)  # type: ignore[union-attr]
     except Exception:  # noqa: BLE001
         return []
-    if not isinstance(raw, list):
-        return []
+    rows = _rows_from_doubt_friends_api(raw)
     out: list[dict[str, Any]] = []
-    for x in raw:
-        if not isinstance(x, dict) or "user_id" not in x:
+    for x in rows:
+        uid_raw = x.get("user_id")
+        if uid_raw is None:
+            uid_raw = x.get("uin")
+        if uid_raw is None:
             continue
         try:
-            uid = int(x["user_id"])
+            uid = int(uid_raw)
         except (TypeError, ValueError):
             continue
-        out.append({"user_id": uid, "flag": str(x.get("flag", ""))})
+        flag = x.get("flag")
+        if flag is None:
+            continue
+        flag_str = str(flag).strip()
+        if not flag_str:
+            continue
+        out.append({"user_id": uid, "flag": flag_str})
     return out
 
 

--- a/src/plugins/request_handler/__init__.py
+++ b/src/plugins/request_handler/__init__.py
@@ -440,14 +440,48 @@ if _approval_notice_dirty:
 _APPROVE_REPLY_TEXT = frozenset({"", "同意", "好", "yes", "y", "ok"})
 
 
+def rows_from_doubt_friends_api(result: object) -> list[dict]:
+    if isinstance(result, list):
+        return [x for x in result if isinstance(x, dict)]
+    if isinstance(result, dict):
+        data = result.get("data")
+        if isinstance(data, list):
+            return [x for x in data if isinstance(x, dict)]
+    return []
+
+
+def uid_flag_from_doubt_friend_row(item: dict) -> tuple[str, str] | None:
+    flag = item.get("flag")
+    if flag is None:
+        return None
+    flag_str = str(flag).strip()
+    if not flag_str:
+        return None
+    uid_raw = item.get("user_id")
+    if uid_raw is None:
+        uid_raw = item.get("uin")
+    if uid_raw is None:
+        return None
+    uid_str = str(uid_raw).strip()
+    if not uid_str:
+        return None
+    return uid_str, flag_str
+
+
 async def fetch_doubt_friends(bot: Bot) -> dict[str, str]:
     """获取被过滤的好友申请"""
     try:
         result = await bot.call_api("get_doubt_friends_add_request", count=50)
-        if isinstance(result, list):
-            return {str(item["user_id"]): item["flag"] for item in result}
-    except Exception:
-        pass
+        out: dict[str, str] = {}
+        for item in rows_from_doubt_friends_api(result):
+            pair = uid_flag_from_doubt_friend_row(item)
+            if pair is None:
+                continue
+            uid_str, flag_str = pair
+            out[uid_str] = flag_str
+        return out
+    except Exception as e:
+        logger.debug("get_doubt_friends_add_request 调用异常: {}", e)
     return {}
 
 

--- a/src/plugins/request_handler/__init__.py
+++ b/src/plugins/request_handler/__init__.py
@@ -38,6 +38,7 @@ __plugin_meta__ = PluginMetadata(
 同意好友 <QQ> — 同意指定 QQ 的好友申请
 拒绝好友 <QQ> — 拒绝指定 QQ 的好友申请
 同意所有好友 — 同意当前全部好友申请
+拒绝所有好友 — 拒绝当前全部好友申请
 查看入群邀请 — 列出待处理入群邀请
 同意入群 <群号> — 同意指定群的邀请
 同意所有入群 — 同意当前全部入群邀请
@@ -83,9 +84,9 @@ __plugin_meta__ = PluginMetadata(
             {
                 "func": "批量审批",
                 "trigger_method": "on_cmd",
-                "trigger_condition": "同意所有好友 / 同意所有入群",
-                "brief_des": "一次性全部同意",
-                "detail_des": "同意当前所有待处理好友申请，或所有待处理入群邀请",
+                "trigger_condition": "同意所有好友 / 拒绝所有好友 / 同意所有入群",
+                "brief_des": "好友或入群批量同意/拒绝",
+                "detail_des": "一次性同意或拒绝当前全部待处理好友申请，或同意全部入群邀请",
             },
             {
                 "func": "入群邀请审批",
@@ -134,7 +135,7 @@ RH_LIST_TAIL_FRIEND = (
     "• 私聊只发「同意」→ 处理牛牛最新一条好友审批提醒；\n"
     "• 引用某条审批消息后再发 同意 → 只处理那条对应的申请；\n"
     "• 「同意好友 <QQ号>」→ 按号码同意、「拒绝好友 <QQ号>」→ 按号码拒绝；\n"
-    "• 「同意所有好友」→ 当前表里剩余的全部同意。"
+    "• 「同意所有好友」→ 全部同意、「拒绝所有好友」→ 全部拒绝。"
 )
 RH_LIST_TAIL_GROUP = (
     "怎么操作：\n"
@@ -606,6 +607,7 @@ list_friends_cmd = on_command("查看好友申请", priority=5, block=True)
 approve_latest_cmd = on_command("同意", priority=5, block=True)
 approve_friend_cmd = on_command("同意好友", priority=5, block=True)
 approve_all_friends_cmd = on_command("同意所有好友", priority=5, block=True)
+reject_all_friends_cmd = on_command("拒绝所有好友", priority=5, block=True)
 list_groups_cmd = on_command("查看入群邀请", priority=5, block=True)
 approve_group_cmd = on_command("同意入群", priority=5, block=True)
 approve_all_groups_cmd = on_command("同意所有入群", priority=5, block=True)
@@ -976,6 +978,45 @@ async def handle_approve_all_friends(bot: Bot, event: MessageEvent):
         clear_quick_approve_state(bot_key, "friend", uid)
 
     await approve_all_friends_cmd.finish(f"已同意 {ok} 条好友申请" + (f"，{fail} 条失败" if fail else ""))
+
+
+@reject_all_friends_cmd.handle()
+async def handle_reject_all_friends(bot: Bot, event: MessageEvent):
+    if not await PERM(bot, event):
+        return
+    bot_key = str(bot.self_id)
+    bot_pending = pending_friend.get(bot_key, {})
+    doubt_requests = await fetch_doubt_friends(bot)
+    cached_doubt_friend[bot_key] = doubt_requests
+
+    if not bot_pending and not doubt_requests:
+        await reject_all_friends_cmd.finish("暂无待处理好友申请")
+
+    ok, fail = 0, 0
+    cleared_friend_ids: set[str] = set()
+    for uid, flag in list(bot_pending.items()):
+        try:
+            await bot.set_friend_add_request(flag=flag, approve=False)
+            bot_pending.pop(uid, None)
+            ok += 1
+            cleared_friend_ids.add(uid)
+        except Exception:
+            fail += 1
+    save_json(FRIEND_REQ_FILE, pending_friend)
+
+    for uid, flag in list(doubt_requests.items()):
+        try:
+            await bot.call_api("set_doubt_friends_add_request", flag=flag, approve=False)
+            cached_doubt_friend[bot_key].pop(uid, None)
+            ok += 1
+            cleared_friend_ids.add(uid)
+        except Exception:
+            fail += 1
+
+    for uid in cleared_friend_ids:
+        clear_quick_approve_state(bot_key, "friend", uid)
+
+    await reject_all_friends_cmd.finish(f"已拒绝 {ok} 条好友申请" + (f"，{fail} 条失败" if fail else ""))
 
 
 @approve_all_groups_cmd.handle()


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

为待处理的好友请求添加批量拒绝支持，并加强对“已过滤好友” API 响应的处理健壮性。

新功能：
- 引入一个命令，用于拒绝所有待处理的好友请求，并将其集成到批量同意工作流和帮助文本中。

错误修复：
- 使对“已过滤好友”（疑似好友）API 响应的解析在请求处理器和 WebUI 扩展 API 中都能稳健应对不同的返回结构和缺失字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add bulk rejection support for pending friend requests and harden handling of filtered-friend API responses.

New Features:
- Introduce a command to reject all pending friend requests and integrate it into the batch approval workflow and help text.

Bug Fixes:
- Make parsing of the filtered-friend (doubt friends) API responses robust to different return shapes and missing fields in both the request handler and WebUI extended API.

</details>