### PR TITLE
feat(pallas_image): 支持获取头像作为参考图

### DIFF
--- a/src/plugins/pallas_image/draw.py
+++ b/src/plugins/pallas_image/draw.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 
 import httpx
 from nonebot import logger, on_command
@@ -64,6 +65,35 @@ def dedupe_urls(urls: list[str]) -> list[str]:
             seen.add(u)
             out.append(u)
     return out
+
+
+def extract_at_user_ids(msg: Message) -> list[int]:
+    """从消息中提取所有 at 段的用户 ID。"""
+    ids: list[int] = []
+    for seg in msg:
+        if seg.type == "at":
+            uid = seg.data.get("qq")
+            if uid is not None:
+                try:
+                    ids.append(int(uid))
+                except (TypeError, ValueError):
+                    pass
+    return ids
+
+
+_AT_QQ_RE = re.compile(r"@(\d{5,12})")
+
+
+def extract_at_qq_from_text(text: str) -> tuple[list[int], str]:
+    """从纯文本中提取 @QQ号，返回 (QQ号列表, 去除 @QQ 后的文本)。"""
+    ids = [int(m.group(1)) for m in _AT_QQ_RE.finditer(text)]
+    cleaned = _AT_QQ_RE.sub("", text).strip()
+    return ids, cleaned
+
+
+def qq_avatar_url(user_id: int) -> str:
+    """构造 QQ 头像 URL（用于作为参考图）。"""
+    return f"https://q.qlogo.cn/g?b=qq&nk={user_id}&s=0"
 
 
 def image_backends_with_endpoint(
@@ -177,6 +207,31 @@ async def pallas_draw_handle(bot: Bot, event: GroupMessageEvent, args: Message =
         extract_image_urls_from_message(args)
         + (extract_image_urls_from_message(event.reply.message) if event.reply else [])
     )
+
+    # 如果没有图片参考，尝试用 @ 或回复对象的头像作为参考图
+    if not ref_urls:
+        # 合并 at 段和纯文本 @QQ 号
+        at_ids = extract_at_user_ids(args)
+        text_qq_ids, cleaned_text = extract_at_qq_from_text(text)
+        all_at_ids = at_ids + text_qq_ids
+        if text_qq_ids:
+            text = cleaned_text  # 从提示词中去掉 @QQ 号
+
+        avatar_user_id: int | None = None
+        if all_at_ids:
+            # 取第一个不是 bot 自己的 @ 用户
+            bot_self = int(event.self_id)
+            for aid in all_at_ids:
+                if aid != bot_self:
+                    avatar_user_id = aid
+                    break
+        elif event.reply and event.reply.sender:
+            reply_uid = event.reply.sender.user_id
+            if reply_uid != int(event.self_id):
+                avatar_user_id = reply_uid
+        if avatar_user_id is not None:
+            ref_urls.append(qq_avatar_url(avatar_user_id))
+
     if not text and not ref_urls:
         await pallas_draw.finish(
             message_at_user(

--- a/src/plugins/pallas_image/draw.py
+++ b/src/plugins/pallas_image/draw.py
@@ -85,9 +85,14 @@ _AT_QQ_RE = re.compile(r"@(\d{5,12})")
 
 
 def extract_at_qq_from_text(text: str) -> tuple[list[int], str]:
-    """从纯文本中提取 @QQ号，返回 (QQ号列表, 去除 @QQ 后的文本)。"""
+    """从纯文本中提取 @QQ号，返回 (QQ号列表, 去除 @QQ 后的文本)。
+    为避免直接删除 @QQ 导致相邻词语黏连（如 foo@123bar -> foobar），
+    这里先用空格替换 @QQ，再对连续空白做一次折叠。
+    """
     ids = [int(m.group(1)) for m in _AT_QQ_RE.finditer(text)]
-    cleaned = _AT_QQ_RE.sub("", text).strip()
+    # 先用空格替换所有 @QQ，再将多余空白折叠为单个空格
+    cleaned = _AT_QQ_RE.sub(" ", text)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
     return ids, cleaned
 
 
@@ -225,7 +230,7 @@ async def pallas_draw_handle(bot: Bot, event: GroupMessageEvent, args: Message =
                 if aid != bot_self:
                     avatar_user_id = aid
                     break
-        elif event.reply and event.reply.sender:
+        if avatar_user_id is None and event.reply and event.reply.sender:
             reply_uid = event.reply.sender.user_id
             if reply_uid != int(event.self_id):
                 avatar_user_id = reply_uid


### PR DESCRIPTION
## Summary by Sourcery

在 pallas 图像绘制命令中，当没有显式提供图片时，使用被提及或被回复的 QQ 用户头像作为备用参考图像。

新功能：
- 当未提供图片 URL 时，允许绘制命令使用通过 @ 提及的用户 QQ 头像作为参考图像。
- 支持解析纯文本形式的 @QQ号 模式，并在使用对应头像作为参考图像的同时，从提示词中移除这些 @QQ号 文本。
- 当未显式提及任何其他用户时，回退使用被回复消息发送者的 QQ 头像作为参考图像。

增强：
- 通过使用 qlogo 服务构造 QQ 头像 URL，以提升参考图像分辨率。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use mentioned or replied QQ user avatars as fallback reference images when no explicit image is provided in pallas image drawing commands.

New Features:
- Allow drawing commands to use @-mentioned users' QQ avatars as reference images when no image URLs are supplied.
- Support parsing plain-text @QQ-number patterns and stripping them from the prompt while using the corresponding avatar as a reference image.
- Fallback to the replied message sender's QQ avatar as a reference image if no other user is explicitly mentioned.

Enhancements:
- Improve reference image resolution by constructing QQ avatar URLs via the qlogo service.

</details>

close #199 