### PR TITLE
fix(pallas_protocol): 修复资产版本下拉页

### DIFF
--- a/src/plugins/pallas_protocol/web/pages.py
+++ b/src/plugins/pallas_protocol/web/pages.py
@@ -3352,30 +3352,55 @@ def render_protocol_assets_page(base_path: str, pallas_console_http_base: str = 
     }}
     async function loadAssetReleases() {{
       const btn = document.getElementById("btnLoadReleases");
-      btn.disabled = true;
-      btn.textContent = "加载中…";
+      const ra = document.getElementById("releasesArea");
+      const rp = document.getElementById("releasesPlaceholder");
+      const sel = document.getElementById("releaseSelect");
+      if (!sel || !ra || !rp) return;
+      if (btn) {{
+        btn.disabled = true;
+        btn.textContent = "加载中…";
+      }}
       try {{
         const url = assetsProtoIsSl()
           ? "/api/snowluma/runtime/releases?limit=200"
           : "/api/runtime/releases?limit=200";
         const data = await api(url);
-        const releases = data.releases || [];
-        _assetReleaseList = releases;
-        const sel = document.getElementById("releaseSelect");
-        sel.innerHTML = releases.map((r) => {{
-          const label = r.tag_name + (r.prerelease ? " (pre)" : "") + (r.name && r.name !== r.tag_name ? " · " + r.name : "");
-          return `<option value="${{r.tag_name}}">${{label}}</option>`;
+        const raw = Array.isArray(data.releases) ? data.releases : [];
+        _assetReleaseList = raw
+          .map((x) => {{
+            const tn = String(x.tag_name || x.tag || "").trim();
+            if (!tn) return null;
+            return {{ ...x, tag_name: tn }};
+          }})
+          .filter(Boolean);
+        if (!_assetReleaseList.length) {{
+          sel.innerHTML = "";
+          ra.style.display = "block";
+          rp.style.display = "block";
+          rp.textContent =
+            "未获取到版本列表（请检查仓库配置、网络或 GitHub API 限流；可在配置中设置 pallas_protocol_github_token）。";
+          const det = document.getElementById("releaseDetail");
+          if (det) det.textContent = "";
+          return;
+        }}
+        rp.style.display = "none";
+        sel.innerHTML = _assetReleaseList.map((r) => {{
+          const tag = r.tag_name;
+          const label = tag + (r.prerelease ? " (pre)" : "") + (r.name && r.name !== tag ? " · " + r.name : "");
+          return `<option value="${{invEsc(tag)}}">${{invEsc(label)}}</option>`;
         }}).join("");
-        document.getElementById("releasesArea").style.display = "block";
-        document.getElementById("releasesPlaceholder").style.display = "none";
+        ra.style.display = "block";
         updateAssetReleaseDetail();
         sel.onchange = () => updateAssetReleaseDetail();
-        if (typeof shellPrettySyncSelect === "function" && sel) shellPrettySyncSelect(sel);
+        if (typeof initShellPrettySelects === "function") initShellPrettySelects(ra);
+        if (typeof shellPrettySyncSelect === "function") shellPrettySyncSelect(sel);
       }} catch (e) {{
         alert("加载 release 列表失败: " + (e.message || e));
       }} finally {{
-        btn.disabled = false;
-        btn.textContent = "加载版本列表";
+        if (btn) {{
+          btn.disabled = false;
+          btn.textContent = "加载版本列表";
+        }}
       }}
     }}
     function updateAssetReleaseDetail() {{


### PR DESCRIPTION
## Summary by Sourcery

改进协议资产页面中资产发行下拉菜单的加载行为和健壮性。

新功能：
- 当无法获取任何资产发行信息时，向用户显示提示信息，并给出可能的配置或网络问题的指引。

错误修复：
- 更加防御性地处理缺失或格式错误的发行数据，避免导致资产发行下拉菜单失效。
- 当协议资产页面上缺少加载按钮或与发行相关的 DOM 元素时，避免抛出错误。

增强项：
- 在使用前对发行标签名称进行清理和规范化，并在渲染发行下拉菜单时对选项的值/标签进行转义。
- 将发行下拉菜单与 shell pretty select 的初始化集成，以在加载发行信息后保持样式同步。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the asset release dropdown loading behavior and robustness on the protocol assets page.

New Features:
- Display a user-facing message when no asset releases can be retrieved, with guidance on potential configuration or network issues.

Bug Fixes:
- Handle missing or malformed release data more defensively to avoid breaking the asset release dropdown.
- Avoid errors when the load button or release-related DOM elements are absent on the protocol assets page.

Enhancements:
- Sanitize and normalize release tag names before use and escape option values/labels when rendering the releases dropdown.
- Integrate the release dropdown with the shell pretty select initialization to keep styling in sync after loading releases.

</details>