### PR TITLE
feat(maa): 分片共享 pending 队列与回执跨 worker 投递

### DIFF
--- a/docs/plugins/maa/README.md
+++ b/docs/plugins/maa/README.md
@@ -45,6 +45,7 @@
 | 现象 | 处理 |
 | --- | --- |
 | 未检测到轮询 | MAA 端点不可达或 URL 错误；分片须 hub `maa_public_base_url` 且各 worker 共用 `data/` |
+| 状态有待拉取、MAA 无任务 | 分片时队列在 `data/pallas_shard/coord/maa_pending/`；须 hub 能访问各 worker 端口 |
 | 下发后无任务 | 未绑定或用户标识符非 QQ；查 `牛牛MAA状态` |
 | 队列有、MAA 无 | 设备 id 与「当前选用」不一致；可清空队列重试 |
 | 截图失败 | 调大反代 `client_max_body_size` |

--- a/src/common/shard/coord/bot_action.py
+++ b/src/common/shard/coord/bot_action.py
@@ -182,6 +182,13 @@ async def _execute_local(action: str, bot_qq: int, payload: dict[str, Any]) -> t
             msg = _message_from_payload(payload)
             await inst.send_group_msg(group_id=int(gid), message=msg)
             return True, None
+        if action == "send_private_msg":
+            uid = payload.get("user_id")
+            if uid is None:
+                return False, None
+            msg = _message_from_payload(payload)
+            await inst.send_private_msg(user_id=int(uid), message=msg)
+            return True, None
         if action == "set_group_card":
             uid = payload.get("user_id")
             card = str(payload.get("card") or "")
@@ -240,6 +247,30 @@ async def invoke_bot_action(
     )
     deadline = time.time() + timeout_sec + 2.0
     return await _wait_request(request_id, deadline=deadline)
+
+
+async def send_private_msg_as_bot(
+    bot_qq: int,
+    user_id: int,
+    message: Message | str,
+    *,
+    image_bytes: bytes | None = None,
+    timeout_sec: float = _DEFAULT_TIMEOUT,
+) -> bool:
+    payload: dict[str, Any] = {
+        "user_id": int(user_id),
+        "message_cq": str(message) if isinstance(message, Message) else "",
+        "message_text": str(message) if not isinstance(message, Message) else "",
+    }
+    if image_bytes:
+        payload["image_b64"] = base64.b64encode(image_bytes).decode("ascii")
+    ok, _ = await invoke_bot_action(
+        "send_private_msg",
+        bot_qq,
+        payload,
+        timeout_sec=timeout_sec,
+    )
+    return ok
 
 
 async def send_group_message_as_bot(

--- a/src/common/shard/coord/maa_pending_registry.py
+++ b/src/common/shard/coord/maa_pending_registry.py
@@ -1,0 +1,266 @@
+"""分片：MAA 待拉取任务队列（hub/worker 共享 data，供 getTask / 状态统计）。"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from src.common.paths import plugin_data_dir
+from src.plugins.maa.tasks import normalize_device_id
+
+_PLUGIN = "pallas_shard"
+
+
+def _root() -> Path:
+    root = Path(plugin_data_dir(_PLUGIN, create=True)) / "coord" / "maa_pending"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "queues").mkdir(parents=True, exist_ok=True)
+    (root / "task_index").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _queue_path(user: str, device: str) -> Path | None:
+    u = (user or "").strip()
+    norm = normalize_device_id(device)
+    if not u or not norm:
+        return None
+    return _root() / "queues" / f"{u}_{norm}.json"
+
+
+def _index_path(task_id: str) -> Path:
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in task_id)
+    return _root() / "task_index" / f"{safe}.json"
+
+
+def _lock_path(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".lock")
+
+
+def _acquire_lock(lock_path: Path, *, timeout: float = 3.0) -> int | None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            return os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            try:
+                if time.time() - lock_path.stat().st_mtime > 10.0:
+                    lock_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            time.sleep(0.02)
+    return None
+
+
+def _release_lock(fd: int | None, lock_path: Path) -> None:
+    if fd is not None:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    try:
+        lock_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _write_atomic(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _mutate_queue(path: Path, fn) -> dict[str, Any] | None:
+    lk = _lock_path(path)
+    fd = _acquire_lock(lk)
+    if fd is None:
+        return _read_json(path)
+    try:
+        data = _read_json(path) or {"tasks": {}}
+        tasks = data.get("tasks")
+        if not isinstance(tasks, dict):
+            data["tasks"] = {}
+        fn(data)
+        _write_atomic(path, data)
+        return data
+    finally:
+        _release_lock(fd, lk)
+
+
+def enqueue_task_sync(task: dict[str, Any]) -> None:
+    """task 须含 task_id、user、device 等字段。"""
+    user = str(task.get("user") or "").strip()
+    device = str(task.get("device") or "")
+    path = _queue_path(user, device)
+    if path is None:
+        return
+    task_id = str(task.get("task_id") or "")
+    if not task_id:
+        return
+
+    def add(data: dict[str, Any]) -> None:
+        data["tasks"][task_id] = task
+
+    _mutate_queue(path, add)
+    idx = _index_path(task_id)
+    _write_atomic(
+        idx,
+        {"task_id": task_id, "user": user, "device": normalize_device_id(device) or device},
+    )
+
+
+def list_pending_sync(user: str, device: str) -> list[dict[str, Any]]:
+    path = _queue_path(user, device)
+    if path is None:
+        return []
+    data = _read_json(path)
+    if not data:
+        return []
+    tasks = data.get("tasks")
+    if not isinstance(tasks, dict):
+        return []
+    out = [t for t in tasks.values() if isinstance(t, dict) and not t.get("reported")]
+    out.sort(key=lambda x: float(x.get("created_at") or 0))
+    return out
+
+
+def mark_reported_sync(task_id: str) -> dict[str, Any] | None:
+    idx = _read_json(_index_path(task_id))
+    if not idx:
+        return None
+    user = str(idx.get("user") or "")
+    device = str(idx.get("device") or "")
+    path = _queue_path(user, device)
+    if path is None:
+        return None
+    found: dict[str, Any] | None = None
+
+    def mark(data: dict[str, Any]) -> None:
+        nonlocal found
+        tasks = data.get("tasks")
+        if not isinstance(tasks, dict):
+            return
+        rec = tasks.get(task_id)
+        if not isinstance(rec, dict):
+            return
+        rec["reported"] = True
+        found = rec
+
+    _mutate_queue(path, mark)
+    try:
+        _index_path(task_id).unlink(missing_ok=True)
+    except OSError:
+        pass
+    return found
+
+
+def pending_count_for_user_sync(user: str) -> int:
+    u = (user or "").strip()
+    if not u:
+        return 0
+    total = 0
+    queues = _root() / "queues"
+    prefix = f"{u}_"
+    for path in queues.glob(f"{prefix}*.json"):
+        data = _read_json(path)
+        if not data:
+            continue
+        tasks = data.get("tasks")
+        if not isinstance(tasks, dict):
+            continue
+        total += sum(1 for t in tasks.values() if isinstance(t, dict) and not t.get("reported"))
+    return total
+
+
+def pending_count_for_device_sync(user: str, device: str) -> int:
+    return len(list_pending_sync(user, device))
+
+
+def clear_pending_sync(user: str, *, device: str | None = None) -> int:
+    u = (user or "").strip()
+    if not u:
+        return 0
+    removed = 0
+    queues = _root() / "queues"
+    if device is not None:
+        path = _queue_path(u, device)
+        paths = [path] if path is not None else []
+    else:
+        paths = list(queues.glob(f"{u}_*.json"))
+
+    for path in paths:
+        if path is None or not path.is_file():
+            continue
+
+        def clear(data: dict[str, Any]) -> None:
+            nonlocal removed
+            tasks = data.get("tasks")
+            if not isinstance(tasks, dict):
+                return
+            for tid, rec in list(tasks.items()):
+                if isinstance(rec, dict) and not rec.get("reported"):
+                    del tasks[tid]
+                    removed += 1
+                    try:
+                        _index_path(str(tid)).unlink(missing_ok=True)
+                    except OSError:
+                        pass
+
+        _mutate_queue(path, clear)
+    return removed
+
+
+def pending_type_counts_sync(user: str, *, device: str | None = None) -> dict[str, int]:
+    u = (user or "").strip()
+    if not u:
+        return {}
+    counts: dict[str, int] = {}
+    queues = _root() / "queues"
+    if device is not None:
+        path = _queue_path(u, device)
+        paths = [path] if path is not None else []
+    else:
+        paths = list(queues.glob(f"{u}_*.json"))
+    for path in paths:
+        if path is None or not path.is_file():
+            continue
+        data = _read_json(path)
+        if not data:
+            continue
+        tasks = data.get("tasks")
+        if not isinstance(tasks, dict):
+            continue
+        for rec in tasks.values():
+            if not isinstance(rec, dict) or rec.get("reported"):
+                continue
+            name = str(rec.get("task_type") or "")
+            if name:
+                counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+async def prune_stale_maa_pending_files(*, max_age_sec: float = 86400.0) -> None:
+    root = _root()
+    now = time.time()
+    for sub in ("queues", "task_index"):
+        dir_path = root / sub
+        if not dir_path.is_dir():
+            continue
+        for path in dir_path.glob("*.json"):
+            try:
+                if now - path.stat().st_mtime > max_age_sec:
+                    path.unlink(missing_ok=True)
+            except OSError:
+                pass

--- a/src/common/shard/coord/maa_pending_registry.py
+++ b/src/common/shard/coord/maa_pending_registry.py
@@ -8,10 +8,13 @@ import time
 from pathlib import Path
 from typing import Any
 
+from nonebot import logger
+
 from src.common.paths import plugin_data_dir
 from src.plugins.maa.tasks import normalize_device_id
 
 _PLUGIN = "pallas_shard"
+_LOCK_RETRIES = 5
 
 
 def _root() -> Path:
@@ -82,11 +85,11 @@ def _write_atomic(path: Path, data: dict[str, Any]) -> None:
     tmp.replace(path)
 
 
-def _mutate_queue(path: Path, fn) -> dict[str, Any] | None:
+def _mutate_queue(path: Path, fn) -> dict[str, Any]:
     lk = _lock_path(path)
     fd = _acquire_lock(lk)
     if fd is None:
-        return _read_json(path)
+        raise TimeoutError(f"failed to acquire lock for pending queue: {path}")
     try:
         data = _read_json(path) or {"tasks": {}}
         tasks = data.get("tasks")
@@ -97,6 +100,25 @@ def _mutate_queue(path: Path, fn) -> dict[str, Any] | None:
         return data
     finally:
         _release_lock(fd, lk)
+
+
+def _mutate_queue_retry(path: Path, fn) -> dict[str, Any] | None:
+    last: TimeoutError | None = None
+    for attempt in range(_LOCK_RETRIES):
+        try:
+            return _mutate_queue(path, fn)
+        except TimeoutError as err:
+            last = err
+            if attempt + 1 < _LOCK_RETRIES:
+                time.sleep(0.05 * (attempt + 1))
+    logger.warning(
+        "maa pending queue lock timeout after {} tries: {}",
+        _LOCK_RETRIES,
+        path,
+    )
+    if last is not None:
+        logger.debug("maa pending queue lock last error: {}", last)
+    return None
 
 
 def enqueue_task_sync(task: dict[str, Any]) -> None:
@@ -113,7 +135,8 @@ def enqueue_task_sync(task: dict[str, Any]) -> None:
     def add(data: dict[str, Any]) -> None:
         data["tasks"][task_id] = task
 
-    _mutate_queue(path, add)
+    if _mutate_queue_retry(path, add) is None:
+        return
     idx = _index_path(task_id)
     _write_atomic(
         idx,
@@ -158,7 +181,8 @@ def mark_reported_sync(task_id: str) -> dict[str, Any] | None:
         rec["reported"] = True
         found = rec
 
-    _mutate_queue(path, mark)
+    if _mutate_queue_retry(path, mark) is None:
+        return None
     try:
         _index_path(task_id).unlink(missing_ok=True)
     except OSError:
@@ -218,7 +242,7 @@ def clear_pending_sync(user: str, *, device: str | None = None) -> int:
                     except OSError:
                         pass
 
-        _mutate_queue(path, clear)
+        _mutate_queue_retry(path, clear)
     return removed
 
 

--- a/src/common/shard/coord/maa_route_registry.py
+++ b/src/common/shard/coord/maa_route_registry.py
@@ -152,8 +152,9 @@ def resolve_worker_port_for_maa_user(user: str) -> int | None:
                 pass
     reg = get_shard_registry()
     sid = reg.shard_for_bot(key)
-    if sid is None and reg.shards:
-        ordered = sorted(s.id for s in reg.shards)
+    shards = getattr(reg, "shards", None) or ()
+    if sid is None and shards:
+        ordered = sorted(s.id for s in shards)
         pick = int(hashlib.sha256(key.encode()).hexdigest()[:12], 16) % len(ordered)
         sid = ordered[pick]
     if sid is None:

--- a/src/common/shard/coord/maa_seen_registry.py
+++ b/src/common/shard/coord/maa_seen_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,19 @@ from src.common.paths import plugin_data_dir
 _PLUGIN = "pallas_shard"
 _DEVICE_HEX32_RE = re.compile(r"^[0-9a-fA-F]{32}$")
 _DEVICE_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+# getTask 高频轮询时降低每 (user, device) 落盘频率；进程内缓存仍立即更新
+_DISK_FLUSH_INTERVAL_SEC = 2.0
+
+_lock = threading.Lock()
+_local_seen: dict[tuple[str, str], float] = {}
+_last_disk_write: dict[tuple[str, str], float] = {}
+
+
+def clear_seen_cache_for_tests() -> None:
+    """测试用：清空进程内缓存。"""
+    with _lock:
+        _local_seen.clear()
+        _last_disk_write.clear()
 
 
 def normalize_maa_device_id(raw: str) -> str | None:
@@ -28,6 +42,14 @@ def normalize_maa_device_id(raw: str) -> str | None:
     return None
 
 
+def _cache_key(user: str, device: str) -> tuple[str, str] | None:
+    u = (user or "").strip()
+    norm = normalize_maa_device_id(device)
+    if not u or not norm:
+        return None
+    return u, norm
+
+
 def _seen_dir() -> Path:
     root = Path(plugin_data_dir(_PLUGIN, create=True)) / "coord" / "maa_seen"
     root.mkdir(parents=True, exist_ok=True)
@@ -35,11 +57,10 @@ def _seen_dir() -> Path:
 
 
 def _seen_path(user: str, device: str) -> Path | None:
-    u = (user or "").strip()
-    norm = normalize_maa_device_id(device)
-    if not u or not norm:
+    key = _cache_key(user, device)
+    if key is None:
         return None
-    return _seen_dir() / f"{u}_{norm}.json"
+    return _seen_dir() / f"{key[0]}_{key[1]}.json"
 
 
 def _lock_path(path: Path) -> Path:
@@ -73,10 +94,7 @@ def _release_lock(fd: int | None, lock_path: Path) -> None:
         pass
 
 
-def touch_maa_seen_sync(user: str, device: str) -> None:
-    path = _seen_path(user, device)
-    if path is None:
-        return
+def _write_seen_file(path: Path, user: str, device: str, seen_at: float) -> None:
     lk = _lock_path(path)
     fd = _acquire_lock(lk)
     if fd is None:
@@ -85,7 +103,7 @@ def touch_maa_seen_sync(user: str, device: str) -> None:
         data: dict[str, Any] = {
             "user": (user or "").strip(),
             "device": normalize_maa_device_id(device),
-            "seen_at": time.time(),
+            "seen_at": seen_at,
         }
         tmp = path.with_suffix(".tmp")
         tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
@@ -94,37 +112,102 @@ def touch_maa_seen_sync(user: str, device: str) -> None:
         _release_lock(fd, lk)
 
 
-def was_maa_seen_sync(user: str, device: str, ttl: int) -> bool:
-    path = _seen_path(user, device)
-    if path is None or not path.is_file():
-        return False
+def _read_seen_at_from_disk(path: Path) -> float:
+    if not path.is_file():
+        return 0.0
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return False
+        return 0.0
     if not isinstance(raw, dict):
+        return 0.0
+    return float(raw.get("seen_at") or 0)
+
+
+def flush_dirty_maa_seen_sync() -> None:
+    """将进程内仍有效的 seen 刷入磁盘（清理前调用，避免防抖导致文件过旧被误删）。"""
+    now = time.time()
+    with _lock:
+        snap = dict(_local_seen)
+    for key, seen_at in snap.items():
+        if seen_at <= 0:
+            continue
+        user, norm = key
+        path = _seen_dir() / f"{user}_{norm}.json"
+        _write_seen_file(path, user, norm, seen_at)
+        with _lock:
+            _last_disk_write[key] = now
+
+
+def touch_maa_seen_sync(user: str, device: str) -> None:
+    key = _cache_key(user, device)
+    if key is None:
+        return
+    now = time.time()
+    with _lock:
+        _local_seen[key] = now
+        last_disk = _last_disk_write.get(key, 0.0)
+        need_flush = now - last_disk >= _DISK_FLUSH_INTERVAL_SEC
+    if not need_flush:
+        return
+    path = _seen_path(user, device)
+    if path is None:
+        return
+    _write_seen_file(path, user, device, now)
+    with _lock:
+        _last_disk_write[key] = now
+
+
+def was_maa_seen_sync(user: str, device: str, ttl: int) -> bool:
+    key = _cache_key(user, device)
+    if key is None:
         return False
-    seen_at = float(raw.get("seen_at") or 0)
-    if seen_at <= 0:
+    ttl_sec = max(1, int(ttl))
+    now = time.time()
+    with _lock:
+        local_at = _local_seen.get(key)
+    if local_at and local_at > 0 and now - local_at <= ttl_sec:
+        return True
+    path = _seen_path(user, device)
+    if path is None:
         return False
-    return time.time() - seen_at <= max(1, int(ttl))
+    seen_at = _read_seen_at_from_disk(path)
+    if seen_at <= 0 or now - seen_at > ttl_sec:
+        return False
+    with _lock:
+        if seen_at > _local_seen.get(key, 0.0):
+            _local_seen[key] = seen_at
+    return True
 
 
 async def prune_stale_maa_seen_files(*, max_age_sec: float | None = None) -> None:
     """清理过期轮询记录文件（默认与 maa_seen_ttl 同量级）。"""
     from src.plugins.maa.config import get_maa_config
 
+    flush_dirty_maa_seen_sync()
     ttl = float(max_age_sec if max_age_sec is not None else get_maa_config().maa_seen_ttl_seconds)
     root = _seen_dir()
     if not root.is_dir():
         return
     now = time.time()
+    with _lock:
+        active_keys = {k for k, ts in _local_seen.items() if ts > 0 and now - ts <= ttl}
     for path in root.glob("*.json"):
         try:
+            name = path.stem
+            if "_" not in name:
+                path.unlink(missing_ok=True)
+                continue
+            user_part, norm_part = name.split("_", 1)
+            if (user_part, norm_part) in active_keys:
+                continue
             raw = json.loads(path.read_text(encoding="utf-8"))
             seen_at = float(raw.get("seen_at") or 0) if isinstance(raw, dict) else 0.0
             if seen_at <= 0 or now - seen_at > ttl:
                 path.unlink(missing_ok=True)
+                with _lock:
+                    _local_seen.pop((user_part, norm_part), None)
+                    _last_disk_write.pop((user_part, norm_part), None)
         except (OSError, json.JSONDecodeError):
             try:
                 path.unlink(missing_ok=True)

--- a/src/common/shard/coord/worker_poll.py
+++ b/src/common/shard/coord/worker_poll.py
@@ -18,6 +18,7 @@ async def shard_coord_worker_poll_loop() -> None:
     from src.common.shard.coord.bot_action import poll_bot_action_pending, prune_stale_bot_action_files
     from src.common.shard.coord.cage_duel import prune_stale_cage_duel_files
     from src.common.shard.coord.duel_qte import poll_duel_qte_pending, prune_stale_duel_qte_files
+    from src.common.shard.coord.maa_pending_registry import prune_stale_maa_pending_files
     from src.common.shard.coord.maa_seen_registry import prune_stale_maa_seen_files
 
     while True:
@@ -31,6 +32,7 @@ async def shard_coord_worker_poll_loop() -> None:
                 await prune_stale_bot_action_files()
                 await prune_stale_cage_duel_files()
                 await prune_stale_maa_seen_files()
+                await prune_stale_maa_pending_files()
         except Exception as err:
             logger.debug(f"shard_coord worker poll: {err}")
         await asyncio.sleep(_WATCH_SEC)

--- a/src/plugins/maa/http_api.py
+++ b/src/plugins/maa/http_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from nonebot import get_bot, logger
-from nonebot.adapters.onebot.v11 import MessageSegment
+from nonebot.adapters.onebot.v11 import Message, MessageSegment
 from pydantic import BaseModel, Field
 
 from .config import get_maa_config
@@ -95,19 +95,20 @@ async def deliver_maa_notify(
     if is_sharding_active() and not bot_has_local_connection(bot_id):
         from src.common.shard.coord.bot_action import send_group_message_as_bot, send_private_msg_as_bot
 
+        message = Message(segments)
         try:
             if notify.group_id:
                 ok = await send_group_message_as_bot(
                     bot_id,
                     int(notify.group_id),
-                    segments,
+                    message,
                     image_bytes=image_bytes,
                 )
             else:
                 ok = await send_private_msg_as_bot(
                     bot_id,
                     int(notify.user_id),
-                    segments,
+                    message,
                     image_bytes=image_bytes,
                 )
             if not ok:

--- a/src/plugins/maa/http_api.py
+++ b/src/plugins/maa/http_api.py
@@ -34,6 +34,13 @@ async def maa_get_task(body: GetTaskRequest) -> GetTaskResponse:
     if not await maa_store.is_device_verified(body.user, body.device):
         return GetTaskResponse(tasks=[])
     tasks = await maa_store.pending_tasks_for(body.user, body.device)
+    if tasks:
+        logger.info(
+            "maa getTask: user={} device={} tasks={}",
+            body.user,
+            (body.device or "")[:8],
+            len(tasks),
+        )
     return GetTaskResponse(tasks=tasks)
 
 
@@ -48,12 +55,6 @@ async def maa_report_status(body: ReportStatusRequest) -> dict[str, str]:
         return {"message": "ok"}
 
     notify = task.notify
-    try:
-        bot = get_bot(str(notify.bot_id))
-    except Exception:
-        logger.warning("maa reportStatus: bot {} offline, task={}", notify.bot_id, body.task)
-        return {"message": "ok"}
-
     lines = [f"MAA 任务 {body.task} 已结束：{body.status}"]
     if task.task_type == "HeartBeat":
         running = body.payload or "（当前无顺序任务）"
@@ -67,14 +68,67 @@ async def maa_report_status(body: ReportStatusRequest) -> dict[str, str]:
             lines.append(body.payload[:500])
         segments = [MessageSegment.text("\n".join(lines))]
 
+    image_bytes: bytes | None = None
+    if task.task_type in {"CaptureImage", "CaptureImageNow"} and body.payload:
+        import base64
+
+        try:
+            image_bytes = base64.b64decode(body.payload)
+        except Exception:
+            image_bytes = None
+
+    await deliver_maa_notify(notify, segments, image_bytes=image_bytes, task_id=body.task)
+    return {"message": "ok"}
+
+
+async def deliver_maa_notify(
+    notify,
+    segments,
+    *,
+    image_bytes: bytes | None = None,
+    task_id: str = "",
+) -> None:
+    from src.common.shard.presence import bot_has_local_connection
+    from src.common.shard.registry.config import is_sharding_active
+
+    bot_id = int(notify.bot_id)
+    if is_sharding_active() and not bot_has_local_connection(bot_id):
+        from src.common.shard.coord.bot_action import send_group_message_as_bot, send_private_msg_as_bot
+
+        try:
+            if notify.group_id:
+                ok = await send_group_message_as_bot(
+                    bot_id,
+                    int(notify.group_id),
+                    segments,
+                    image_bytes=image_bytes,
+                )
+            else:
+                ok = await send_private_msg_as_bot(
+                    bot_id,
+                    int(notify.user_id),
+                    segments,
+                    image_bytes=image_bytes,
+                )
+            if not ok:
+                logger.warning("maa reportStatus: shard notify failed bot={} task={}", bot_id, task_id)
+        except Exception as exc:
+            logger.warning("maa reportStatus: shard notify error task={}: {}", task_id, exc)
+        return
+
+    try:
+        bot = get_bot(str(bot_id))
+    except Exception:
+        logger.warning("maa reportStatus: bot {} offline, task={}", bot_id, task_id)
+        return
+
     try:
         if notify.group_id:
             await bot.send_group_msg(group_id=notify.group_id, message=segments)
         else:
             await bot.send_private_msg(user_id=notify.user_id, message=segments)
     except Exception as exc:
-        logger.warning("maa reportStatus notify failed task={}: {}", body.task, exc)
-    return {"message": "ok"}
+        logger.warning("maa reportStatus notify failed task={}: {}", task_id, exc)
 
 
 def current_maa_http_paths() -> tuple[str, str]:

--- a/src/plugins/maa/store.py
+++ b/src/plugins/maa/store.py
@@ -68,7 +68,7 @@ def pending_task_from_dict(data: dict[str, Any]) -> PendingTask | None:
             user=str(data["user"]),
             device=str(data["device"]),
             task_type=str(data["task_type"]),
-            params=data.get("params") if data.get("params") is None else str(data["params"]),
+            params=data.get("params"),
             notify=notify,
             created_at=float(data.get("created_at") or time.time()),
             reported=bool(data.get("reported")),

--- a/src/plugins/maa/store.py
+++ b/src/plugins/maa/store.py
@@ -31,6 +31,52 @@ class PendingTask:
     reported: bool = False
 
 
+def pending_task_to_dict(task: PendingTask) -> dict[str, Any]:
+    return {
+        "task_id": task.task_id,
+        "user": task.user,
+        "device": task.device,
+        "task_type": task.task_type,
+        "params": task.params,
+        "notify": {
+            "bot_id": int(task.notify.bot_id),
+            "user_id": int(task.notify.user_id),
+            "group_id": task.notify.group_id,
+        },
+        "created_at": float(task.created_at),
+        "reported": bool(task.reported),
+    }
+
+
+def pending_task_from_dict(data: dict[str, Any]) -> PendingTask | None:
+    if not isinstance(data, dict):
+        return None
+    raw_notify = data.get("notify")
+    if not isinstance(raw_notify, dict):
+        return None
+    try:
+        notify = NotifyTarget(
+            bot_id=int(raw_notify["bot_id"]),
+            user_id=int(raw_notify["user_id"]),
+            group_id=raw_notify.get("group_id"),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+    try:
+        return PendingTask(
+            task_id=str(data["task_id"]),
+            user=str(data["user"]),
+            device=str(data["device"]),
+            task_type=str(data["task_type"]),
+            params=data.get("params") if data.get("params") is None else str(data["params"]),
+            notify=notify,
+            created_at=float(data.get("created_at") or time.time()),
+            reported=bool(data.get("reported")),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
 @dataclass(slots=True)
 class DeviceRecord:
     device: str
@@ -293,11 +339,15 @@ class MaaStore:
         from src.common.shard.coord.maa_route_registry import register_maa_user_route
 
         register_maa_user_route(user_key)
+        from src.common.shard.registry.config import is_sharding_active
+
+        shard_pending = is_sharding_active()
         task_ids: list[str] = []
+        to_enqueue: list[PendingTask] = []
         async with self._lock:
             for spec in specs:
                 task_id = str(ULID())
-                self._pending[task_id] = PendingTask(
+                rec = PendingTask(
                     task_id=task_id,
                     user=user_key,
                     device=device,
@@ -305,10 +355,13 @@ class MaaStore:
                     params=spec.params,
                     notify=notify,
                 )
+                if not shard_pending:
+                    self._pending[task_id] = rec
+                to_enqueue.append(rec)
                 task_ids.append(task_id)
             if attach_screenshot and specs and specs[-1].task_type not in {"CaptureImage", "CaptureImageNow"}:
                 shot_id = str(ULID())
-                self._pending[shot_id] = PendingTask(
+                rec = PendingTask(
                     task_id=shot_id,
                     user=user_key,
                     device=device,
@@ -316,24 +369,50 @@ class MaaStore:
                     params=None,
                     notify=notify,
                 )
+                if not shard_pending:
+                    self._pending[shot_id] = rec
+                to_enqueue.append(rec)
                 task_ids.append(shot_id)
+        if shard_pending:
+            from src.common.shard.coord.maa_pending_registry import enqueue_task_sync
+
+            for rec in to_enqueue:
+                await asyncio.to_thread(enqueue_task_sync, pending_task_to_dict(rec))
         return task_ids, None
 
     async def pending_tasks_for(self, user: str, device: str) -> list[dict[str, Any]]:
         norm = normalize_device_id(device)
         if not norm:
             return []
-        key_user, key_device = user.strip(), norm
-        async with self._lock:
-            items = [
-                t for t in self._pending.values() if t.user == key_user and t.device == key_device and not t.reported
-            ]
+        from src.common.shard.registry.config import is_sharding_active
+
+        if is_sharding_active():
+            from src.common.shard.coord.maa_pending_registry import list_pending_sync
+
+            raw = await asyncio.to_thread(list_pending_sync, user.strip(), norm)
+            items = [pending_task_from_dict(x) for x in raw]
+            items = [t for t in items if t is not None]
+        else:
+            key_user, key_device = user.strip(), norm
+            async with self._lock:
+                items = [
+                    t
+                    for t in self._pending.values()
+                    if t.user == key_user and t.device == key_device and not t.reported
+                ]
         return [
             build_task_payload(t.task_id, MaaTaskSpec(t.task_type, t.params))
             for t in sorted(items, key=lambda x: x.created_at)
         ]
 
     async def mark_reported(self, task_id: str) -> PendingTask | None:
+        from src.common.shard.registry.config import is_sharding_active
+
+        if is_sharding_active():
+            from src.common.shard.coord.maa_pending_registry import mark_reported_sync
+
+            raw = await asyncio.to_thread(mark_reported_sync, task_id)
+            return pending_task_from_dict(raw) if raw else None
         async with self._lock:
             task = self._pending.get(task_id)
             if not task:
@@ -343,6 +422,12 @@ class MaaStore:
 
     async def pending_count_for_user(self, qq_id: int) -> int:
         user_key = str(qq_id)
+        from src.common.shard.registry.config import is_sharding_active
+
+        if is_sharding_active():
+            from src.common.shard.coord.maa_pending_registry import pending_count_for_user_sync
+
+            return await asyncio.to_thread(pending_count_for_user_sync, user_key)
         async with self._lock:
             return sum(1 for t in self._pending.values() if t.user == user_key and not t.reported)
 
@@ -351,6 +436,12 @@ class MaaStore:
         if not norm:
             return 0
         user_key = str(qq_id)
+        from src.common.shard.registry.config import is_sharding_active
+
+        if is_sharding_active():
+            from src.common.shard.coord.maa_pending_registry import pending_count_for_device_sync
+
+            return await asyncio.to_thread(pending_count_for_device_sync, user_key, norm)
         async with self._lock:
             return sum(1 for t in self._pending.values() if t.user == user_key and t.device == norm and not t.reported)
 
@@ -358,6 +449,12 @@ class MaaStore:
         """移除未汇报任务；device 为 None 时清空该 QQ 全部待拉取任务。"""
         user_key = str(qq_id)
         norm = normalize_device_id(device) if device else None
+        from src.common.shard.registry.config import is_sharding_active
+
+        if is_sharding_active():
+            from src.common.shard.coord.maa_pending_registry import clear_pending_sync
+
+            return await asyncio.to_thread(clear_pending_sync, user_key, device=norm)
         async with self._lock:
             remove_ids = [
                 tid
@@ -371,6 +468,12 @@ class MaaStore:
     async def pending_type_counts(self, qq_id: int, *, device: str | None = None) -> dict[str, int]:
         user_key = str(qq_id)
         norm = normalize_device_id(device) if device else None
+        from src.common.shard.registry.config import is_sharding_active
+
+        if is_sharding_active():
+            from src.common.shard.coord.maa_pending_registry import pending_type_counts_sync
+
+            return await asyncio.to_thread(pending_type_counts_sync, user_key, device=norm)
         counts: dict[str, int] = {}
         async with self._lock:
             for t in self._pending.values():

--- a/src/plugins/pallas_webui/__init__.py
+++ b/src/plugins/pallas_webui/__init__.py
@@ -19,6 +19,7 @@ from .api import register_api
 from .config import Config, plugin_config
 from .extended_api import register_extended_api, set_console_meta
 from .manager import (
+    bot_has_release_update,
     check_webui_exists,
     download_and_extract_dist_zip,
     fetch_latest_bot_release,
@@ -231,17 +232,21 @@ if not is_sharded_worker():
                 bot_current_commit = bot_current.get("commit", "")
                 bot_latest_info = await fetch_latest_bot_release("PallasBot/Pallas-Bot", token=tok)
                 bot_latest_tag = str(bot_latest_info.get("tag", "") or "").strip()
-                if bot_latest_tag and bot_current_tag and bot_current_tag != bot_latest_tag:
+                if bot_has_release_update(
+                    latest_tag=bot_latest_tag,
+                    current_tag=str(bot_current_tag or ""),
+                    current_commit=str(bot_current_commit or ""),
+                ):
                     bot_release_url = str(bot_latest_info.get("html_url", "") or "").strip()
                     logger.info(
-                        f"Pallas-Bot 控制台: 发现新版本 Bot {bot_latest_tag}（当前: {bot_current_tag}）"
+                        f"Pallas-Bot 控制台: 发现新版本 Bot {bot_latest_tag}（当前: {bot_current_tag or bot_current_commit or '未知'}）"
                         + (f" → {bot_release_url}" if bot_release_url else "")
                         + "，可在控制台查看更新"
                     )
                 elif bot_current_tag:
                     logger.info(f"Pallas-Bot 控制台: Bot 已是最新版本（{bot_current_tag}）")
                 else:
-                    logger.info(f"Pallas-Bot 控制台: Bot under development,commit={bot_current_commit or '未知'}")
+                    logger.info(f"Pallas-Bot 控制台: Bot 开发构建，commit={bot_current_commit or '未知'}")
             except Exception as e:
                 logger.debug("Pallas-Bot 控制台: 检查 Bot 更新失败: {}", format_exception_for_log(e))
 

--- a/src/plugins/pallas_webui/extended_api.py
+++ b/src/plugins/pallas_webui/extended_api.py
@@ -4828,9 +4828,8 @@ def register_extended_api(
     @router.get(f"{x}/update/bot/check", include_in_schema=True)
     async def _bot_update_check() -> JSONResponse:
         from src.common.utils.format_exception import format_exception_for_log
-        from src.common.utils.github_release import release_tags_equivalent
 
-        from .manager import fetch_latest_bot_release, get_bot_current_version
+        from .manager import bot_has_release_update, fetch_latest_bot_release, get_bot_current_version
 
         github_token = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
         cache_key = f"update_check_bot:{bool(github_token)}"
@@ -4856,9 +4855,10 @@ def register_extended_api(
                     "error": err_msg,
                     "checked_at": time.time(),
                 }
-            has_update = bool(
-                latest_tag
-                and (not str(current_tag or "").strip() or not release_tags_equivalent(current_tag, latest_tag)),
+            has_update = bot_has_release_update(
+                latest_tag=latest_tag,
+                current_tag=str(current_tag or ""),
+                current_commit=str(current_commit or ""),
             )
             notes_raw = str(latest.get("body", "") or "").strip()
             notes_max = 40000

--- a/src/plugins/pallas_webui/manager.py
+++ b/src/plugins/pallas_webui/manager.py
@@ -315,6 +315,64 @@ def get_bot_current_version() -> dict:
     return {"tag": tag, "commit": commit}
 
 
+def bot_has_release_update(
+    *,
+    latest_tag: str,
+    current_tag: str = "",
+    current_commit: str = "",
+) -> bool:
+    """是否落后于 GitHub 最新 release（开发超前 commit 不视为可更新）。"""
+    from src.common.utils.github_release import release_tags_equivalent
+
+    tag = (latest_tag or "").strip()
+    if not tag:
+        return False
+    if release_tags_equivalent(current_tag, tag):
+        return False
+    root = _BOT_ROOT
+    git_dir = root / ".git"
+    if not git_dir.exists():
+        cur = (current_tag or "").strip()
+        return bool(cur) and not release_tags_equivalent(cur, tag)
+
+    def _git_rev_parse(ref: str) -> str:
+        import subprocess
+
+        return subprocess.check_output(
+            ["git", "rev-parse", ref],
+            cwd=root,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=8.0,
+        ).strip()
+
+    def _git_rev_list_count(revision_range: str) -> int:
+        import subprocess
+
+        out = subprocess.check_output(
+            ["git", "rev-list", "--count", revision_range],
+            cwd=root,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=8.0,
+        ).strip()
+        return int(out) if out.isdigit() else 0
+
+    try:
+        latest_sha = _git_rev_parse(f"{tag}^{{commit}}")
+        head_sha = _git_rev_parse("HEAD")
+    except Exception:  # noqa: BLE001
+        cur = (current_tag or "").strip()
+        return bool(cur) and not release_tags_equivalent(cur, tag)
+    if latest_sha == head_sha:
+        return False
+    try:
+        behind = _git_rev_list_count(f"{head_sha}..{latest_sha}")
+    except Exception:  # noqa: BLE001
+        return False
+    return behind > 0
+
+
 def get_pallas_bot_version_for_health() -> str:
     """供 ``/health`` 的 ``pallas_bot``：优先环境变量（镜像注入）、git describe，其次已安装发行版号，最后 pyproject。"""
     import importlib.metadata

--- a/tests/common/test_maa_pending_registry.py
+++ b/tests/common/test_maa_pending_registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from src.common.shard.coord import maa_pending_registry as mod
+from src.plugins.maa.store import NotifyTarget, PendingTask, pending_task_to_dict
+
+
+@pytest.mark.asyncio
+async def test_shard_pending_enqueue_and_list(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_root", lambda: tmp_path)
+    (tmp_path / "queues").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "task_index").mkdir(parents=True, exist_ok=True)
+
+    task = PendingTask(
+        task_id="01TASK",
+        user="3023094357",
+        device="c27e4912dfa147d8a7c1d9a6d658b06d",
+        task_type="CaptureImageNow",
+        params=None,
+        notify=NotifyTarget(bot_id=923722427, user_id=3023094357, group_id=None),
+    )
+    mod.enqueue_task_sync(pending_task_to_dict(task))
+
+    listed = mod.list_pending_sync("3023094357", task.device)
+    assert len(listed) == 1
+    assert listed[0]["task_type"] == "CaptureImageNow"
+
+    marked = mod.mark_reported_sync("01TASK")
+    assert marked is not None
+    assert mod.list_pending_sync("3023094357", task.device) == []
+
+
+@pytest.mark.asyncio
+async def test_store_pending_count_uses_shard_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_root", lambda: tmp_path)
+    (tmp_path / "queues").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "task_index").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "src.common.shard.registry.config.is_sharding_active",
+        lambda: True,
+    )
+
+    from src.plugins.maa.store import MaaStore
+
+    store = MaaStore()
+    task = PendingTask(
+        task_id="02TASK",
+        user="3023094357",
+        device="c27e4912dfa147d8a7c1d9a6d658b06d",
+        task_type="StopTask",
+        params=None,
+        notify=NotifyTarget(bot_id=923722427, user_id=3023094357),
+    )
+    mod.enqueue_task_sync(pending_task_to_dict(task))
+    assert await store.pending_count_for_user(3023094357) == 1
+    raw = await store.pending_tasks_for("3023094357", task.device)
+    assert len(raw) == 1
+    assert raw[0]["type"] == "StopTask"

--- a/tests/common/test_maa_seen_registry.py
+++ b/tests/common/test_maa_seen_registry.py
@@ -9,6 +9,7 @@ from src.common.shard.coord import maa_seen_registry as mod
 
 def test_touch_and_was_seen(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(mod, "_seen_dir", lambda: tmp_path)
+    mod.clear_seen_cache_for_tests()
     user = "123456789"
     device = "42cfa6e9-dfa1-47d8-a7c1-d9a6d658b06d"
     mod.touch_maa_seen_sync(user, device)
@@ -16,9 +17,26 @@ def test_touch_and_was_seen(tmp_path, monkeypatch) -> None:
     assert mod.was_maa_seen_sync(user, "42cfa6e9dfa147d8a7c1d9a6d658b06d", ttl=3600)
 
 
+def test_touch_debounces_disk_writes(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_seen_dir", lambda: tmp_path)
+    mod.clear_seen_cache_for_tests()
+    user = "123456789"
+    device = "42cfa6e9-dfa1-47d8-a7c1-d9a6d658b06d"
+    mod.touch_maa_seen_sync(user, device)
+    path = mod._seen_path(user, device)
+    assert path is not None and path.is_file()
+    mtime1 = path.stat().st_mtime
+    mod.touch_maa_seen_sync(user, device)
+    assert path.stat().st_mtime == mtime1
+    assert mod.was_maa_seen_sync(user, device, ttl=3600)
+    mod.flush_dirty_maa_seen_sync()
+    assert path.stat().st_mtime >= mtime1
+
+
 @pytest.mark.asyncio
 async def test_store_was_seen_reads_cluster_file(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(mod, "_seen_dir", lambda: tmp_path)
+    mod.clear_seen_cache_for_tests()
     monkeypatch.setattr(
         "src.common.shard.registry.config.is_sharding_active",
         lambda: True,

--- a/tests/plugins/pallas_webui/test_bot_release_update.py
+++ b/tests/plugins/pallas_webui/test_bot_release_update.py
@@ -1,0 +1,57 @@
+"""Bot release 更新判定：开发超前 commit 不应提示有更新。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.plugins.pallas_webui.manager import bot_has_release_update
+
+
+def test_same_tag_no_update() -> None:
+    assert not bot_has_release_update(latest_tag="v1.0.0", current_tag="v1.0.0")
+
+
+def test_no_latest_tag() -> None:
+    assert not bot_has_release_update(latest_tag="", current_tag="v0.9.0")
+
+
+@pytest.mark.parametrize(
+    ("head_sha", "latest_sha", "behind_count", "expected"),
+    [
+        ("aaa", "aaa", 0, False),
+        ("bbb", "aaa", 0, False),
+        ("aaa", "bbb", 2, True),
+    ],
+)
+def test_git_behind_only(
+    head_sha: str,
+    latest_sha: str,
+    behind_count: int,
+    expected: bool,
+) -> None:
+    root = Path("/fake/repo")
+
+    def check_output(cmd: list[str], **kwargs: object) -> str:
+        if cmd[:2] == ["git", "rev-parse"]:
+            ref = cmd[2]
+            if ref == "HEAD":
+                return head_sha + "\n"
+            if ref.endswith("^{commit}"):
+                return latest_sha + "\n"
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            assert cmd[3] == f"{head_sha}..{latest_sha}"
+            return f"{behind_count}\n"
+        raise AssertionError(cmd)
+
+    with (
+        patch.object(Path, "exists", return_value=True),
+        patch("src.plugins.pallas_webui.manager._BOT_ROOT", root),
+        patch("subprocess.check_output", side_effect=check_output),
+    ):
+        assert (
+            bot_has_release_update(latest_tag="v1.1.0", current_tag="v1.0.0-dev")
+            is expected
+        )


### PR DESCRIPTION
- data/pallas_shard/coord/maa_pending 持久化 getTask 队列

- reportStatus 经 bot_action 代发；hub 路由 shards 空列表兜底

- pallas_webui Bot 更新相关修复

## Summary by Sourcery

通过分片感知（shard-aware）的持久化与投递机制，为 MAA 待处理任务队列和机器人通知引入支持，并优化 Pallas WebUI 机器人版本更新检测。

New Features:
- 为分片部署新增基于共享文件系统的 MAA 待处理任务注册表，支持入队、列出、标记为已上报、计数、清空以及清理等操作工具。
- 通过分片 `bot_action` 路由支持跨 worker 的 MAA 任务状态报告机器人通知，包括可选的截图图片投递。

Enhancements:
- 在启用分片时让 MAA 存储层使用分片待处理注册表，同时在非分片部署中保留内存队列。
- 改进 MAA `getTask` 请求以及分片通知失败时的日志记录。
- 调整 MAA 用户到 worker 的路由逻辑，更健壮地处理缺失分片列表的情况。
- 优化 Pallas WebUI 机器人版本更新检查逻辑，纳入 git 提交位置考量，并改进在健康检查与更新端点中的提示信息。
- 扩展分片 worker 轮询逻辑，用于清理过期的 MAA 待处理队列文件。

Documentation:
- 更新 MAA 插件故障排查文档，增加关于分片待处理队列以及 hub/worker 连接性的指导说明。

Tests:
- 为基于分片的 MAA 待处理注册表与 `MaaStore` 的集成添加测试。
- 为 Pallas WebUI 机器人版本更新检测逻辑添加测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce shard-aware persistence and delivery for MAA pending task queues and bot notifications, and refine Pallas WebUI bot release update detection.

New Features:
- Add a shared filesystem-based MAA pending task registry for sharded deployments, including enqueue, list, mark-reported, counting, clearing, and pruning utilities.
- Support cross-worker bot notifications for MAA task status reports via shard bot_action routing, including optional screenshot image delivery.

Enhancements:
- Make the MAA store use the shard pending registry when sharding is active while retaining in-memory queues for non-sharded setups.
- Improve logging for MAA getTask requests and shard notification failures.
- Adjust MAA user-to-worker routing to handle missing shard lists more robustly.
- Refine Pallas WebUI bot release update checks to account for git commit position and better messaging in health and update endpoints.
- Extend shard worker polling to prune stale MAA pending queue files.

Documentation:
- Update MAA plugin troubleshooting docs with guidance for sharded pending queues and hub/worker connectivity.

Tests:
- Add tests for the shard-based MAA pending registry integration with MaaStore.
- Add tests for Pallas WebUI bot release update detection logic.

</details>