### PR TITLE
feat(pallas_protocol): 使用 ioctl 获取 Linux docker0 网卡 IP 替代默认路由网关

### DIFF
--- a/docs/plugins/pallas_protocol/README.md
+++ b/docs/plugins/pallas_protocol/README.md
@@ -25,7 +25,7 @@
 | `PALLAS_PROTOCOL_GITHUB_TOKEN` | 拉 Release 时限额（可选） |
 | `PALLAS_PROTOCOL_ONEBOT_WS_URL` | 完整反向 WebSocket 地址（最高优先级；常见为明文 `ws`，见下节） |
 | `PALLAS_PROTOCOL_ONEBOT_WS_HOST` / `_PORT` / `_PATH` | 未设 URL 时按主机、端口、路径拼接反向 WebSocket 地址 |
-| `PALLAS_PROTOCOL_DOCKER_ONEBOT_HOST` | NapCat/SnowLuma 容器访问宿主机 Bot；**留空或 `auto`**：`bridge` 在 **Linux** 下为默认路由网关（读 `/proc/net/route`）或回退 `172.17.0.1`；**非 Linux** 常为 `host.docker.internal`；`host` 网络为 `127.0.0.1`；仍会在 `docker run` 加 `host.docker.internal:host-gateway`（Docker 20.10+）作辅助解析 |
+| `PALLAS_PROTOCOL_DOCKER_ONEBOT_HOST` | NapCat/SnowLuma 容器访问宿主机 Bot；**留空或 `auto`**：`bridge` 在 **Linux** 下为 `docker0` 网卡 IPv4（ioctl）或回退 `172.17.0.1`（不用系统默认路由网关，避免写成局域网路由器）；**非 Linux** 常为 `host.docker.internal`；`host` 网络为 `127.0.0.1`；仍会在 `docker run` 加 `host.docker.internal:host-gateway`（Docker 20.10+）作辅助解析 |
 | `PALLAS_PROTOCOL_AUTO_DOWNLOAD_RUNTIME` | 无本地运行时是否后台下载 |
 | `PALLAS_PROTOCOL_PROGRAM_DIR` | 手动指定 NapCat 发行根 |
 | `PALLAS_PROTOCOL_DOCKER_IMAGE` | NapCat 镜像（可被 profile 覆盖） |

--- a/src/plugins/pallas_protocol/config.py
+++ b/src/plugins/pallas_protocol/config.py
@@ -122,7 +122,8 @@ class Config(BaseModel):
     )
     pallas_protocol_docker_onebot_host: str = Field(
         default="",
-        description="容器访问宿主机 Bot 的主机名或 IP；空或 auto 为自动（bridge→host.docker.internal，host→127.0.0.1）",
+        description="容器访问宿主机 Bot 的主机名或 IP；"
+        "空或 auto：Linux bridge 为 docker0 地址或 172.17.0.1，host 为 127.0.0.1，其它常为 host.docker.internal",
     )
     pallas_protocol_docker_internal_webui_port: int = Field(
         default=6099,

--- a/src/plugins/pallas_protocol/docker_onebot_host.py
+++ b/src/plugins/pallas_protocol/docker_onebot_host.py
@@ -3,9 +3,44 @@
 from __future__ import annotations
 
 import socket
+import struct
 import sys
 from pathlib import Path
 from typing import Any
+
+
+def linux_interface_ipv4(ifname: str) -> str | None:
+    """读取指定网卡 IPv4；非 Linux 或失败时返回 None。"""
+    if not sys.platform.startswith("linux"):
+        return None
+    try:
+        import fcntl
+    except ImportError:
+        return None
+    name = (ifname or "").strip().encode("utf-8")[:15]
+    if not name:
+        return None
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # SIOCGIFADDR
+        ifreq = struct.pack("16sH14s", name, socket.AF_INET, b"\x00" * 14)
+        res = fcntl.ioctl(sock.fileno(), 0x8915, ifreq)
+    except OSError:
+        return None
+    finally:
+        sock.close()
+    fam = struct.unpack_from("H", res, 16)[0]
+    if fam != socket.AF_INET:
+        return None
+    ip = socket.inet_ntoa(res[20:24])
+    if ip == "0.0.0.0":
+        return None
+    return ip
+
+
+def linux_docker_bridge_host_ip() -> str | None:
+    """宿主机上默认 bridge（docker0）的 IPv4，即容器内访问宿主机常用地址。"""
+    return linux_interface_ipv4("docker0")
 
 
 def linux_default_route_gateway() -> str | None:
@@ -39,8 +74,8 @@ def effective_docker_onebot_host(raw: str | None, *, docker_network_mode: str) -
 
     - 非空且非 ``auto``：原样使用（便于 Compose 同网主机名等）。
     - ``host`` 网络：自动为 ``127.0.0.1``（与宿主机网络栈一致）。
-    - ``bridge`` 等且自动：**Linux** 优先默认路由网关（读 ``/proc/net/route``），失败则
-      ``172.17.0.1``；容器内不依赖 ``host.docker.internal`` 解析。**非 Linux**（如仅在本机
+    - ``bridge`` 等且自动：**Linux** 优先 ``docker0`` 网卡地址（ioctl），失败则 ``172.17.0.1``；
+      不用系统默认路由网关（常为局域网路由器，从容器内连 Bot 会错）。**非 Linux**（如仅在本机
       配协议端）仍可用 ``host.docker.internal``（通常配合 Docker Desktop）。
     - ``docker run`` 仍会加 ``--add-host=host.docker.internal:host-gateway``，便于镜像内其它逻辑解析。
     """
@@ -51,7 +86,7 @@ def effective_docker_onebot_host(raw: str | None, *, docker_network_mode: str) -
     if mode == "host":
         return "127.0.0.1"
     if sys.platform.startswith("linux"):
-        return linux_default_route_gateway() or "172.17.0.1"
+        return linux_docker_bridge_host_ip() or "172.17.0.1"
     return "host.docker.internal"
 
 

--- a/tests/plugins/pallas_protocol/test_docker_onebot_host.py
+++ b/tests/plugins/pallas_protocol/test_docker_onebot_host.py
@@ -27,12 +27,12 @@ def test_linux_default_route_gateway_reads_proc_net_route(monkeypatch) -> None:
 def test_effective_docker_onebot_host_explicit_and_auto(monkeypatch) -> None:
     from src.plugins.pallas_protocol import docker_onebot_host as m
 
-    monkeypatch.setattr(m, "linux_default_route_gateway", lambda: "10.200.0.1")
+    monkeypatch.setattr(m, "linux_docker_bridge_host_ip", lambda: "10.5.0.1")
     monkeypatch.setattr(m.sys, "platform", "linux")
-    assert m.effective_docker_onebot_host("", docker_network_mode="bridge") == "10.200.0.1"
-    assert m.effective_docker_onebot_host("auto", docker_network_mode="bridge") == "10.200.0.1"
+    assert m.effective_docker_onebot_host("", docker_network_mode="bridge") == "10.5.0.1"
+    assert m.effective_docker_onebot_host("auto", docker_network_mode="bridge") == "10.5.0.1"
 
-    monkeypatch.setattr(m, "linux_default_route_gateway", lambda: None)
+    monkeypatch.setattr(m, "linux_docker_bridge_host_ip", lambda: None)
     assert m.effective_docker_onebot_host("", docker_network_mode="bridge") == "172.17.0.1"
 
     monkeypatch.setattr(m.sys, "platform", "win32")


### PR DESCRIPTION
## Summary by Sourcery

在 Linux 上，将 Docker OneBot 主机检测方式从默认路由网关切换为使用 `docker0` 网桥 IP，并相应更新相关配置、测试和文档。

新功能：
- 添加一个辅助工具，通过 `ioctl` 获取指定 Linux 网络接口的 IPv4 地址，并用它解析容器所使用的 `docker0` 网桥主机 IP。

错误修复：
- 在 Linux 桥接网络上，避免将系统默认路由网关（通常是局域网路由器）用作容器访问主机的地址，以防止导致 Bot 连接路由错误。

文档：
- 更新配置说明和插件 README，记录 Docker OneBot 容器在 Linux 上基于 `docker0` 的主机检测新行为。

测试：
- 调整 Docker OneBot 主机相关测试，使其覆盖新的基于 `docker0` 的主机 IP 解析逻辑，而不是默认路由网关。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch Docker OneBot host detection on Linux from default route gateway to the docker0 bridge IP and update related config, tests, and docs accordingly.

New Features:
- Add helper to retrieve IPv4 address of a specific Linux network interface via ioctl and use it to resolve the docker0 bridge host IP for containers.

Bug Fixes:
- Avoid using the system default route gateway (often a LAN router) as the container-to-host address on Linux bridge networks to prevent misrouting Bot connections.

Documentation:
- Update configuration description and plugin README to document the new Linux docker0-based host detection behavior for Docker OneBot containers.

Tests:
- Adjust Docker OneBot host tests to cover the new docker0-based host IP resolution logic instead of the default route gateway.

</details>