### PR TITLE
feat(pallas_webui): 新增通用配置段功能支持

### DIFF
--- a/src/common/env_dotenv.py
+++ b/src/common/env_dotenv.py
@@ -1,0 +1,47 @@
+"""项目根 `.env` 读写。"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def repo_env_path() -> Path:
+    return Path(__file__).resolve().parents[2] / ".env"
+
+
+def env_value_to_str(v: Any) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (dict, list)):
+        return json.dumps(v, ensure_ascii=False)
+    if v is None:
+        return ""
+    return str(v)
+
+
+def upsert_env_dotenv_items(items: dict[str, str]) -> None:
+    path = repo_env_path()
+    if path.exists():
+        lines = path.read_text(encoding="utf-8").splitlines()
+    else:
+        lines = []
+    remained = set(items.keys())
+    out: list[str] = []
+    for line in lines:
+        replaced = False
+        for k, v in items.items():
+            if re.match(rf"^\s*#?\s*{re.escape(k)}\s*=", line):
+                out.append(f"{k}={v}")
+                remained.discard(k)
+                replaced = True
+                break
+        if not replaced:
+            out.append(line)
+    if remained:
+        if out and out[-1].strip() != "":
+            out.append("")
+        out.extend(f"{k}={items[k]}" for k in sorted(remained))
+    path.write_text("\n".join(out) + "\n", encoding="utf-8")

--- a/src/common/webui_env_sections.py
+++ b/src/common/webui_env_sections.py
@@ -1,0 +1,171 @@
+"""在 WebUI 中暴露的「通用配置段」：对应 src/common 下走 .env 的 Pydantic 模型。
+
+新增段：在本文件 `_SECTIONS` 中追加 `WebuiEnvSection` 即可。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import util as importlib_util
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
+
+from src.common.env_dotenv import env_value_to_str, upsert_env_dotenv_items
+
+
+@lru_cache(maxsize=1)
+def _message_scrub_models() -> tuple[type[BaseModel], Any]:
+    path = Path(__file__).resolve().parent / "message_scrub" / "config.py"
+    name = "_pallas_webui_message_scrub_config"
+    spec = importlib_util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"message_scrub 配置模块未找到: {path}")
+    mod = importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.MessageScrubConfig, mod.get_message_scrub_config
+
+
+def _field_kind_from_annotation(ann: Any) -> str:
+    text = str(ann).lower()
+    if "list" in text or "dict" in text or "set" in text or "tuple" in text:
+        return "json"
+    if "bool" in text:
+        return "bool"
+    if "int" in text:
+        return "int"
+    if "float" in text:
+        return "float"
+    return "string"
+
+
+def _jsonable_value(v: Any) -> Any:
+    if v is PydanticUndefined:
+        return None
+    if isinstance(v, BaseModel):
+        return v.model_dump(mode="python")
+    if isinstance(v, dict):
+        return {str(k): _jsonable_value(val) for k, val in v.items()}
+    if isinstance(v, list):
+        return [_jsonable_value(x) for x in v]
+    if isinstance(v, (set, tuple)):
+        return [_jsonable_value(x) for x in v]
+    return v
+
+
+@dataclass(frozen=True)
+class WebuiEnvSection:
+    id: str
+    title: str
+    module_label: str
+    model_cls: type[BaseModel]
+    read_current: Any
+    field_to_env: dict[str, str]
+    skip_fields: frozenset[str]
+
+
+def _message_scrub_section() -> WebuiEnvSection:
+    msg_cfg_cls, get_msg_cfg = _message_scrub_models()
+    field_to_env = {
+        "inbound_filter_substrings": "PALLAS_INBOUND_FILTER_SUBSTRINGS",
+        "scrub_lexicon_path": "PALLAS_SCRUB_LEXICON_PATH",
+        "scrub_lexicon_extra": "PALLAS_SCRUB_LEXICON_EXTRA",
+        "scrub_review_providers": "PALLAS_SCRUB_REVIEW_PROVIDERS",
+        "scrub_api_url": "PALLAS_SCRUB_API_URL",
+        "inbound_filter_api_url": "PALLAS_INBOUND_FILTER_API_URL",
+        "inbound_filter_api_key": "PALLAS_INBOUND_FILTER_API_KEY",
+        "inbound_filter_api_timeout_sec": "PALLAS_INBOUND_FILTER_API_TIMEOUT_SEC",
+        "inbound_filter_api_fail_open": "PALLAS_INBOUND_FILTER_API_FAIL_OPEN",
+        "scrub_baidu_api_key": "PALLAS_SCRUB_BAIDU_API_KEY",
+        "scrub_baidu_secret_key": "PALLAS_SCRUB_BAIDU_SECRET_KEY",
+        "scrub_baidu_censor_url": "PALLAS_SCRUB_BAIDU_CENSOR_URL",
+        "scrub_baidu_strategy_id": "PALLAS_SCRUB_BAIDU_STRATEGY_ID",
+        "scrub_baidu_block_suspected": "PALLAS_SCRUB_BAIDU_BLOCK_SUSPECTED",
+    }
+    return WebuiEnvSection(
+        id="message_scrub",
+        title="消息审查 / 入站过滤",
+        module_label="src.common.message_scrub",
+        model_cls=msg_cfg_cls,
+        read_current=get_msg_cfg,
+        field_to_env=field_to_env,
+        skip_fields=frozenset({"scrub_review_providers_key_present"}),
+    )
+
+
+_sections_cache: tuple[WebuiEnvSection, ...] | None = None
+
+
+def _registered_sections() -> tuple[WebuiEnvSection, ...]:
+    global _sections_cache
+    if _sections_cache is not None:
+        return _sections_cache
+    parts: list[WebuiEnvSection] = []
+    if (Path(__file__).resolve().parent / "message_scrub" / "config.py").is_file():
+        parts.append(_message_scrub_section())
+    _sections_cache = tuple(parts)
+    return _sections_cache
+
+
+def list_webui_env_sections() -> list[dict[str, str]]:
+    return [{"id": s.id, "title": s.title} for s in _registered_sections()]
+
+
+def get_webui_env_section(section_id: str) -> WebuiEnvSection:
+    sid = (section_id or "").strip()
+    for s in _registered_sections():
+        if s.id == sid:
+            return s
+    raise ValueError(f"未知 common-config: {section_id}")
+
+
+def webui_env_section_payload(section_id: str) -> dict[str, Any]:
+    s = get_webui_env_section(section_id)
+    cfg_obj = s.read_current()
+    fields: list[dict[str, Any]] = []
+    for key, f in s.model_cls.model_fields.items():
+        if key in s.skip_fields:
+            continue
+        env_key = s.field_to_env.get(key)
+        if not env_key:
+            continue
+        cur = getattr(cfg_obj, key, f.default)
+        default_value = None if f.default is PydanticUndefined else f.default
+        fields.append({
+            "name": key,
+            "kind": _field_kind_from_annotation(f.annotation),
+            "required": bool(f.is_required()),
+            "description": str(f.description or ""),
+            "env_key": env_key,
+            "default": _jsonable_value(default_value),
+            "current": _jsonable_value(cur),
+        })
+    return {
+        "plugin": s.id,
+        "module": s.module_label,
+        "fields": fields,
+    }
+
+
+def apply_webui_env_section_patch(section_id: str, patch: dict[str, Any]) -> dict[str, Any]:
+    s = get_webui_env_section(section_id)
+    current = s.read_current().model_dump(mode="python")
+    allowed = set(s.field_to_env.keys()) - set(s.skip_fields)
+    for k in patch:
+        if k not in allowed:
+            raise ValueError(f"未知配置项: {k}")
+    merged = {**current, **patch}
+    validated = s.model_cls(**merged).model_dump(mode="python")
+    items = {s.field_to_env[k]: env_value_to_str(validated[k]) for k in patch}
+    upsert_env_dotenv_items(items)
+    if section_id == "message_scrub":
+        try:
+            from src.common.inbound_filter import reload_inbound_filter_needles
+
+            reload_inbound_filter_needles()
+        except Exception:
+            pass
+    return webui_env_section_payload(section_id)

--- a/src/plugins/pallas_webui/extended_api.py
+++ b/src/plugins/pallas_webui/extended_api.py
@@ -7,7 +7,6 @@ import importlib
 import json
 import os
 import platform
-import re
 import shutil
 import socket
 import sys
@@ -24,6 +23,7 @@ from nonebot.adapters import Event  # noqa: TC002
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic_core import PydanticUndefined
 
+from src.common.env_dotenv import env_value_to_str, upsert_env_dotenv_items
 from src.common.pallas_console_login import (
     current_http_request,
     extract_session_from_request,
@@ -167,10 +167,6 @@ def _jsonable_value(v: Any) -> Any:
     return v
 
 
-def _plugin_env_path() -> Path:
-    return Path(__file__).resolve().parents[3] / ".env"
-
-
 def _find_loaded_plugin(plugin_name: str):
     target = (plugin_name or "").strip()
     for p in get_loaded_plugins():
@@ -241,42 +237,6 @@ def _plugin_config_payload(plugin_name: str) -> dict[str, Any]:
     }
 
 
-def _to_env_value(v: Any) -> str:
-    if isinstance(v, bool):
-        return "true" if v else "false"
-    if isinstance(v, (dict, list)):
-        return json.dumps(v, ensure_ascii=False)
-    if v is None:
-        return ""
-    return str(v)
-
-
-def _upsert_env_items(items: dict[str, str]) -> None:
-    path = _plugin_env_path()
-    if path.exists():
-        lines = path.read_text(encoding="utf-8").splitlines()
-    else:
-        lines = []
-    remained = set(items.keys())
-    out: list[str] = []
-    for line in lines:
-        replaced = False
-        for k, v in items.items():
-            # 同名键若存在注释行，直接改写并取消注释
-            if re.match(rf"^\s*#?\s*{re.escape(k)}\s*=", line):
-                out.append(f"{k}={v}")
-                remained.discard(k)
-                replaced = True
-                break
-        if not replaced:
-            out.append(line)
-    if remained:
-        if out and out[-1].strip() != "":
-            out.append("")
-        out.extend(f"{k}={items[k]}" for k in sorted(remained))
-    path.write_text("\n".join(out) + "\n", encoding="utf-8")
-
-
 def _list_bots_dict() -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for key, bot in get_bots().items():
@@ -321,7 +281,6 @@ def _is_onebot_v11_bot(bot: object) -> bool:
 
 def _read_pending_friend_requests_disk() -> dict[str, dict[str, str]]:
     """与 request_handler 插件写入的 JSON 结构一致：{ bot_id: { user_id: flag } }。"""
-    import json
 
     from src.common.paths import plugin_data_dir
 
@@ -344,8 +303,6 @@ def _read_pending_friend_requests_disk() -> dict[str, dict[str, str]]:
 
 
 def _save_pending_friend_requests_disk(data: dict[str, dict[str, str]]) -> None:
-    import json
-
     from src.common.paths import plugin_data_dir
 
     path = plugin_data_dir("request_handler") / "pending_friend_requests.json"
@@ -354,7 +311,6 @@ def _save_pending_friend_requests_disk(data: dict[str, dict[str, str]]) -> None:
 
 def _read_pending_group_requests_disk() -> dict[str, dict[str, dict[str, Any]]]:
     """与 request_handler 插件写入的 JSON 结构一致：{ bot_id: { group_id: request } }。"""
-    import json
 
     from src.common.paths import plugin_data_dir
 
@@ -397,8 +353,6 @@ def _read_pending_group_requests_disk() -> dict[str, dict[str, dict[str, Any]]]:
 
 
 def _save_pending_group_requests_disk(data: dict[str, dict[str, dict[str, Any]]]) -> None:
-    import json
-
     from src.common.paths import plugin_data_dir
 
     path = plugin_data_dir("request_handler") / "pending_group_requests.json"
@@ -479,8 +433,6 @@ def _normalize_ai_extension_config(raw: dict[str, Any] | None) -> dict[str, Any]
 
 
 def _load_ai_extension_config() -> dict[str, Any]:
-    import json
-
     path = _ai_extension_config_path()
     if not path.exists():
         return _normalize_ai_extension_config(None)
@@ -494,8 +446,6 @@ def _load_ai_extension_config() -> dict[str, Any]:
 
 
 def _save_ai_extension_config(data: dict[str, Any]) -> dict[str, Any]:
-    import json
-
     clean = _normalize_ai_extension_config(data)
     path = _ai_extension_config_path()
     path.write_text(json.dumps(clean, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -1609,9 +1559,43 @@ def register_extended_api(
                     raise ValueError(f"未知配置项: {k}")
             merged = {**current, **patch}
             validated = cfg_cls(**merged).model_dump(mode="python")
-            env_items = {str(k).upper(): _to_env_value(validated[k]) for k in patch}
-            _upsert_env_items(env_items)
+            env_items = {str(k).upper(): env_value_to_str(validated[k]) for k in patch}
+            upsert_env_dotenv_items(env_items)
             data = _plugin_config_payload(plugin_name)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        except Exception as e:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=str(e)) from e
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.get(f"{x}/common-config/sections", include_in_schema=True)
+    async def _common_config_sections_list() -> JSONResponse:
+        from src.common.webui_env_sections import list_webui_env_sections
+
+        return JSONResponse({"ok": True, "data": list_webui_env_sections()})
+
+    @router.get(f"{x}/common-config/{{section_id}}", include_in_schema=True)
+    async def _common_config_get(section_id: str) -> JSONResponse:
+        from src.common.webui_env_sections import webui_env_section_payload
+
+        try:
+            data = webui_env_section_payload(section_id)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        return JSONResponse({"ok": True, "data": data})
+
+    @router.put(f"{x}/common-config/{{section_id}}", include_in_schema=True)
+    async def _common_config_put(
+        section_id: str,
+        body: _PluginConfigUpdateBody,
+        token: str | None = Query(default=None),
+        x_pallas_token: str | None = Header(default=None, alias="X-Pallas-Token"),
+    ) -> JSONResponse:
+        _check_pallas_write_token(plugin_config, x_pallas_token=x_pallas_token, token=token)
+        from src.common.webui_env_sections import apply_webui_env_section_patch
+
+        try:
+            data = apply_webui_env_section_patch(section_id, dict(body.values or {}))
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
         except Exception as e:  # noqa: BLE001
@@ -2079,7 +2063,6 @@ def register_extended_api(
         path: str,
         body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        import json
         import urllib.error
         import urllib.request
 

--- a/tests/plugins/test_webui_env_sections.py
+++ b/tests/plugins/test_webui_env_sections.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+_MS_CFG = Path(__file__).resolve().parents[2] / "src" / "common" / "message_scrub" / "config.py"
+skip_no_message_scrub = pytest.mark.skipif(not _MS_CFG.is_file(), reason="无 message_scrub 配置模块")
+
+
+@skip_no_message_scrub
+def test_list_webui_env_sections_contains_message_scrub():
+    from src.common.webui_env_sections import list_webui_env_sections
+
+    rows = list_webui_env_sections()
+    ids = {r["id"] for r in rows}
+    assert "message_scrub" in ids
+
+
+@skip_no_message_scrub
+def test_message_scrub_payload_shape():
+    from src.common.webui_env_sections import webui_env_section_payload
+
+    data = webui_env_section_payload("message_scrub")
+    assert data["plugin"] == "message_scrub"
+    assert data["module"]
+    names = {f["name"] for f in data["fields"]}
+    assert "inbound_filter_substrings" in names
+    assert "scrub_review_providers_key_present" not in names
+    for f in data["fields"]:
+        assert f["env_key"]
+        assert f["kind"] in ("bool", "int", "float", "json", "string")
+
+
+@skip_no_message_scrub
+def test_message_scrub_patch_roundtrip(tmp_path, monkeypatch):
+    from src.common import env_dotenv as ed
+    from src.common.webui_env_sections import apply_webui_env_section_patch
+
+    env_file = tmp_path / ".env"
+    monkeypatch.setattr(ed, "repo_env_path", lambda: env_file)
+    apply_webui_env_section_patch("message_scrub", {"inbound_filter_substrings": "a,b"})
+    text = env_file.read_text(encoding="utf-8")
+    assert "PALLAS_INBOUND_FILTER_SUBSTRINGS=a,b" in text


### PR DESCRIPTION
## Summary by Sourcery

引入可通过 WebUI 管理的通用配置段，这些配置由 `.env` 支持，并通过新的扩展 API 端点对外暴露。

新特性：
- 添加 common-config WebUI API 端点，用于列出、读取和更新共享配置段，例如 `message_scrub`。
- 定义 `WebuiEnvSection` 抽象，用于将基于 Pydantic 的配置映射到由 `.env` 支持的环境键，包括 `message_scrub` 配置。

改进：
- 将 `.env` 读写辅助函数重构到共享的 `env_dotenv` 模块中，并在插件配置更新中复用这些函数。
- 通过移除扩展 API 辅助函数中冗余的内联 `json` 导入，简化 JSON 处理。

测试：
- 添加测试，用于验证 `message_scrub` 通用配置段的发现、负载结构以及 `.env` 补丁的往返行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce WebUI-manageable common configuration sections backed by .env and expose them via new extended API endpoints.

New Features:
- Add common-config WebUI API endpoints to list, read, and update shared configuration sections such as message_scrub.
- Define a WebuiEnvSection abstraction for mapping Pydantic-based configs to .env-backed environment keys, including message_scrub configuration.

Enhancements:
- Refactor .env read/write helpers into a shared env_dotenv module and reuse them from plugin configuration updates.
- Simplify JSON handling by removing redundant inline json imports in extended_api helper functions.

Tests:
- Add tests to verify message_scrub common-config section discovery, payload shape, and .env patch roundtrip behavior.

</details>