### PR TITLE
docs: 完善仓库文档并精简 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
   <p>
     <a href="https://github.com/PallasBot/Pallas-Bot/issues">报告 Bug</a> ·
-    <a href="https://github.com/PallasBot/Pallas-Bot/issues">提出新特性</a> ·
-    <a href="docs/Deployment.md">快速部署</a>
+    <a href="https://github.com/PallasBot/Pallas-Bot/issues">提出新特性</a>
   </p>
 
 </div>
@@ -23,7 +22,7 @@
 [![stars](https://img.shields.io/github/stars/PallasBot/Pallas-Bot?style=social)](https://github.com/PallasBot/Pallas-Bot/stargazers)
 [![ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-[![maa-remote](https://img.shields.io/badge/Feature-MAA%20%E8%BF%9C%E6%8E%A7-FE7D37)](docs/plugins/maa/README.md)
+[![maa-remote](https://img.shields.io/badge/Feature-MAA%20%E8%BF%9C%E6%8E%A7-FE7D37)](https://PallasBot.github.io/Pallas-Bot-Docs/plugins/maa)
 ![learning-repeater](https://img.shields.io/badge/Feature-%E5%AD%A6%E4%B9%A0%E5%9E%8B%E5%A4%8D%E8%AF%BB-8A2BE2)
 ![plugin-system](https://img.shields.io/badge/Feature-%E6%8F%92%E4%BB%B6%E5%8C%96-00A3FF)
 [![ai-chat-sing-tts](https://img.shields.io/badge/AI-Chat%26Sing%26TTS-6A5ACD)](https://github.com/PallasBot/Pallas-Bot-AI.git)
@@ -37,12 +36,7 @@
 </div>
 
 <p align="center">面向群聊场景的学习型机器人：会复读、会整活、可管理、可扩展。</p>
-<p align="center">亦可作为 <b>MAA（MaaAssistantArknights）</b> 的 QQ 侧远控：绑定设备后，在群聊或私聊用口令排队任务。</p>
-
->牛牛 基于 **`NoneBot2`** 与 **`OneBot v11`**，数据层支持 **`MongoDB`** 或 **`PostgreSQL`**；自带运维面板 [**`Pallas-Bot-WebUI`**](https://github.com/PallasBot/Pallas-Bot-WebUI.git)。使用 MAA 远控时，牛牛实现 [MAA 远程控制协议](https://docs.maa.plus/zh-cn/protocol/remote-control-schema.html)（详见 [MAA 远控](#maa-远控)）。
-发版与变更说明见 [Releases](https://github.com/PallasBot/Pallas-Bot/releases)；若需参考仅 **`MongoDB`** 的历史实现，见分支 [`archive/v2`](https://github.com/PallasBot/Pallas-Bot/tree/archive/v2)；向 **`PostgreSQL`** 迁移可使用 [Mongo → PG 迁移脚本](tools/migrate_mongo_to_pg.py)。
-
-<!-- Copy-paste in your Readme.md file -->
+<p align="center">基于 <b>NoneBot2</b> + <b>OneBot v11</b>，数据层 <b>MongoDB / PostgreSQL</b>，自带 Web 控制台与协议端管理；可选 <b>MAA</b> QQ 远控与 AI 扩展。</p>
 
 <a href="https://next.ossinsight.io/widgets/official/analyze-repo-stars-history?repo_id=425810267" target="_blank" style="display: block" align="center">
   <picture>
@@ -51,100 +45,9 @@
   </picture>
 </a>
 
-<!-- Made with [OSS Insight](https://ossinsight.io/) -->
->喜欢牛牛，就给牛牛点个 [**⭐**](https://github.com/PallasBot/Pallas-Bot/stargazers) 吧！
+> 喜欢牛牛，就给牛牛点个 [**⭐**](https://github.com/PallasBot/Pallas-Bot/stargazers) 吧！
 
-## 📑 目录
-
-- [关于项目](#关于项目)
-  - [项目特点](#项目特点)
-  - [MAA 远控](#maa-远控)
-- [运维入口](#运维入口)
-- [快速开始（部署）](#快速开始部署)
-  - [部署方式](#部署方式)
-  - [环境要求](#环境要求)
-  - [简单部署](#简单部署)
-- [使用指南](#使用指南)
-  - [功能列表](#功能列表)
-  - [AI 扩展](#ai-扩展)
-- [配置要点](#配置要点)
-  - [当前配置与文件](#当前配置与文件)
-  - [从 .env 迁移（旧用户）](#从-env-迁移旧用户)
-- [文档与链接](#文档与链接)
-- [开发与贡献指南](#开发与贡献指南)
-- [社区与支持](#社区与支持)
-  - [QQ 群](#qq-群)
-  - [打赏](#打赏)
-- [致谢](#致谢)
-- [许可证](#许可证)
-
-<a id="关于项目"></a>
-## 📖 关于项目
-
-牛牛的功能就是废话和复读。可以认为是高级版的复读机。
-发现牛牛学了一些不合适的话及时帮忙[删除](docs/FAQ.md#使用与管理)。
-大家一起教出更棒更聪明的牛牛！✿✿ヽ(°▽°)ノ✿
-
-若你使用 [**MaaAssistantArknights**](https://github.com/MaaAssistantArknights/MaaAssistantArknights)，牛牛还可作为其 QQ 侧远控：在 MAA 中配置远控地址并私聊绑定设备后，用「牛牛长草」「牛牛作战」等口令排队任务，执行结果与截图会回到 QQ（说明见下文 [MAA 远控](#maa-远控)）。
-
-<a id="项目特点"></a>
-### ✨ 项目特点
-
-- 学习型复读，不依赖硬编码问答库
-- 支持跨群语料聚合与全局禁用
-- 牛牛玩法：喝酒、轮盘、决斗、做梦、唱歌、聊天、生图、夺舍等；
-- 管理能力：黑名单、好友欢迎、好友/入群申请管理
-- 数据后端：`MongoDB` 或 `PostgreSQL`
-- 运维：`pallas_webui` 控制台、`pallas_protocol` 协议端管理
-- **MAA 远控**（可选）：与 MAA 客户端配合，在 QQ 绑定设备、下发口令、回传截图与状态（详见 [MAA 远控](#maa-远控)）
-- **牛牛帮助**：三级帮助图（总览 → 插件 → 功能详情）；群管可按插件开关功能
-- **牛牛连通**：探测画画网关、MAA 端点、唱歌 AI 等延迟（WebUI 可一键检测）
-
-<a id="maa-远控"></a>
-### 📡 MAA 远控
-
-与 [**MaaAssistantArknights**](https://github.com/MaaAssistantArknights/MaaAssistantArknights) 配套：MAA 在本地跑任务，牛牛在 QQ 侧**绑定设备、排队口令、回传截图与状态**（`getTask` / `reportStatus`）。
-
-1. 配置 `maa_public_base_url`（见 [maa 插件说明](docs/plugins/maa/README.md)）
-2. MAA「设置 → 远程控制」填入帮助页 URL，用户标识符填 QQ 号
-3. 私聊 `牛牛绑定MAA <设备标识符>`，群聊发 `牛牛长草`、`牛牛作战` 等
-
-口令一览、多设备与排障见 [docs/plugins/maa/README.md](docs/plugins/maa/README.md) 或 **牛牛帮助 → MAA 远控**；协议见 [MAA 远程控制文档](https://docs.maa.plus/zh-cn/protocol/remote-control-schema.html)。
-
-<a id="运维入口"></a>
-## 🗂️ 运维入口
-
-以下路径中的 **`HOST`**、**`PORT`** 以 **`config/pallas.toml`** 的 `[bootstrap]` 为准（默认常为本机 **`8088`**）。
-
-| 入口 | URL 示例 |
-| --- | --- |
-| Web 控制台 | `http://<HOST>:<PORT>/pallas/` |
-| 协议端管理 | `http://<HOST>:<PORT>/protocol/console/` |
-
-- **登录口令**：控制台与协议端管理**共用**；首次启动见 Bot 日志。遗忘后的处理见 [FAQ · 部署排障](docs/FAQ.md#部署排障)。
-- **Docker**：`pallasbot` 服务镜像见根目录 [`docker-compose.yml`](docker-compose.yml) 的 `image`；需对齐某次 Release 时请直接改为带 tag 的镜像名（或自建 override 文件）。
-- **排障与插件字段**：[FAQ](docs/FAQ.md)、[协议端（pallas_protocol）](docs/plugins/pallas_protocol/README.md)、[控制台（pallas_webui）](docs/plugins/pallas_webui/README.md)。
-
-<a id="快速开始部署"></a>
-## 🚀 快速开始（部署）
-
-<a id="部署方式"></a>
-### 📦 部署方式
-
-- **托管实例接入**：加入 [拉牛牛群](#qq-群) 获取可用实例
-- **标准部署**：按 [部署教程](docs/Deployment.md) 执行完整流程
-- **容器化部署**：使用 [Docker 部署](docs/DockerDeployment.md)
-
-<a id="环境要求"></a>
-### 📋 环境要求
-
-- `Python 3.12+`
-- `uv`
-- `MongoDB` 或 `PostgreSQL`（二选一）
-- `OneBot v11` 协议端
-
-<a id="简单部署"></a>
-### ⚡ 简单部署
+## 🚀 快速开始
 
 ```bash
 #获取代码
@@ -160,164 +63,30 @@ uv sync                 # 安装依赖
 # 主配置（首次部署）
 cp config/pallas.example.toml config/pallas.toml
 # 编辑 [bootstrap]：监听、SUPERUSERS、DB_BACKEND、MONGO_* 或 PG_*
-# 若仍使用根目录 .env，见下方「从 .env 迁移」
 
 # 开始运行（单进程）
 uv run nb run
 ```
-> 完整部署细节请查看 [部署教程](docs/Deployment.md) 和 [Docker 部署](docs/DockerDeployment.md)。
-> 部署好自己牛牛之后，若将他人账号接为自己的牛牛，请把对方 QQ 写入该牛牛的 **`admins`**（号主）；**新建牛牛**时也可由超管私聊 **「创建牛牛」** 并在命令里带上号主 QQ，**会自动写入** `admins`。详见 [FAQ：如何为牛牛配置号主（`admins`）](docs/FAQ.md#faq-bot-admins)。
 
-<a id="使用指南"></a>
-## 📚 使用指南
+浏览器打开 `http://<主机>:8088/pallas/`，使用启动日志中的口令登录。
 
-<a id="功能列表"></a>
-### 🎮 功能列表
+<a id="文档"></a>
+## 📖 文档
 
-<details>
-  <summary>忘记了就用牛牛帮助!</summary>
+部署、配置、插件、迁移与排障等完整说明见在线文档站。
 
-#### MAA 远控（[`maa`](docs/plugins/maa/README.md)）
-
-| 类型 | 口令示例 |
+| | |
 | --- | --- |
-| 绑定 / 设备 | `牛牛绑定MAA`、`牛牛MAA状态`、`牛牛切换MAA设备`、`牛牛MAA设备名`、`牛牛清空MAA队列` |
-| 任务 | `牛牛长草`、`牛牛作战`、`牛牛公招`、`牛牛基建`、`牛牛截图`、`牛牛停止` 等 |
-| 高级 | `牛牛MAA任务 <type> [params]`（协议原始 type） |
-
-#### 基础玩法
-
-| 口令 / 插件 | 说明 |
-| --- | --- |
-| `牛牛帮助` | 三级帮助图：总览 → 插件 → 功能；`牛牛开启` / `牛牛关闭` 管理本群插件 |
-| `牛牛喝酒` / `牛牛醒一醒` | 醉酒与醒酒，影响聊天、轮盘、夺舍、做梦等 |
-| `牛牛轮盘` | 踢人/禁言轮盘；`牛牛救一下`、`牛牛补一枪` |
-| `牛牛决斗` / `八角笼牛` | 泰拉风味多幕决斗、干员 QTE、双牛八角笼（[duel](docs/plugins/duel/README.md)） |
-| `牛牛做梦` / `牛牛醒梦` | 跨群梦话漂流、历史梦与画画归档图；醉酒联动夺舍（[dream](docs/plugins/dream/README.md)） |
-| 酒后聊天 | 醉酒时 @牛牛 或「牛牛 + 文本」（依赖 [AI 服务](https://github.com/PallasBot/Pallas-Bot-AI)） |
-| `牛牛唱歌` | 翻唱、继续唱、点歌、查歌名（依赖 AI 服务） |
-| `牛牛画画` | AI 生图，可附图或回复图作参考 |
-| `牛牛连通` / `牛牛网关` | 探测画画、MAA、唱歌等服务延迟（[connectivity](docs/plugins/connectivity/README.md)） |
-
-#### 被动与管理
-
-- **复读**（`repeater`）：学习型复读核心
-- **欢迎**（`greeting`）：入群/好友欢迎与部分群通知
-- **夺舍**（`take_name`）：定时改牛牛群名片；醉酒时可能同步改群友名片
-- **控制台**（`pallas_webui`）、**协议端**（`pallas_protocol`）：Web 运维与多账号协议端
-- **群管**：帮助与插件开关；轮盘禁言/踢人需群管权限
-- **号主**（`admins`）：`牛牛重新上号`、`设置好友欢迎`、`同意好友/入群`、`牛牛在吗`
-- **超管**：`创建牛牛`、隐藏功能开关、`牛牛在吗`（含邮件测试）
-</details>
-
-<a id="ai-扩展"></a>
-### 🤖 AI 扩展
-
-部署 [Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI) 并开启对应能力后可用：
-<details>
-  <summary>展开查看完整功能列表</summary>
-
-- `[角色名]唱歌 <歌曲名>`（指定翻唱，支持 `key=N` 调整音调）& `[角色名]唱歌`（播放唱过的歌曲）
-- `[角色名]继续唱` / `[角色名]接着唱`（继续上次未完成的歌曲）
-- `[角色名]什么歌` / `[角色名]哪首歌`（查询当前播放歌曲名）
-- `牛牛点歌 <歌曲名>`
-- `网易云登录` / `网易云登出`
-- 酒后聊天（ChatRWKV 模型）
-- 酒后聊天内容文本转语音（TTS）
-
-</details>
-
-<a id="配置要点"></a>
-## ⚙️ 配置要点
-
-<a id="当前配置与文件"></a>
-### 当前配置与文件
-
-自 v3 起，运行配置以 **`config/pallas.toml`** 与 WebUI 落盘的 **`data/pallas_config/webui.json`** 为主；根目录 **`.env` 仅作遗留只读合并**，新部署与文档不再以 `.env` 为准。
-
-| 文件 | 用途 | Git |
-| --- | --- | --- |
-| [`config/pallas.example.toml`](config/pallas.example.toml) | 示例与注释（可复制为 `pallas.toml`） | 跟踪 |
-| `config/pallas.toml` | **本地主配置**：`[bootstrap]` 监听、超管、数据库；`[env]` 分片/协议端等扁平键 | **忽略（勿提交密钥）** |
-| `data/pallas_config/webui.json` | 控制台 **「插件」「通用配置」** 保存项（`env` + `sections`） | 随 `data/` 部署 |
-| `config/pallas.webui.export.toml` | WebUI 保存后自动生成的只读快照，便于查阅 | 忽略 |
-| `.env` / `.env.prod` | 旧版键名；仍可被读取，但**优先级低于** `webui.json` | 建议迁移后删除或仅留备份 |
-
-**合并顺序**（后者覆盖前者）：`pallas.toml` → `.env` → `.env.{ENVIRONMENT}` → `webui.json`（WebUI 落盘最高）。细节见 [配置存储](docs/architecture/settings-storage.md)。
-
-- **单进程**：`uv run nb run`，改 `pallas.toml` 后重启进程。
-- **多进程分片**：`./scripts/run_sharded_bot.sh start`；`[env]` 可配 `REDIS_URL`（跨进程 claim，可选）、`PALLAS_SHARD_*` 等，见 [分片架构](docs/architecture/bot_process_sharding.md)。
-- **PostgreSQL**：`db_backend = "postgresql"` 时需 `uv sync --extra pg`；**Redis claim** 需 `uv sync --extra coord-redis`（可与 pg 同写：`uv sync --extra pg --extra coord-redis`）。
-
-<a id="从-env-迁移旧用户"></a>
-### 从 .env 迁移（旧用户）
-
-若你仍在使用仓库根目录的 **`.env`** / **`.env.prod`**，建议一次性迁入 TOML + WebUI JSON：
-
-```bash
-# 在仓库根目录
-uv run python tools/migrate_env_to_pallas.py
-# 已存在 pallas.toml / webui.json 时：加 --force 覆盖（请先备份）
-```
-
-脚本会把 **bootstrap 相关键**（`HOST`、`PORT`、`SUPERUSERS`、`DB_BACKEND`、`MONGO_*`、`PG_*` 等）写入 `config/pallas.toml`，其余写入 `data/pallas_config/webui.json`。
-
-迁移后请逐项确认：
-
-1. **TOML 字符串必须加双引号**（例如 `db_backend = "postgresql"`、`user = "postgres"`；`postgresql` 裸写会导致 `tomllib` 解析失败，Bot 读不到任何配置）。
-2. **分片 / Redis**（可选）在 `pallas.toml` 增加 **`[env]`** 段，例如 `REDIS_URL = "redis://127.0.0.1:6379/0"`（见 `pallas.example.toml` 注释）。
-3. **`.env` 与 nb 插件**：可复制 [`.env.example`](.env.example) 为 `.env`，专放 pip/nb 插件环境变量；与 `webui.json` 避免同名键重复（运行时以 `webui.json` 为准）。
-4. 校验：`uv run python -c "import tomllib; tomllib.load(open('config/pallas.toml','rb')); print('toml ok')"`。
-
-数据库从 Mongo 迁到 PostgreSQL 另见 [Migration-v3](docs/Migration-v3.md) 与 [`tools/migrate_mongo_to_pg.py`](tools/migrate_mongo_to_pg.py)（与 `.env` → TOML 迁移无关）。
-
----
-
-以下为启动前最常见的几项；**更多键名与默认值以各插件 Pydantic 配置为准**，推荐在 Web 控制台 **「插件」「通用配置」** 中修改（写入 `webui.json`），离线编辑 bootstrap / `[env]` 见 `config/pallas.toml`。
-
-| 配置项 | 默认/示例 | 说明 | 必填 |
-| --- | --- | --- | --- |
-| `HOST` / `PORT` | `0.0.0.0` / `8088` | Bot HTTP 监听；控制台与协议管理页同源 | 是 |
-| `SUPERUSERS` | QQ 号列表 | 超管 QQ | 是 |
-| `DB_BACKEND` | `mongodb` / `postgresql` | 数据后端 | 是 |
-| `MONGO_*` / `PG_*` | 见 `config/pallas.example.toml` | 数据库地址与账号（与 `DB_BACKEND` 对应） | 是 |
-| `ACCESS_TOKEN` | 空 | 驱动层 HTTP 鉴权；公网暴露时建议填写 | 否 |
-| `PALLAS_PROTOCOL_ENABLED` / `PALLAS_PROTOCOL_WEBUI_ENABLED` | 默认开启 | 协议端插件与管理页 | 否 |
-| `maa_public_base_url` | （空） | MAA 远控对外 HTTP 基址；一般部署**只需此项**（见 [maa](docs/plugins/maa/README.md)） | 使用 MAA 时建议填 |
-
-
-控制台与协议管理页为**浏览器登录**，口令在 `data/pallas_console/`；说明见 [pallas_webui](docs/plugins/pallas_webui/README.md)、[pallas_protocol](docs/plugins/pallas_protocol/README.md)，遗忘与排障见 [FAQ](docs/FAQ.md)。
-
-<a id="文档与链接"></a>
-## 📚 文档与链接
-
-| 类型 | 链接 |
-| --- | --- |
-| 标准部署 | [docs/Deployment.md](docs/Deployment.md) |
-| Docker | [docs/DockerDeployment.md](docs/DockerDeployment.md) |
-| 常见问题 | [docs/FAQ.md](docs/FAQ.md)（[学习机制](docs/FAQ.md#学习机制)、[使用与管理](docs/FAQ.md#使用与管理)、[部署排障](docs/FAQ.md#部署排障)） |
-| 插件索引 | [docs/plugins/README.md](docs/plugins/README.md) |
-| MAA 远控 | [docs/plugins/maa/README.md](docs/plugins/maa/README.md) |
-| 连通性检测 | [docs/plugins/connectivity/README.md](docs/plugins/connectivity/README.md) |
-| 命令权限 / 帮助菜单 | [docs/common/cmd_perm/README.md](docs/common/cmd_perm/README.md) |
-| 协议端 / 控制台 | [pallas_protocol](docs/plugins/pallas_protocol/README.md)、[pallas_webui](docs/plugins/pallas_webui/README.md) |
-| 变更记录 | [GitHub Releases](https://github.com/PallasBot/Pallas-Bot/releases) |
-| 配置存储 | [settings-storage](docs/architecture/settings-storage.md)、[pallas.example.toml](config/pallas.example.toml) |
-| `.env` → TOML | [`tools/migrate_env_to_pallas.py`](tools/migrate_env_to_pallas.py)（见 README [从 .env 迁移](#从-env-迁移旧用户)） |
-| 数据迁移 | [Mongo → PG 脚本](tools/migrate_mongo_to_pg.py)、[迁移说明（v3）](docs/Migration-v3.md) |
-| 多进程分片 | [bot_process_sharding](docs/architecture/bot_process_sharding.md)、[`run_sharded_bot.sh`](scripts/run_sharded_bot.sh) |
-| 历史分支 | [`archive/v2`](https://github.com/PallasBot/Pallas-Bot/tree/archive/v2)（仅 MongoDB 旧版参考） |
+| **文档** | [![docs on GitHub Pages](https://img.shields.io/badge/docs%20on-GitHub.Pages-FE7D37)](https://PallasBot.github.io/Pallas-Bot-Docs/) |
 
 <a id="开发与贡献指南"></a>
 ## 💻 开发与贡献指南
 
-欢迎通过 [Issues](https://github.com/PallasBot/Pallas-Bot/issues) / PR 参与改进。参与前请阅读 [贡献指南](CONTRIBUTING.md) 与仓库根目录 [AGENTS.md](AGENTS.md)（本地安装、Ruff、pytest、提交约定）。
-
+欢迎通过 [Issues](https://github.com/PallasBot/Pallas-Bot/issues) / PR 参与改进。参与前请阅读 [贡献指南](CONTRIBUTING.md) 与仓库根目录 [AGENTS.md](AGENTS.md)。
 
 <a id="社区与支持"></a>
 ## 🤝 社区与支持
 
-页顶徽章展示社区部署概况。`community_stats` 在 hub / 单进程**默认开启**；关闭见 [社区统计说明](docs/common/community_stats.md)。
 
 <a id="qq-群"></a>
 ### 💬 QQ 群
@@ -354,8 +123,6 @@ uv run python tools/migrate_env_to_pallas.py
 - [**zhenxun_bot**](https://github.com/zhenxun-org/zhenxun_bot.git)：非常可爱的绪山真寻Bot
 - [**Amiya-bot**](https://github.com/AmiyaBot/Amiya-Bot.git)：基于 AmiyaBot 框架的 QQ 聊天机器人
 - [**CustomMarkdownImage**](https://github.com/Monody-S/CustomMarkdownImage.git)：基于pillow的可自定义markdown渲染器
-## 📊 统计
-<!-- Copy-paste in your Readme.md file -->
 
 <a href="https://next.ossinsight.io/widgets/official/analyze-repo-pushes-and-commits-per-month?repo_id=425810267" target="_blank" style="display: block" align="center">
   <picture>
@@ -364,9 +131,6 @@ uv run python tools/migrate_env_to_pallas.py
   </picture>
 </a>
 
-<!-- Made with [OSS Insight](https://ossinsight.io/) -->
-<!-- Copy-paste in your Readme.md file -->
-
 <a href="https://next.ossinsight.io/widgets/official/compose-recent-active-contributors?repo_id=425810267&limit=30" target="_blank" style="display: block" align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/compose-recent-active-contributors/thumbnail.png?repo_id=425810267&limit=30&image_size=auto&color_scheme=dark" width="655" height="auto">
@@ -374,7 +138,6 @@ uv run python tools/migrate_env_to_pallas.py
   </picture>
 </a>
 
-<!-- Made with [OSS Insight](https://ossinsight.io/) -->
 ## 👥 贡献者
 
 感谢各位大佬！

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1,0 +1,136 @@
+# 配置要点（生产）
+
+启动与长期运行前，按本节核对 **`config/pallas.toml`** 与持久化目录。完整机制见 [配置存储](architecture/settings-storage.md)。
+
+## 配置合并顺序（优先级从低到高）
+
+1. `config/pallas.toml` — 启动必需项（监听、超管、数据库）
+2. 遗留 `.env` / `.env.{ENVIRONMENT}`（若存在）
+3. `data/pallas_config/webui.json` — **WebUI 保存后最高**，覆盖同名键
+
+生产环境建议：**启动相关、密钥、数据库** 写在 `pallas.toml`；**插件开关与业务参数** 在控制台修改并落盘 `webui.json`。
+
+---
+
+## 首次部署检查清单
+
+- [ ] 已复制 `config/pallas.example.toml` → **`config/pallas.toml`**
+- [ ] `[bootstrap] superusers` 已填 QQ 号
+- [ ] `db_backend` 与 `[bootstrap.mongo]` / `[bootstrap.postgres]` 与实际库一致
+- [ ] `host` / `port` 与防火墙、反向代理一致（默认 `0.0.0.0:8088`）
+- [ ] `data/` 目录可写（首次启动自动创建子目录）
+- [ ] 已记录控制台初始口令（`data/pallas_console/`，遗忘见 [FAQ](FAQ.md)）
+- [ ] 未在生产环境开启 `pallas_webui_dev_mode`
+
+---
+
+## `[bootstrap]` 必改项
+
+| 配置项 | 说明 | 生产注意 |
+| --- | --- | --- |
+| `superusers` | 超管 QQ 列表 | 至少一名可信管理员 |
+| `host` / `port` | HTTP 监听 | 反代后仍常为 `0.0.0.0` + 应用端口 |
+| `db_backend` | `mongodb` 或 `postgresql` | 与已安装/编排的数据库一致 |
+| `access_token` | HTTP API 鉴权 | 公网或不可信网络建议设置 |
+
+### MongoDB
+
+```toml
+[bootstrap]
+db_backend = "mongodb"
+
+[bootstrap.mongo]
+host = "127.0.0.1"
+port = 27017
+user = ""
+password = ""
+db = "PallasBot"
+```
+
+Docker Compose 默认栈中 Bot 容器内 host 为 **`mongodb`**（由 compose 注入），见 [Docker 部署](DockerDeployment.md)。
+
+### PostgreSQL
+
+```toml
+[bootstrap]
+db_backend = "postgresql"
+
+[bootstrap.postgres]
+host = "127.0.0.1"
+port = 5432
+user = "postgres"
+password = "your_password"
+db = "PallasBot"
+```
+
+需已执行 `uv sync --extra pg`。Docker 内置 Postgres 时另备 `config/compose.env`，且 **`PG_DB` 与数据卷初始化库名一致**。
+
+**如何确认数据库配置正确**：启动 Bot 无 `connection refused` / 认证失败；日志完成 `init_db`；控制台可打开且无持久 5xx。
+
+---
+
+## `[env]` 与分片（按需）
+
+```toml
+[env]
+REDIS_URL = "redis://127.0.0.1:6379/0"
+```
+
+多进程分片跨 worker 协调时使用；`run_sharded_bot.sh` 可自动探测。与 Pallas-Bot-AI 共用同一 Redis 时填相同 URL。
+
+---
+
+## `[community_stats]`（可选）
+
+默认**开启**，一般**无需**添加整段配置。关闭上报：
+
+```toml
+[community_stats]
+enabled = false
+```
+
+或环境变量 `PALLAS_COMMUNITY_STATS_ENABLED=false`。详见 [社区统计](common/community_stats.md)。
+
+---
+
+## WebUI 与控制台
+
+| 内容 | 存储位置 |
+| --- | --- |
+| 插件开关、业务配置 | `data/pallas_config/webui.json` |
+| 控制台 / 协议端登录 | `data/pallas_console/auth_state.json` |
+| 只读导出快照 | `config/pallas.webui.export.toml`（保存时自动生成） |
+
+在浏览器打开 `/pallas/` 修改插件项后，**重启是否必需** 因插件而异；关键项保存后建议观察日志或按插件文档操作。
+
+---
+
+## 从旧 `.env` 迁移
+
+```bash
+uv run python tools/migrate_env_to_pallas.py
+```
+
+迁移后 `.env` 仍可保留 **nb/pip 插件专用** 项；与 `webui.json` **避免同名键重复**。
+
+---
+
+## 生产备份建议
+
+定期备份（至少）：
+
+- `config/pallas.toml`
+- `data/pallas_config/webui.json`
+- `data/pallas_console/`
+- 整个 `data/`（含协议端实例、分片状态）
+
+恢复时保持路径与挂载一致；Docker 见 [配置存储 · Docker 挂载](architecture/settings-storage.md)。
+
+---
+
+## 相关文档
+
+- [配置存储](architecture/settings-storage.md) — 合并顺序、热重载
+- [标准部署](Deployment.md) — 分步安装与验证
+- [Docker 部署](DockerDeployment.md) — Compose 与卷挂载
+- [站点定制与更新](architecture/site-customization-and-updates.md) — `local/plugins` 与更新策略

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,270 +1,275 @@
 # Pallas-Bot 3.0 部署教程
 
-> 导航：[`README`](../README.md) · [`Docker 部署`](DockerDeployment.md) · [`多进程分片`](architecture/bot_process_sharding.md) · [`3.0 迁移`](Migration-v3.md) · [`FAQ`](FAQ.md)
+> 导航：[`README`](../README.md) · [`Docker 部署`](DockerDeployment.md) · [`配置要点`](Config.md) · [`多进程分片`](architecture/bot_process_sharding.md) · [`3.0 迁移`](Migration-v3.md) · [`FAQ`](FAQ.md)
 
-快来部署属于你自己的牛牛吧 (｡･∀･)ﾉﾞ
+本文面向**本机或 VPS 上的生产/长期运行**部署：按步骤完成环境、配置与协议端接入，并在每步说明如何确认成功。
 
-## 看前提示
+## 部署前检查清单
 
-- 你需要一个额外的 QQ 小号，一台自己的 `电脑` 或 `服务器`，不推荐用大号进行部署
-- 你自己部署的牛牛与其他牛牛数据并不互通，是一张白纸，需要从头调教
-- **3.0** 起提供 **Web 控制台**（`/pallas/`）与 **协议端管理**（默认 `/protocol/console/`，由插件 `pallas_protocol` 提供），用于管理 NapCat 等协议端进程；数据后端可选 **MongoDB** 或 **PostgreSQL**
-- 牛牛支持使用 `Docker Compose` 一键部署，可以参考 [Docker 部署](DockerDeployment.md)；仓库自带 Compose **默认不编排独立 NapCat**，QQ 协议端由 **协议端管理**（`/protocol/console/`）统一创建与连接
-- **多牛生产环境**可选用 [多进程分片](architecture/bot_process_sharding.md)（hub + worker，共享 `data/`），见下文 [多进程分片（可选）](#多进程分片可选)
-- 以下内容适用于将牛牛作为一个独立 `Bot` 部署。如果你想将牛牛功能作为一组 `plugin` 添加到现有 `Bot`，请参照 [作为插件部署](#作为插件部署) 一节
+在开始前请确认：
 
-## 基本环境配置
+| 项 | 要求 |
+| --- | --- |
+| 硬件 | 建议 **2 核 CPU / 4 GB 内存** 起；多牛或启用 AI 功能需更高配置 |
+| 系统 | Linux（推荐）或 Windows；长期运行优先 Linux + systemd |
+| QQ 账号 | 使用**小号**登录协议端，勿用大号 |
+| 网络 | 服务器可访问数据库端口；若外网访问控制台，需开放 **HTTP 端口**（默认 `8088`） |
+| 数据库 | 已安装 **MongoDB** 或 **PostgreSQL**，或可连接远程实例 |
+| 工具 | `git`、`Python 3.12+`（或由 `uv` 自动安装）、[`uv`](https://docs.astral.sh/uv/) |
+| 配置 | 将准备 **`config/pallas.toml`**（从示例复制，**非可选项**） |
 
-1. 下载安装 [git](https://git-scm.com/downloads)，这是一个版本控制工具，可以用来方便的下载、更新牛牛的源码。
-2. 下载牛牛源码
+> 多牛、高负载生产环境可选用 [多进程分片](architecture/bot_process_sharding.md) 或 [Docker 部署](DockerDeployment.md)。
 
-    在你想放数据的文件夹里，Shift + 鼠标右键，打开 Powershell 窗口，输入命令
+---
 
-    ```bash
-    git clone https://github.com/PallasBot/Pallas-Bot.git
-    ```
-
-    受限于国内网络环境，请留意命令是否执行成功，若一直失败可以挂上代理。
-
-3. 下载安装 [Python](https://www.python.org/downloads/)，推荐安装 3.12 以上版本，Windows 用户请确保安装时勾选了 “Add Python to PATH” 选项。
-
-    如果你本地已有 Python 环境可以忽略本条，下方的 `uv` 会自动安装牛牛支持的 Python 版本。
-
-4. 下载安装 [pipx](https://pypa.github.io/pipx/installation/)，用于安装 Python 应用（可执行文件）：
-
-    ```bash
-    python -m pip install --user pipx
-    python -m pipx ensurepath
-    ```
-
-    为确保 `pipx` 路径生效，请关闭并重新打开 Powershell 窗口。
-
-5. 使用 `pipx` 安装 [uv](https://docs.astral.sh/uv/getting-started/installation/), 这是一个现代且高效的 Python 包和项目管理工具：
-
-    ```bash
-    pipx install uv
-    ```
-
-    如果你本地已有 uv 环境可以忽略本条，下方的 `uv` 会自动安装牛牛支持的 Python 版本。
-
-## 项目环境配置
-
-1. 安装依赖
-
-    ```bash
-    cd Pallas-Bot # 进入项目目录
-    uv sync
-    ```
-
-    若 `.env` 中选用 **PostgreSQL** 作为数据后端，请安装 PG 相关依赖（可与下面 `perf` 组合）：
-
-    ```bash
-    uv sync --extra pg
-    # 或同时启用分词加速：uv sync --extra perf --extra pg
-    ```
-
-2. （可选）使用 `jieba-next` 分词（`perf` 可选依赖）
-
-    项目默认安装 `jieba`。加群较多、消息量大的用户可启用 **`perf`**，使用 `jieba-next` 提升分词速度（群较少可跳过）。
-
-    ```bash
-    uv sync --extra perf
-    ```
-
-    若安装失败，在 Windows 上可能需要额外安装 `Visual Studio`，Linux 上需要 `build-essential`。
-    注：启用 `perf` 后，运行时会优先使用 `jieba-next`，否则回退到 `jieba`，无需改代码。
-
-3. 准备数据库（`MongoDB` 或 `PostgreSQL`）
-
-    - **MongoDB**（默认上手简单）
-      - [Windows 平台安装 MongoDB](https://www.runoob.com/mongodb/mongodb-window-install.html)
-      - [Linux 平台安装 MongoDB](https://www.runoob.com/mongodb/mongodb-linux-install.html)
-    - **PostgreSQL**（3.0 支持；迁移见 [`3.0 迁移指南`](Migration-v3.md)）
-      - [Windows 平台安装 PostgreSQL](https://www.postgresql.org/download/windows/)
-      - [Linux 平台安装 PostgreSQL](https://www.postgresql.org/download/linux/)
-      - 使用 PG 时务必已执行 `uv sync --extra pg`（见上一步）。
-
-    只需保证数据库可连接并在 `.env` 中配置正确，库表等会由 `Pallas-Bot` 在启动时初始化。
-
-4. 配置语音功能
-
-    - 配置 FFmpeg：[安装 FFmpeg](https://napneko.github.io/config/advanced#%E5%AE%89%E8%A3%85-ffmpeg)
-
-    Pallas-Bot 会在启动时自动检查并下载语音文件。
-
-    手动下载（仅在自动下载失败时需要）：
-
-    - 下载 [牛牛语音文件](https://huggingface.co/pallasbot/Pallas-Bot/blob/main/voices/Pallas.zip)，解压放到 `resource/voices/` 文件夹下，目录结构参考 [path_structure.txt](../resource/voices/path_structure.txt)
-
-5. 连接 QQ 协议端（两种方式任选或按环境组合）
-
-    **方式 A：3.0 协议端管理（推荐先了解）**
-
-    启动 `Pallas-Bot` 后，在浏览器打开 **协议端管理页**（默认与 Bot 同机同端口）：
-
-    - 地址：`http://<主机IP>:8088/protocol/console/`（若改了 `HOST`/`PORT` 或插件里自定义了 `PALLAS_PROTOCOL_WEBUI_PATH`，请按实际为准）
-    - 管理页鉴权与 Pallas-Bot 控制台共用（浏览器登录，口令哈希在 `data/pallas_console/`）。可选：`PALLAS_PROTOCOL_ENABLED`、`PALLAS_PROTOCOL_WEBUI_ENABLED`（默认一般为开；可在控制台「插件」→ `pallas_protocol` 中调整）
-
-    在页面内可完成 NapCat **运行模式**（如 Docker / AppImage / Shell）、**镜像或本地下载**、**实例创建与启停**、日志等；具体步骤与排障见 [`pallas_protocol` 插件说明](plugins/pallas_protocol/README.md)。
-
-    **方式 B：自行安装 NapCat / 其他 OneBot 客户端（与常见 NoneBot 部署相同）**
-
-    若你已在机器上单独安装了 `NapCat`，可继续用手动配 WS 的方式接入，无需强制使用方式 A。
-
-    - 部署步骤参照 [NapCat](https://napneko.github.io/) 官方文档；Windows 可选用 [NapCat.Win.一键版本](https://napneko.github.io/guide/boot/Shell#napcat-win-%E4%B8%80%E9%94%AE%E7%89%88%E6%9C%AC)。
-    - 运行 `NapCat` 后访问 `http://localhost:6099/webui`（默认 `token`：`napcat`），在 `网络配置` → `新建` → `WebSocket 客户端` 中启用，**URL** 填 **`ws://localhost:8088/onebot/v11/ws`**（明文 WebSocket；远程部署时把 `localhost` 换成 Bot 所在机器 IP）。
-    - 其他客户端示例：[Lagrange.OneBot](https://lagrangedev.github.io/Lagrange.Doc/v1/Lagrange.OneBot/)、[AstralGocq](https://github.com/ProtocolScience/AstralGocq) 等，`WebSocket` 目标路径同上。
-
-6. （可选）配置 `config/pallas.toml`
-
-    复制 [`config/pallas.example.toml`](../config/pallas.example.toml) 为 **`config/pallas.toml`**（已 gitignore，勿提交密钥），填写 `[bootstrap]` 监听与数据库等。其余项建议在启动后于控制台 **「插件」「通用配置」** 中编辑（写入 `data/pallas_config/webui.json`），或查阅 [配置存储](architecture/settings-storage.md) 与 [插件文档索引](plugins/README.md)。从旧 `.env` 迁移：`uv run python tools/migrate_env_to_pallas.py`。
-
-## 启动 Pallas-Bot
+## 步骤 1：获取源码
 
 ```bash
-cd Pallas-Bot # 进入项目目录
-uv run nb run        # 运行
+git clone https://github.com/PallasBot/Pallas-Bot.git
+cd Pallas-Bot
 ```
 
-**注意：请不要关闭这个命令行窗口！这会导致 `Pallas-Bot` 停止运行！**
-**同样请不要关闭 `NapCat` 的命令行窗口！**
-Linux 用户推荐使用 [Termux](https://termux.dev/) 或 [GNU Screen](https://zhuanlan.zhihu.com/p/405968623) 来保持 `Pallas-Bot` 和 QQ 客户端在后台运行，或者考虑使用 [Docker 部署](DockerDeployment.md)。
+**如何确认成功**：目录内存在 `pyproject.toml`、`config/pallas.example.toml`。
+
+国内网络若 `git clone` 失败，可配置代理或换镜像源后重试。
+
+---
+
+## 步骤 2：安装依赖
+
+```bash
+uv sync
+```
+
+若 `pallas.toml` 中计划使用 PostgreSQL：
+
+```bash
+uv sync --extra pg
+```
+
+消息量较大、希望加速分词时（可选）：
+
+```bash
+uv sync --extra perf
+```
+
+**如何确认成功**：命令退出码为 `0`，且 `.venv` 已创建；可执行 `uv run python -c "import nonebot"` 无报错。
+
+---
+
+## 步骤 3：准备主配置 `config/pallas.toml`（必做）
+
+```bash
+cp config/pallas.example.toml config/pallas.toml
+```
+
+编辑 **`config/pallas.toml`**，至少完成：
+
+1. **`[bootstrap] superusers`**：填写你的 QQ 号（超管，用于控制台与高危操作）。
+2. **`db_backend`**：设为 `mongodb` 或 `postgresql`。
+3. **`[bootstrap.mongo]`** 或 **`[bootstrap.postgres]`**：填写数据库地址、库名、账号密码（与步骤 4 中实际库一致）。
+
+示例（MongoDB）：
+
+```toml
+[bootstrap]
+host = "0.0.0.0"
+port = 8088
+superusers = ["你的QQ号"]
+db_backend = "mongodb"
+
+[bootstrap.mongo]
+host = "127.0.0.1"
+port = 27017
+db = "PallasBot"
+```
+
+从旧版 `.env` 迁移：
+
+```bash
+uv run python tools/migrate_env_to_pallas.py
+```
+
+**如何确认成功**：`config/pallas.toml` 为**文件**（非目录），且 `superusers`、数据库段已填写。勿将含密钥的文件提交到 git。
+
+插件与通用项可在首次启动后于 Web 控制台修改（落盘 `data/pallas_config/webui.json`），详见 [配置要点](Config.md) 与 [配置存储](architecture/settings-storage.md)。
+
+---
+
+## 步骤 4：准备数据库
+
+任选 **MongoDB** 或 **PostgreSQL**，保证 Bot 所在机器能连通。
+
+- MongoDB：[Windows 安装](https://www.runoob.com/mongodb/mongodb-window-install.html) · [Linux 安装](https://www.runoob.com/mongodb/mongodb-linux-install.html)
+- PostgreSQL：[官方下载](https://www.postgresql.org/download/) · 使用 PG 时需已执行 `uv sync --extra pg`
+
+库表由 Pallas-Bot **首次启动时自动初始化**，无需手工建表（PG 需库已存在，见 [Docker 部署 · PG 排障](DockerDeployment.md#pg-日志-fatal-database-pallasbot-does-not-exist)）。
+
+**如何确认成功**：
+
+- MongoDB：`mongosh` 或客户端能连上 `pallas.toml` 中的 host/port。
+- PostgreSQL：`psql -h ... -U ... -d ...` 可登录，且库名与 `pallas.toml` 中 `db` 一致。
+
+---
+
+## 步骤 5：（可选）语音资源
+
+Pallas-Bot 启动时会尝试自动下载语音包。若需 FFmpeg（唱歌等）：
+
+- [安装 FFmpeg](https://napneko.github.io/config/advanced#%E5%AE%89%E8%A3%85-ffmpeg)
+
+自动下载失败时，可手动将 [Pallas.zip](https://huggingface.co/pallasbot/Pallas-Bot/blob/main/voices/Pallas.zip) 解压到 `resource/voices/`，结构见 [path_structure.txt](../resource/voices/path_structure.txt)。
+
+**如何确认成功**：启动日志无语音目录相关致命错误；`resource/voices/` 下存在预期文件。
+
+---
+
+## 步骤 6：启动 Bot
+
+```bash
+uv run nb run
+```
+
+**如何确认成功**：
+
+1. 日志中出现 NoneBot / 插件加载完成，无数据库连接致命错误。
+2. 日志中打印 **Web 控制台初始口令**（存于 `data/pallas_console/`）。
+3. 浏览器访问 `http://<主机IP>:8088/pallas/api/health`（或控制台首页），返回正常。
+4. 浏览器打开 `http://<主机IP>:8088/pallas/`，使用口令登录成功。
+
+> **勿关闭运行 Bot 的终端**（未配置守护时关闭即停止服务）。Linux 生产环境请使用下文 **systemd** 或 [Docker](DockerDeployment.md)。
+
+---
+
+## 步骤 7：接入 QQ 协议端
+
+**方式 A：协议端管理（推荐）**
+
+1. 打开 `http://<主机IP>:8088/protocol/console/`（端口以 `pallas.toml` 为准）。
+2. 使用与控制台相同的登录方式鉴权。
+3. 在页面内创建 NapCat 实例、登录 QQ、确认 OneBot WebSocket 已指向 Bot（通常为 `ws://<Bot主机>:8088/onebot/v11/ws`）。
+
+详见 [`pallas_protocol` 插件说明](plugins/pallas_protocol/README.md)。
+
+**方式 B：自管 NapCat / 其他 OneBot 客户端**
+
+- 按 [NapCat](https://napneko.github.io/) 等官方文档安装。
+- 在协议端新建 **WebSocket 客户端**，URL：`ws://<Bot主机>:8088/onebot/v11/ws`（远程部署时将 `localhost` 换为 Bot 机器 IP）。
+
+**如何确认成功**：
+
+1. 控制台 **「在线 Bot」** 或协议端页显示账号已连接。
+2. 在 QQ 群 @ 牛牛或发送测试指令有正常回复。
+
+---
+
+## 生产环境建议
+
+### 使用 systemd 守护（Linux）
+
+示例 unit（路径与用户按实际修改）：
+
+```ini
+[Unit]
+Description=Pallas-Bot
+After=network.target mongod.service
+
+[Service]
+Type=simple
+User=pallas
+WorkingDirectory=/opt/Pallas-Bot
+ExecStart=/home/pallas/.local/bin/uv run nb run
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+启用：`sudo systemctl enable --now pallas-bot.service`。状态：`systemctl status pallas-bot`。
+
+也可使用仓库 **`tools/scripts/bot_watchdog.py`** 探活 `/pallas/api/health`；若 Bot 已由 systemd 启动，须加 **`--no-spawn`**，避免重复占用端口。详见 [进程守护脚本](#进程守护脚本可选)。
+
+### 备份 `data/` 目录
+
+以下内容建议**定期备份**（停机或快照均可）：
+
+- `data/pallas_config/webui.json` — WebUI 配置
+- `data/pallas_console/` — 控制台口令哈希
+- `data/` 下协议端实例、注册表等（分片/多牛共用同一 `data/`）
+
+配置模板 `config/pallas.toml` 请单独版本管理或加密备份，勿与镜像混放密钥。
+
+### 防火墙与安全
+
+- 仅对**可信网络**开放 `8088`（控制台、协议端管理、OneBot HTTP/WS）。
+- 生产环境**不要**开启 `pallas_webui_dev_mode`。
+- 若必须公网访问控制台，请配合反向代理、HTTPS 与强口令；`ACCESS_TOKEN` 见 [配置要点](Config.md)。
+
+### 更新
+
+- **git 部署**：`git pull origin main --autostash` 后 `uv sync`（依赖变更时）并重启进程。
+- **Docker**：见 [Docker 部署 · 后续更新](DockerDeployment.md#后续更新)。
+- 控制台 **「版本与更新」** 可更新 Web 静态资源；git 工作副本内可在线拉主仓（Docker 纯镜像树除外）。**任何代码/依赖更新后须重启 Bot。**
+
+自定义请尽量只改 **`config/pallas.toml`**、**`data/`**、**`local/plugins/`**，避免直接改 `src/` 跟踪文件。见 [站点定制与更新](architecture/site-customization-and-updates.md)。
+
+---
 
 ## 多进程分片（可选）
 
-当同一台机器需要长期运行 **多只牛牛**（例如十余个 QQ 账号）且单进程出现卡顿、延迟堆积时，可启用 **hub + worker** 分片模式，而不是继续加大单进程负载。
+同一台机器长期运行**多只牛牛**且单进程卡顿时，可使用 **hub + worker**，共用 **`data/`** 与同一份 **`config/pallas.toml`**。
 
-- **默认**：`uv run nb run`（单进程），适合牛数量较少或初次部署。
-- **分片**：1 个 **hub**（WebUI、协议端管理、注册表）+ 多个 **worker**（各接一部分牛牛的反向 WebSocket），**共用同一 `data/` 目录**与同一份 **`config/pallas.toml`**（数据库等全局配置一致）。
-- **启动**：在仓库根目录执行 `./scripts/run_sharded_bot.sh start`（详见 [多进程分片架构说明](architecture/bot_process_sharding.md)）。
-- **控制台**：仍只访问 hub 端口（默认 `http://<主机>:8088/pallas/`）；协议端管理也在 hub。
-- **注意**：worker 需额外监听端口（默认从 8090 起）；协议端各账号的 WebSocket 会指向对应 worker，变更端口后须在协议端 **重启** 账号。使用 PostgreSQL 时请预留足够 `max_connections`。
+- 启动：`./scripts/run_sharded_bot.sh start`（详见 [多进程分片架构说明](architecture/bot_process_sharding.md)）。
+- 控制台与协议端管理仅访问 **hub** 端口（默认 `8088`）。
+- 切换前请备份 `data/`；Docker 示例见 [Docker 部署 · 多进程分片](DockerDeployment.md#多进程分片可选)。
 
-从单进程切换到分片前请备份 `data/`。Docker 编排示例见 [Docker 部署 · 多进程分片](DockerDeployment.md#多进程分片可选)。
+---
 
-## 进程守护脚本
+## 进程守护脚本（可选）
 
-（可选）仓库提供 **`tools/scripts/bot_watchdog.py`**：按间隔请求 Web 控制台的 **`/pallas/api/health`**（需启用 **`pallas_webui`**），在进程连续无响应达到阈值后，**结束当前子进程并重新执行启动命令**，或（可选）在宿主机对指定容器执行 **`docker restart`**。适合「希望有一条常驻监护进程」而不只依赖手动重开终端的场景。
+仓库提供 **`tools/scripts/bot_watchdog.py`**：请求 **`/pallas/api/health`**，连续失败后结束子进程并重启，或对 Docker 容器执行 `docker restart`。
 
-**HOST / PORT 从哪来**：与 Bot 一致——当前 shell 的**环境变量优先**；未 `export` 时，脚本会从 **`--workdir` 目录下的 `.env`**（遗留）或 **`config/pallas.toml` 的 `[bootstrap]`** 读取 **`HOST`、`PORT`、`ONEBOT_PORT`**。默认 `--workdir` 为仓库根。
+| 场景 | 用法 |
+| --- | --- |
+| 由脚本拉起 Bot | `uv run python tools/scripts/bot_watchdog.py` |
+| Bot 已由 systemd/Docker 运行 | 必须加 **`--no-spawn`** |
+| 监护容器 | `--docker-container <名> --no-spawn` |
 
-**与「谁启动 Bot」配合**：
+`HOST`/`PORT` 从环境变量或 `config/pallas.toml` 的 `[bootstrap]` 读取。完整参数：`uv run python tools/scripts/bot_watchdog.py --help`。
 
-- **由守护脚本负责拉起 Bot**：在仓库根执行，**不要**加 `--no-spawn`（默认子进程为 `uv run nb run`，可用 `--start` 自定义整条命令）。
-- **Bot 已由 systemd、screen、另一终端或 Docker Compose 启动**：必须加 **`--no-spawn`**，否则脚本会再拉起一条 Bot，**端口冲突**。
-- **Bot 跑在 Docker 容器内、在宿主机上监护**：使用 **`--docker-container <容器名> --no-spawn`**（宿主机需已安装 `docker` CLI，且容器名与 `docker compose` 中一致）。
+---
 
-**常用命令**（均在项目根，且已 `uv sync`）：
+## 访问控制台与协议端
 
-```bash
-# 由守护进程启动 Bot（HOST/PORT 来自环境或 ./.env）
-uv run python tools/scripts/bot_watchdog.py
+| 服务 | 默认地址 |
+| --- | --- |
+| Web 控制台 | `http://<主机>:8088/pallas/` |
+| 协议端管理 | `http://<主机>:8088/protocol/console/` |
 
-# Bot 已在跑：只探活、不重复启动
-uv run python tools/scripts/bot_watchdog.py --no-spawn
+修改了 `host`/`port` 或自定义路径时，以 `pallas.toml` 与插件配置为准。
 
-# 失败时在宿主机重启 compose 中的 Bot 容器（示例名 pallasbot，按实际修改）
-uv run python tools/scripts/bot_watchdog.py --docker-container pallasbot --no-spawn
-```
+---
 
-生产环境可将上述命令写入 **systemd** `User=` 服务、`supervisor` 或 **`screen`/`tmux`** 会话，与 Bot 是否同机同用户按需调整。脚本首轮探活成功会打一条 **INFO**，之后仅在失败、恢复时继续输出日志；更多参数与边界说明见脚本顶部文档字符串或执行 **`uv run python tools/scripts/bot_watchdog.py --help`**。
+## AI 功能（可选）
 
-## 访问 3.0 控制台与协议端管理
+基础功能（复读、轮盘等）不依赖独立 AI 服务。唱歌、酒后闲聊、TTS 等需 [Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI)，对 GPU/内存要求较高，性能不足可跳过。
 
-启动后可在浏览器访问（端口以 `.env` 中 `PORT` 为准，默认 `8088`）：
-
-- **总控 / 数据与插件等**：`http://<主机IP>:8088/pallas/`（HTTP API 基址一般为 `http://<主机IP>:8088/pallas/api`）
-- **协议端管理（NapCat 等）**：`http://<主机IP>:8088/protocol/console/`（与 `pallas_protocol` 插件默认挂载一致）
-
-若修改了 `HOST` / `PORT` 或 `pallas_webui_http_base`、协议端自定义路径，请按实际 URL 访问。
-
-- 控制台与协议端写操作需先登录（同源 Cookie 会话）；仅本机开发可在 `pallas_webui` 中开启 `pallas_webui_dev_mode`。
-- 协议端管理页说明见 [`pallas_protocol` 说明](plugins/pallas_protocol/README.md)。
-
-## 后续更新
-
-部署方式不同，推荐做法也不同：
-
-- **Docker / Compose（推荐生产）**：代码在镜像层，不涉及你本机上的 git 合并冲突。在 compose 目录执行 `docker compose pull`（或你编排里写的镜像拉取命令）后重建容器即可，详见 [Docker 部署](DockerDeployment.md)。
-- **本机 git clone（开发或手动部署）**：在项目目录打开终端，拉取上游变更后重启 Bot。
-
-```bash
-git pull origin main --autostash
-```
-
-`--autostash` 会在拉取前临时 stash **未提交**的本地修改，拉完再尝试恢复；**不能**自动解决「你与上游改了同一处已跟踪文件」的合并冲突，此时需在本地手动 `merge`/`rebase` 解决后再拉。无人值守自动拉取时更稳妥的做法是使用 **`git pull --ff-only`**（非快进则失败退出，避免静默产生合并提交）。
-
-自 **3.0 控制台**起，在浏览器 **「版本与更新」** 页可对 **Web 控制台静态资源** 一键下载更新；若当前进程运行在 **git 工作副本** 内，同一页可对 **Bot 主仓** 发起在线更新（写操作需控制台鉴权）。控制台在 **发布标签** 部署下会 `fetch` 后 `checkout` 到 GitHub 最新 Release 标签（**有本地改动时会自动 stash 并尝试恢复**）；在 **非标签**（开发克隆）下会对当前分支执行 **`git pull --ff-only --autostash`**（优先使用已配置的上游分支，否则回退到 `origin` 的默认分支）。**Docker 仅镜像文件树**时该按钮会提示改用镜像更新。无论哪种方式，**更新依赖或代码后请重启 Bot 进程**。
-
-为减少与上游冲突，自定义内容请尽量只放在 **`config/pallas.toml`**、**`data/`**、**`local/plugins/`** 以及文档允许的挂载目录，避免直接修改 `src/` 下已纳入版本控制的文件。详见 [站点定制与更新](architecture/site-customization-and-updates.md)。
-
-## AI 功能
-
-至此，你已经完成了牛牛基础功能的配置，包括复读、轮盘、夺舍、基本的酒后乱讲话等所有非 AI 功能
-（AI 功能目前包括 唱歌、酒后闲聊、酒后 TTS 说话）
-
-AI 功能均对设备硬件要求较高（要么有一块 6G 显存或更高的英伟达显卡，要么可能占满 CPU 且吃 10G 以上内存）
-若设备性能不足，或对额外的 AI 功能不感兴趣，可以跳过这部分内容。
-
-配置 AI 功能请移步单独的 AI 功能服务端 [Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI)
+---
 
 ## 作为插件部署
 
-> [!NOTE]
-> 该章节是给有 Bot 部署经验的开发者使用的，如果你只是单纯想要部署一个牛牛可以不用看这一部分
-> 对于正在阅读该章节的开发者，我们假定您有一定的 [nonebot2](https://github.com/nonebot/nonebot2) 开发经验
+> 面向已有 NoneBot 项目的开发者；仅部署独立牛牛可跳过本节。
 
-牛牛是基于 nonebot2 来写的 Bot，那么自然支持以插件的形式部署，下面是部署指南
+1. 获取源码并 `uv sync`（PG 用 `--extra pg`）。
+2. 将 `src/common` 与所需 `src/plugins/*` 复制到现有 Bot。
+3. 在 `bot.py` 中于启动时调用 `init_db()`、`ensure_voices()`（参见仓库 [`bot.py`](../bot.py)）。
+4. 配置使用 **`config/pallas.toml`** + **`webui.json`**。
 
-首先，参照上面的步骤获取牛牛的源码，安装依赖到 Bot 的运行环境，并部署好 **MongoDB 或 PostgreSQL**（使用 PG 时需 `uv sync --extra pg`）。在这之后，将 `src/common` 和 `src/plugins` 复制到现有 Bot 的目录下，其中 `src/common` 是必须复制的，而 `src/plugins` 中的插件则可以选择性启用，各插件功能如下：
-+ `auto_accept`: 自动同意拉群请求
-+ `block`: 黑名单功能，不回复指定用户的消息
-+ `callback`：包含牛牛唱歌（tts），`sing` 和 `chat` 的回调接口
-+ `chat`：牛牛酒后闲聊 **依赖于`callback`, `drink`**
-+ `drink`：牛牛喝酒 **依赖于`block`**
-+ `greeting`：欢迎新人/自身加群介绍
-+ `repeater`：牛牛复读
-+ `roulette`：牛牛开枪（轮盘）
-+ `sing`：牛牛唱歌（从网易云下载）**依赖于`callback`**
-+ `take_name`：牛牛夺舍，随机修改为群友 id
-+ `pallas_webui`：3.0 Web 控制台（按需启用）
-+ `pallas_protocol`：3.0 协议端管理（按需启用）
+插件列表见 [插件索引](plugins/README.md)。多 Bot 共存时注意 `matcher` 优先级与 `block` 插件。
 
-此外，对于多 bot 客户端，`block` 插件是必须的。
-
-然后，你需要修改 nonebot 的 `bot.py`，添加数据库初始化的代码。关于这一步，请参照本仓库的 [`bot.py`](https://github.com/PallasBot/Pallas-Bot/blob/main/bot.py)
-
-```diff
-import nonebot
-from nonebot.adapters.onebot.v11 import Adapter as ONEBOT_V11Adapter
-
-+from src.common.db import init_db
-+from src.common.utils.voice_downloader import ensure_voices
-
-nonebot.init()
-
-driver = nonebot.get_driver()
-driver.register_adapter(ONEBOT_V11Adapter)
-config = driver.config
-
-
-+@driver.on_startup
-+async def startup():
-+    await init_db()
-+    await ensure_voices()
-
-
-nonebot.load_from_toml("pyproject.toml")
-
-if __name__ == "__main__":
-    nonebot.run()
-```
-
-然后运行，你就能快乐的和牛牛聊天了~
-
-在这种部署模式下，可能需要手动调整各插件的代码来保证牛牛的消息不会被其他插件截断。你可以统一降低牛牛各插件 `matcher` 的 `priority`（`block` 除外），同时将用户插件 `matcher` 的 `block` 统一设置为 True
+---
 
 ## 开发者群
 
-QQ 群: [牛牛听话！](https://jq.qq.com/?_wv=1027&k=tlLDuWzc)
-欢迎加入~
+QQ 群：[牛牛听话！](https://jq.qq.com/?_wv=1027&k=tlLDuWzc)

--- a/docs/DockerDeployment.md
+++ b/docs/DockerDeployment.md
@@ -1,202 +1,210 @@
 # Pallas-Bot Docker 部署
 
-> 导航：[`README`](../README.md) · [`标准部署`](Deployment.md) · [`多进程分片`](architecture/bot_process_sharding.md) · [`3.0 迁移`](Migration-v3.md) · [`FAQ`](FAQ.md)
+> 导航：[`README`](../README.md) · [`标准部署`](Deployment.md) · [`配置要点`](Config.md) · [`多进程分片`](architecture/bot_process_sharding.md) · [`3.0 迁移`](Migration-v3.md) · [`FAQ`](FAQ.md)
 
-如果你不想自己配置环境，可以使用 `Docker Compose` 一键部署已构建好的镜像。拉取镜像请优先使用与你的版本对应的 **Release** 标签。在宿主机 **`pallas-bot/config/pallas.toml`**（由仓库 [`config/pallas.example.toml`](../config/pallas.example.toml) 复制）的 **`[bootstrap]`** 中设置 **`db_backend = "mongodb"`** 或 **`"postgresql"`** 并填写对应连接信息；WebUI 保存的插件项写入 **`pallas-bot/data/pallas_config/webui.json`**（随 `data` 卷挂载）。详见 [配置存储](architecture/settings-storage.md)。你需要安装 `Docker` 与 `Docker Compose`（较新版本的 `Docker` 已集成 `Compose` 插件），镜像支持 `amd64` 与 `arm64`。
+使用 **Docker Compose** 运行官方镜像，适合生产环境统一版本、隔离依赖。需预先安装 [Docker](https://docs.docker.com/get-docker/) 与 Compose 插件（`docker compose version` 有输出即可）。
 
-## 准备工作
+## 部署前检查清单
 
-### 安装 `Docker` 与 `Docker Compose`
+| 项 | 说明 |
+| --- | --- |
+| Docker | Engine + Compose V2；Linux 可用 `curl -fsSL https://get.docker.com \| bash` |
+| 目录 | 单独目录存放 `docker-compose.yml` 与 `pallas-bot/` 数据（勿用中文空名目录作项目名，见排障） |
+| 配置 | **`pallas-bot/config/pallas.toml`** 必须从示例复制并编辑（**文件**，非目录） |
+| 数据库 | 选定 MongoDB（默认栈）或 PostgreSQL（`--profile postgres`） |
+| 端口 | 宿主机映射 `8088`（或自定义）需在防火墙放行 |
+| 备份 | 持久化 **`pallas-bot/data`** 与数据库卷 |
 
-- [Windows Docker Desktop 安装](https://docs.docker.com/desktop/install/windows-install/) ，推荐使用基于 [WSL 2](https://learn.microsoft.com/zh-cn/windows/wsl/install) 的 `Docker CE`。
+---
 
-- [Linux Docker 安装](https://docs.docker.com/engine/install/ubuntu/)，推荐使用 `curl -fsSL https://get.docker.com | bash -s docker --mirror Aliyun` 命令一键安装。
+## 步骤 1：安装 Docker 与 Compose
 
-- 较新版本的 `Docker` 已集成 `Compose` 插件，可以通过 `docker compose version` 查看 `Compose` 插件是否已安装。
+- [Windows Docker Desktop](https://docs.docker.com/desktop/install/windows-install/)（推荐 WSL2 后端）
+- [Linux 安装](https://docs.docker.com/engine/install/ubuntu/)
 
-- 如果你需要为之前已经安装过的老版本 `Docker` 安装 `Docker Compose` 插件，推荐 [单独安装 Docker Compose](https://docs.docker.com/compose/install/other/)。Windows 用户可以直接在 `Docker Desktop` 中启用 `Docker Compose`（`Settings -> General -> Use Docker Compose V2`）。
-
-- （可选）Linux Rootless 模式
-  如果你希望以非 root 用户运行 Docker，可以参考 [Docker Rootless 模式](https://docs.docker.com/engine/security/rootless/)。
-  如果你使用的是一键安装方式，可以使用以下命令配置 Rootless 模式：
-
-    ```bash
-    sudo apt-get install -y uidmap
-    dockerd-rootless-setuptool.sh install
-    ```
-
-如果你使用的是 Linux 一键安装方式，安装脚本会为你自动配置 Docker 镜像加速。其他安装方式推荐手动[配置镜像加速](https://www.runoob.com/docker/docker-mirror-acceleration.html)。
-
-### 配置 docker-compose.yml
-
-1. 复制一份 [docker-compose.yml](../docker-compose.yml) 到本地单独目录，按需修改 `volumes` 路径：
-
-    ```yml
-    ...
-    volumes:
-        - ./pallas-bot/resource/voices:/app/resource/voices
-        - ./pallas-bot/config/pallas.toml:/app/config/pallas.toml
-        - ./pallas-bot/data:/app/data
-    ...
-      - ./mongo/data:/data/db
-      - ./mongo/logs:/var/log/mongodb
-    ...
-      - ./postgres/data:/var/lib/postgresql/data   # 仅在使用 --profile postgres 时创建
-    ```
-
-    说明：
-
-    - **`./pallas-bot/config/pallas.toml` 必须是宿主机上的一个「文件」**（从仓库复制 [`config/pallas.example.toml`](../config/pallas.example.toml) 后至少填写 `[bootstrap]` 监听与数据库；更多项可在控制台「插件」「通用配置」中编辑并写入 `data/pallas_config/webui.json`）。若路径不存在就执行 `compose up`，在 Windows 上有时会被自动建成**同名文件夹**，再启动会报 **`mounting ... not a directory`**：请删除错误目录，改放真正的 TOML 文件后再启动。
-    - **`resource/voices`** 单独挂载：持久化语音文件。**不要**把宿主机空目录挂到 **`/app/resource` 根目录**，否则会盖住镜像内的 **`resource/styles/default`**（`help` 插件），出现「样式路径不存在」告警。
-    - **`pallas-bot/data`** 映射到容器内 **`/app/data`**，用于持久化 **协议端管理**、**WebUI 配置**（`pallas_config/webui.json`）、控制台口令等；不映射则容器删除后配置会丢。
-    - **`postgres` 服务**默认带 **`profiles: ["postgres"]`**，只有加 `--profile postgres` 才会启动；默认栈里 **只有 MongoDB** 作为数据库容器。
-
-2. 准备配置目录（示例目录名 `pallas-bot`，与 compose 中 `volumes` 一致）：
-
-    ```bash
-    mkdir -p pallas-bot/config pallas-bot/data
-    cp config/pallas.example.toml pallas-bot/config/pallas.toml
-    # 编辑 pallas.toml：SUPERUSERS、数据库等
-    ```
-
-    若从旧版根目录 `.env` 迁移：`uv run python tools/migrate_env_to_pallas.py`（输出到上述路径后按需移动）。
-
-    使用内置 **PostgreSQL** 时，另复制 [`config/compose.env.example`](../config/compose.env.example) 为 **`pallas-bot/config/compose.env`**，其中 **`PG_*`** 与 `pallas.toml` 的 `[bootstrap.postgres]` 保持一致（仅供 Compose 插值 `POSTGRES_*`）。
-
-    控制台与协议端管理页使用浏览器登录（口令哈希持久化在 `data/pallas_console/`）；其余插件项可在控制台内调整。
-
-3. **数据后端二选一**
-
-    - **MongoDB（默认）**：直接 `docker compose up -d`。`pallas.toml` 中 `db_backend = "mongodb"`（或默认）。compose 已为 `pallasbot` 注入 **`MONGO_HOST=mongodb`**、**`MONGO_PORT=27017`**。若你自建 Mongo 或改服务名，请同步改 compose 或 `pallas.toml` 的 `[bootstrap.mongo]`。
-    - **PostgreSQL**：在 **`pallas.toml`** 中设置 `db_backend = "postgresql"`，并填写 **`[bootstrap.postgres]`**。compose 已为 `pallasbot` 注入 **`PG_HOST=postgres`**、**`PG_PORT=5432`**，无需在 TOML 里把 host 写成 `127.0.0.1`。启动内置数据库时请执行 **`docker compose --env-file ./pallas-bot/config/compose.env --profile postgres up -d`**，以便 compose 把 **`PG_*`** 插值写入 `postgres` 容器的 **`POSTGRES_*`**。若使用自建 Postgres，可不加 `--profile postgres`，删掉 compose 里 **`PG_HOST`/`PG_PORT`** 覆盖并在 `pallas.toml` 写明真实地址，并从 `depends_on` 中视情况移除对内置 `postgres` 的等待（见仓库 `docker-compose.yml` 注释）。
-
-    从历史数据迁移请参考 [`3.0 迁移指南`](Migration-v3.md)。
-
-4. **QQ / NapCat 与协议端管理**
-
-    默认 **不再** 在 Compose 中编排独立 **`napcat`** 容器；请在浏览器打开 **`http://<宿主机>:8088/protocol/console/`**（端口随映射变化），在 **协议端管理** 中创建实例并登录。管理页会按当前 Bot 的运行方式（本机进程或 Docker 等）自动填写 OneBot WebSocket 等连接信息，一般无需手动改；自管 NapCat 或网络异常时再查 [`pallas_protocol` 说明](plugins/pallas_protocol/README.md)。
-
-    - **Linux** 且管理页里使用 **Docker 模式** 拉起 NapCat：需在 `pallasbot` 服务上挂载 **`/var/run/docker.sock`**（`docker-compose.yml` 内已用注释标出；有安全风险，生产环境请加固）。
-    - 若仍希望 **单独** 起一个 NapCat 容器，可自行写 compose 并做好与 Bot 的网络互通；注意与协议端管理不要 **重复登录同一账号**。
-
-## 启动与使用
-
-### 启动
+验证：
 
 ```bash
-# 仅 MongoDB（默认）
-docker compose up -d
+docker --version
+docker compose version
+```
 
-# 需要本 compose 内的 PostgreSQL 时（PG_* 写在 pallas-bot/config/compose.env）
+**如何确认成功**：两条命令均正常输出版本号。
+
+（可选）Linux Rootless：`dockerd-rootless-setuptool.sh install`，见 [官方文档](https://docs.docker.com/engine/security/rootless/)。
+
+---
+
+## 步骤 2：准备 Compose 与目录
+
+1. 将仓库 [`docker-compose.yml`](../docker-compose.yml) 复制到部署目录（例如 `~/pallas-deploy/`）。
+
+2. 创建数据目录并复制主配置：
+
+```bash
+mkdir -p pallas-bot/config pallas-bot/data
+cp /path/to/Pallas-Bot/config/pallas.example.toml pallas-bot/config/pallas.toml
+```
+
+3. 编辑 **`pallas-bot/config/pallas.toml`**（必做）：
+
+   - `superusers`、 `db_backend`
+   - `[bootstrap.mongo]` 或 `[bootstrap.postgres]`
+
+4. 按需调整 compose 中 **`volumes`**（与下列一致即可）：
+
+```yml
+volumes:
+  - ./pallas-bot/resource/voices:/app/resource/voices
+  - ./pallas-bot/config/pallas.toml:/app/config/pallas.toml
+  - ./pallas-bot/data:/app/data
+```
+
+要点：
+
+- **`pallas.toml` 必须是宿主机上的普通文件**；若误建成文件夹，启动会报 `not a directory`（见排障）。
+- **只挂载 `resource/voices`**，勿把整个 `resource` 挂到 `/app/resource`，否则会盖住镜像内 `styles/default`。
+- **`data`** 持久化 WebUI、协议端、控制台口令等。
+
+**如何确认成功**：`file pallas-bot/config/pallas.toml` 显示为文本文件；`pallas-bot/data` 目录存在。
+
+---
+
+## 步骤 3：选择数据库并启动
+
+### MongoDB（默认）
+
+`pallas.toml` 中 `db_backend = "mongodb"`（或省略默认）。compose 已为 Bot 注入 `MONGO_HOST=mongodb`。
+
+```bash
+docker compose up -d
+```
+
+### PostgreSQL（内置 compose 数据库）
+
+1. `pallas.toml` 设 `db_backend = "postgresql"` 并填写 `[bootstrap.postgres]`。
+2. 复制 [`config/compose.env.example`](../config/compose.env.example) → **`pallas-bot/config/compose.env`**，使 **`PG_*`** 与 TOML 一致。
+3. 启动：
+
+```bash
 docker compose --env-file ./pallas-bot/config/compose.env --profile postgres up -d
 ```
 
-### 查看日志
+**如何确认成功**：
 
-在 `docker-compose.yml` 所在目录执行：
+```bash
+docker compose ps          # pallasbot、数据库容器为 running
+docker compose logs -f pallasbot   # 无 DB 连接致命错误，出现控制台口令相关日志
+curl -s http://127.0.0.1:8088/pallas/api/health   # 返回正常
+```
+
+---
+
+## 步骤 4：协议端与 QQ
+
+默认 **不** 在 compose 中编排 NapCat。浏览器打开：
+
+`http://<宿主机IP>:8088/protocol/console/`
+
+在协议端管理页创建实例、登录 QQ。Linux 下管理页使用 **Docker 模式** 拉起 NapCat 时，需在 `pallasbot` 服务挂载 **`/var/run/docker.sock`**（compose 内已注释说明，注意安全）。
+
+自管 NapCat 时，WebSocket 客户端 URL：`ws://<可达Bot的地址>:8088/onebot/v11/ws`。
+
+**如何确认成功**：控制台显示在线 Bot；QQ 内测试指令有回复。详见 [`pallas_protocol`](plugins/pallas_protocol/README.md)。
+
+---
+
+## 步骤 5：访问控制台
+
+| 服务 | 地址 |
+| --- | --- |
+| Web 控制台 | `http://<宿主机>:8088/pallas/` |
+| 协议端管理 | `http://<宿主机>:8088/protocol/console/` |
+
+使用启动日志中的口令登录；生产环境勿开 `pallas_webui_dev_mode`。
+
+---
+
+## 日常运维
+
+### 查看日志
 
 ```bash
 docker compose logs -f pallasbot
 ```
 
-### （可选）宿主机进程守护
+### 宿主机探活（可选）
 
-Bot 在容器内运行时，若希望在**宿主机**上定时探活、失败时执行 `docker restart`，可使用仓库脚本 **`tools/scripts/bot_watchdog.py`**（需宿主机已安装 `docker` CLI，且 `--docker-container` 与 compose 服务名一致）。说明与示例见 [标准部署：进程守护脚本](Deployment.md#进程守护脚本)。
+Bot 已在容器内运行时：
 
-### 访问 Web 控制台与协议端管理
+```bash
+uv run python tools/scripts/bot_watchdog.py --docker-container pallasbot --no-spawn
+```
 
-（默认映射宿主机 `8088`，若已修改 `ports` 请替换。）
+容器名须与 compose 中 `container_name` / 服务名一致。详见 [标准部署 · 进程守护](Deployment.md#进程守护脚本可选)。
 
-- **Web 控制台**：`http://<宿主机ip>:8088/pallas/`（HTTP API 一般为 `http://<宿主机ip>:8088/pallas/api`）
-- **协议端管理**：`http://<宿主机ip>:8088/protocol/console/`（与控制台共用登录；详见 [`pallas_protocol`](plugins/pallas_protocol/README.md)）
+### 备份
 
-写操作需先登录（会话 Cookie）；勿在生产环境开启 `pallas_webui_dev_mode`。
+定期备份：
 
-## 多进程分片（可选）
+- `./pallas-bot/data/`
+- `./pallas-bot/config/pallas.toml`
+- `./mongo/data` 或 `./postgres/data`（数据库卷）
 
-单容器 `pallasbot` 适合牛数量较少。若生产环境需 **十余只及以上** 牛牛且希望分摊事件循环压力，可使用仓库提供的分片编排示例 **[`docker-compose.shard.example.yml`](../docker-compose.shard.example.yml)**：
+### 防火墙
 
-- **`pallas-hub`**：`APP_MODULE=bot_hub:app`，映射 **8088**（WebUI、协议端管理、AI/MAA 回调入口）。
-- **`pallas-worker-N`**：`APP_MODULE=bot_worker:app`，各映射 **8090、8091…**，与 `PALLAS_SHARD_ID` 一致。
-- **必须** 为 hub 与所有 worker 挂载 **同一份** `./pallas-bot/config/pallas.toml` 与 `./pallas-bot/data`（注册表、协议端账号、WebUI 配置、协调状态均写在共享 `data/` 下）。
+仅对可信 IP 开放映射的 **8088**（及自定义端口）；公网暴露请加 HTTPS 与强认证。
 
-用法示例：将示例复制为 `docker-compose.override.yml` 或独立 compose 文件，在 `pallas.toml` 中无需改数据库配置，仅需为分片进程设置 `PALLAS_SHARD_ENABLED=true` 等（示例 compose 已注入 hub/worker 角色变量）。worker 数量不足时参照示例增删 `pallas-worker-*` 服务，或在本机用 [`scripts/run_sharded_bot.sh`](../scripts/run_sharded_bot.sh) 自动按账号数计算。
-
-协议端在 Docker 模式下须能访问 **worker 容器端口**；`PALLAS_SHARD_WS_HOST` 或协议端插件中的 OneBot 主机应填容器网络可达地址。完整说明、端口同步与排障见 **[多进程分片架构说明](architecture/bot_process_sharding.md)** 与 [标准部署 · 多进程分片](Deployment.md#多进程分片可选)。
-
-## 排障
-
-### `project name must not be empty`
-
-Compose 默认用**当前文件夹名**作为项目名；目录名为中文等时，部分 Docker Desktop 版本会推出**空项目名**从而报错。本仓库 [`docker-compose.yml`](../docker-compose.yml) 已在顶层设置 **`name: pallas-bot`** 规避该问题。
-
-若你使用的 `docker-compose.yml` 尚无此行，可任选其一：
-
-- 启动时指定项目名：`docker compose -p pallas-bot --profile postgres up -d`
-- PowerShell：`$env:COMPOSE_PROJECT_NAME = "pallas-bot"` 后再执行 `docker compose ...`
-
-同一台机器多套实例时请改用不同项目名（例如 `-p pallasbot-home2`），避免网络/容器名冲突。
-
-### `help` 告警「样式路径不存在 `/app/resource/styles/default`」
-
-多为 **Compose 把整条 `./pallas-bot/resource` 挂到 `/app/resource`**，宿主机目录里没有从仓库带过来的 **`styles/default`**，把镜像内自带样式**遮住**了。请改用仓库当前写法：**只挂载 `./pallas-bot/resource/voices:/app/resource/voices`**，或保证宿主机 `resource` 下包含与仓库一致的 **`styles/default`**。
-
-### PG 日志 `FATAL: database "PallasBot" does not exist`
-
-**不是** Postgres 容器坏了，而是：**当前数据目录里根本没有名为 `PallasBot` 的库**，而 Bot 的 **`PG_DB`**（默认 `PallasBot`）正在连这个库。
-
-常见原因：
-
-1. **数据卷是以前用别的 `POSTGRES_DB` 初始化过的**（例如旧 compose 默认建过库名 **`pallas`**）。Postgres 官方镜像**只在数据目录为空时**根据 `POSTGRES_DB` 建库，**改环境变量不会自动改名/建新库**。
-2. **`pallas.toml` / `compose.env` 里 `PG_DB` 与 compose 插值出的 `POSTGRES_DB` 不一致**（且卷里只有其中一侧的库）。
-
-处理任选其一：
-
-- **对齐名字**：把 **`pallas.toml`** 的 **`[bootstrap.postgres] db`** 与 **`compose.env`** 的 **`PG_DB`** 改成与卷里**已有**库名一致（若当初建的是 `pallas` 就写 `pallas`），并 **`docker compose restart pallasbot`**。
-- **重建空卷（会删库）**：`docker compose --profile postgres down`，删除宿主机 **`./postgres/data`** 目录，再 **`docker compose --env-file ./pallas-bot/config/compose.env --profile postgres up -d`**，让镜像按当前 **`POSTGRES_DB`**（默认与 **`PG_DB`** 一致为 **`PallasBot`**）重新初始化。
-- **保留数据手动建库**：`docker exec -it pallasbot_postgres psql -U <PG_USER> -d postgres -c 'CREATE DATABASE "PallasBot";'`（库名与 **`PG_DB`** 一致即可）。
-
-### `python:3.12-slim` / `registry-1.docker.io` 拉取失败、`EOF`、`connectex`
-
-访问 **Docker Hub** 不稳定时，构建会在 **`FROM python`** 或解析 manifest 阶段失败。可选做法：
-
-1. **构建参数换基础镜像前缀**（仓库 [`Dockerfile`](../Dockerfile) 支持 **`BASE_IMAGE`**）：
-
-    ```bash
-    docker build --build-arg BASE_IMAGE=docker.m.daocloud.io/library/python:3.12-slim -t pallasbot:local .
-    ```
-
-    可选 **`PALLAS_BOT_VERSION`**（写入镜像环境变量，控制台 `/health` 的 `pallas_bot` 优先显示）：例如 `docker build --build-arg PALLAS_BOT_VERSION="$(git describe --tags --always)" ...`。仓库 **GitHub Actions**（`docker-image.yml`、`release.yml`）构建时会自动传入。
-
-    若某镜像站不可用，请换你环境能访问的 **`library/python:3.12-slim`** 同步源（需与官方标签一致或兼容）。
-
-2. **Docker Desktop**：在 **Settings → Docker Engine** 中为 `registry-mirrors` 配置加速，并重试 `docker build`。
-
-3. **代理 / VPN**：让 Docker 守护进程能访问 `registry-1.docker.io`。
-
-### `mounting ... pallas.toml ... not a directory` / `Are you trying to mount a directory onto a file`
-
-宿主机上 `./pallas-bot/config/pallas.toml` 与容器内 **`/app/config/pallas.toml`（文件）** 类型不一致时会出现。常见原因：该路径实际是**文件夹**，或路径写错。处理：删掉宿主机上误建的目录，从仓库复制 **`config/pallas.example.toml`** 为 **`pallas-bot/config/pallas.toml`** 后再 `docker compose up`。
-
-### Compose 服务名 `pallasbot` 与内网 WebSocket
-
-- **不必**为了协议端专门「取消」自定义网络：Compose 会为项目建网络，**服务名 DNS**（如 `pallasbot`）只在该网络内的容器之间生效；删掉显式 `networks:` 仍会生成默认网络，**并不能**让协议端 Docker 模式自动改用 `pallasbot` 主机名。
-- **协议端管理**写入 **`onebot*.json`** 时，依据的是 **`pallas.toml` / 驱动里的 `HOST`、`PORT` 等** 解析出 WS，再在 **Linux Docker 模式**下把主机替换为解析后的 **`PALLAS_PROTOCOL_DOCKER_ONEBOT_HOST`**（留空时 Linux **`bridge`** 一般为**宿主机在容器视角的网关 IP**；见插件文档），**不会**根据 Compose 服务名自动填 `pallasbot`。
-- 若你**自行**把 NapCat 写成与 `pallasbot` **同一 Compose 网络**的 service，则可在 NapCat 里把 OneBot 客户端 URL 写成 **`ws://pallasbot:<PORT>/onebot/v11/ws`**（明文 WebSocket、常见内网无 TLS）；这与当前协议端插件 **`docker run` 默认桥接网络** 是两条路径。
-
-## 后续更新
+### 后续更新
 
 ```bash
 docker compose down
 docker compose pull
 docker compose up -d
+# PostgreSQL profile 时加上 --env-file 与 --profile postgres
 ```
 
-站点自有插件若挂载 `./pallas-bot/local/plugins`，更新镜像后仍会保留；需在 `pallas.toml` 配置 `extra_plugin_dirs = ["local/plugins"]`。见 [站点定制与更新](architecture/site-customization-and-updates.md)。
+站点插件若挂载 `./pallas-bot/local/plugins`，需在 `pallas.toml` 设置 `extra_plugin_dirs`。见 [站点定制与更新](architecture/site-customization-and-updates.md)。
+
+---
+
+## 多进程分片（可选）
+
+十余只及以上牛牛、需 hub + worker 时，参考 [`docker-compose.shard.example.yml`](../docker-compose.shard.example.yml)：
+
+- hub 映射 **8088**；worker 映射 **8090、8091…**
+- hub 与所有 worker **共用同一份** `pallas.toml` 与 **`data/`** 挂载
+
+说明见 [多进程分片架构](architecture/bot_process_sharding.md) 与 [标准部署 · 分片](Deployment.md#多进程分片可选)。
+
+---
+
+## 排障
+
+### `project name must not be empty`
+
+仓库 compose 已设 `name: pallas-bot`。若仍报错：`docker compose -p pallas-bot up -d`，或避免用特殊字符作当前目录名。
+
+### `mounting ... pallas.toml ... not a directory`
+
+宿主机 `pallas-bot/config/pallas.toml` 被建成了**目录**。删除该目录，重新 `cp config/pallas.example.toml` 为文件后再 `up`。
+
+### `help` 告警样式路径不存在
+
+勿将空 `./pallas-bot/resource` 挂到 `/app/resource`；仅挂载 **`voices`** 子目录。
+
+### PG：`FATAL: database "PallasBot" does not exist`
+
+数据卷曾用其他 `POSTGRES_DB` 初始化，与当前 `PG_DB` 不一致。对齐库名或清空 `./postgres/data` 后重建，见原文档说明或 [FAQ](FAQ.md)。
+
+### 拉取 `python:3.12-slim` 失败
+
+使用镜像加速或：
 
 ```bash
-# 若使用 postgres profile：
-# docker compose --env-file ./pallas-bot/config/compose.env --profile postgres down
-# docker compose pull
-# docker compose --env-file ./pallas-bot/config/compose.env --profile postgres up -d
+docker build --build-arg BASE_IMAGE=docker.m.daocloud.io/library/python:3.12-slim -t pallasbot:local .
 ```
+
+### Compose 服务名与 WebSocket
+
+协议端插件按 `pallas.toml` 的 `HOST`/`PORT` 生成 WS；**不会**自动使用 compose 服务名 `pallasbot`。自管 NapCat 且与 Bot 同网络时，可手写 `ws://pallasbot:8088/onebot/v11/ws`。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# Pallas-Bot 文档
+
+> **在线阅读**：[https://PallasBot.github.io/Pallas-Bot-Docs/](https://PallasBot.github.io/Pallas-Bot-Docs/)（仓库 [PallasBot/Pallas-Bot-Docs](https://github.com/PallasBot/Pallas-Bot-Docs)）
+
+面向部署者与插件维护者的文档索引。运行配置以 **`config/pallas.toml`** + **`data/pallas_config/webui.json`** 为主（见 [配置存储](architecture/settings-storage.md)）；遗留根目录 `.env` 只读合并，WebUI 保存不再写入 `.env`。
+
+## 快速上手
+
+| 文档 | 说明 |
+| --- | --- |
+| [配置要点](Config.md) | `pallas.toml` 与 WebUI |
+| [标准部署](Deployment.md) | git clone、uv、数据库、控制台 |
+| [Docker 部署](DockerDeployment.md) | Compose、卷挂载、内置 PG/Mongo |
+| [常见问题](FAQ.md) | 学习机制、号主、排障 |
+| [3.0 迁移](Migration-v3.md) | Mongo → PostgreSQL 等 |
+
+## 架构
+
+| 文档 | 说明 |
+| --- | --- |
+| [项目结构](architecture/project-structure.md) | 目录职责与分层 |
+| [插件规范](architecture/plugin-convention.md) | `src/plugins` 组织方式 |
+| [配置存储](architecture/settings-storage.md) | pallas.toml + webui.json |
+| [多进程分片](architecture/bot_process_sharding.md) | hub + worker 生产部署 |
+| [站点定制与更新](architecture/site-customization-and-updates.md) | local/plugins、更新策略 |
+
+## 插件
+
+完整索引见 [plugins/README.md](plugins/README.md)。新增插件文档可复制 [plugins/TEMPLATE.md](plugins/TEMPLATE.md)。
+
+## 通用能力
+
+| 文档 | 说明 |
+| --- | --- |
+| [命令权限 cmd_perm](common/cmd_perm/README.md) | 帮助菜单「何人可用」 |
+| [WebUI 配置热重载](common/webui/README.md) | `install_hot_reload_config` |
+| [消息审查 message_scrub](common/message_scrub/README.md) | 复读/做梦入站过滤 |
+| [社区统计](common/community_stats.md) | 部署心跳（默认开启） |
+
+## 同步 Web 文档
+
+主仓 `docs/` 变更后，可在仓库根执行：
+
+```bash
+uv run python tools/scripts/sync_docs_to_web.py
+```
+
+将 Markdown 转换并写入 sibling 目录 `Pallas-Bot-Docs/src/`（路径可通过 `--dest` 指定）。

--- a/docs/architecture/plugin-convention.md
+++ b/docs/architecture/plugin-convention.md
@@ -56,7 +56,7 @@
 
 ## WebUI 配置与命令权限
 
-- 需在控制台保存 `.env` 后立即生效的插件配置：在 `config.py` 使用 `src.common.webui.install_hot_reload_config`（见 [WebUI 插件配置](../common/webui/README.md)）；已有自定义缓存的插件可登记到 `plugin_webui_registry`（如决斗插件）。
+- 需在 WebUI 保存 **`webui.json`** 后立即生效的插件配置：在 `config.py` 使用 `src.common.webui.install_hot_reload_config`（见 [WebUI 插件配置](../common/webui/README.md)）；已有自定义缓存的插件可登记到 `plugin_webui_registry`（如决斗插件）。
 - 可配置命令权限：在 `PluginMetadata.extra` 声明 `command_permissions`，matcher 使用 `src.common.cmd_perm.permission_for_command`（见 [cmd_perm](../common/cmd_perm/README.md)）。
 
 ### 命令权限与帮助文案（cmd_perm）

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -6,10 +6,13 @@
 
 - `src/`: 业务源码
 - `tests/`: 单元测试与集成测试
-- `docs/`: 面向开发与部署的文档
+- `docs/`: 面向开发与部署的文档（索引见 [docs/README.md](../README.md)）
+- `config/`: 主配置示例与 Compose 插值（`pallas.example.toml`、`compose.env.example`）
+- `scripts/`: 运维脚本（如 `run_sharded_bot.sh` 分片启动）
+- `local/plugins/`: 站点自有插件（`extra_plugin_dirs`，见 [站点定制](site-customization-and-updates.md)）
 - `tools/`: 维护脚本与辅助配置
 - `.github/workflows/`: CI/CD 流水线
-- `data/`: 运行期持久化数据（按插件分目录，如 `data/help/`）
+- `data/`: 运行期持久化数据（`pallas_config/webui.json`、各插件子目录等）
 - `resource/`: 项目静态资源（如语音、样式）
 
 ## 源码分层约定
@@ -59,9 +62,7 @@
 - 每个插件使用独立目录：`docs/plugins/<plugin_name>/README.md`
 - 插件文档总索引：`docs/plugins/README.md`
 
-当前已迁移示例：
-
-- `bot_status` 插件文档：`docs/plugins/bot_status/README.md`
+当前已迁移的插件文档见 [plugins/README.md](../plugins/README.md)（21 个用户向插件 + 通用能力文档）。
 
 ## tools 目录约定
 

--- a/docs/common/cmd_perm/README.md
+++ b/docs/common/cmd_perm/README.md
@@ -115,10 +115,11 @@ if not await satisfies_command_permission(bot, event, "my_plugin.do_something"):
 
 `menu_data` 里填写的命令 ID 必须与 `permission_for_command(...)` / `satisfies_command_permission(..., "...")` 使用的 ID **一致**，否则帮助上的「何人可用」与实际鉴权不一致。
 
-## 运行中覆盖：`.env` 与 WebUI
+## 运行中覆盖：WebUI 与 webui.json
 
-- 环境变量：`PALLAS_COMMAND_PERMISSION_OVERRIDES`（JSON 对象：命令 ID → 等级字符串）。
-- WebUI：「通用配置」中的 **命令权限** 段会读写同一键，保存后会清理配置缓存，**覆盖值通常无需重启 Bot 即可生效**。
+- WebUI **「通用配置 → 命令权限」** 写入 `data/pallas_config/webui.json`（键 `PALLAS_COMMAND_PERMISSION_OVERRIDES`，JSON：命令 ID → 等级）。
+- 亦可通过环境变量或 `pallas.toml` `[env]` 注入同名键；**WebUI 落盘优先级最高**。
+- 保存后会清理配置缓存，**覆盖值通常无需重启 Bot 即可生效**。
 - 修改 **Python 中的默认等级或 `command_permissions` 列表**：需重新加载插件或重启进程。
 
 ## 相关源文件

--- a/docs/common/community_stats.md
+++ b/docs/common/community_stats.md
@@ -4,23 +4,20 @@
 
 **升级**：包含 `community_stats` 插件的 release 在 **hub / 单进程** 启动后**默认自动接入**，**不必**在 `pallas.toml` 增加 `[community_stats]` 或 `enabled = true`。仅 opt-out：显式 `enabled = false` 或 `PALLAS_COMMUNITY_STATS_ENABLED=false`。**无需向用户分发 token。**
 
-## 心跳地址（自动主备，无需用户改配置）
+## 心跳地址
 
-| 优先级 | 地址 | 说明 |
-| --- | --- | --- |
-| 1 | `https://stats.pallasbot.top/v1/heartbeat` | 正式域名（备案通过后可用） |
-| 2 | `https://pallas.togetsudo.com/v1/heartbeat` | 运维反代备用；正式域名不可达时自动使用 |
+默认上报至：
 
-- 默认**先连正式域名**；失败则切备用，并写入 `data/pallas_config/community_stats.json` 的 `heartbeat_endpoint`。
-- 使用备用期间，每 **6 小时**再探测一次正式域名；备案恢复后**自动切回**，用户无需改 `pallas.toml`。
-- 仅当填写**非上述内置地址**的 `endpoint` 时，才固定单地址（自建私有中心等）。
+`https://stats.pallasbot.top/v1/heartbeat`
+
+无需在配置中填写；仅在自建私有统计中心时通过 `endpoint` 覆盖。
 
 ## 配置（`[community_stats]`，均可省略）
 
 | 键 | 默认 | 说明 |
 | --- | --- | --- |
 | `enabled` | `true` | 省略整段 `[community_stats]` 亦为开启；仅 `false` 时不上报 |
-| `endpoint` | `https://stats.pallasbot.top/v1/heartbeat` | 内置主/备地址时走自动切换；改为其它 URL 则仅用该地址 |
+| `endpoint` | `https://stats.pallasbot.top/v1/heartbeat` | 仅自建/特殊地址时修改 |
 | `token` | 空 | **共用中心留空即可**；仅自建私有中心且启用 token 时填写 |
 | `interval_sec` | `300` | 周期上报间隔（60–3600） |
 
@@ -28,11 +25,11 @@
 
 ## 行为
 
-- 首次启用时在 `data/pallas_config/community_stats.json` 生成 `deployment_id`（UUID），并可能记录当前生效的 `heartbeat_endpoint`。
+- 首次启用时在 `data/pallas_config/community_stats.json` 生成 `deployment_id`（UUID）。
 - **单进程 / hub** 上报；**分片 worker** 不上报（避免重复计数）。
 - `online_bots` 与控制台 **「在线 Bot」** 同源；首包在启动约 **60 秒** 后发送，之后按 `interval_sec`（默认 300 秒）刷新。
-- WebUI **「在线牛总和」** 为全社区各部署 `online_bots` 之和；控制台拉取 stats 时同样走主备 URL。
-- 失败仅记日志，不影响 Bot 启动与消息处理。
+- WebUI **「在线牛总和」** 为全社区各部署 `online_bots` 之和。
+- 上报失败仅记日志，不影响 Bot 启动与消息处理。
 
 ## 隐私
 

--- a/docs/common/message_scrub/README.md
+++ b/docs/common/message_scrub/README.md
@@ -4,7 +4,7 @@
 
 牛牛在**复读学习**和**做梦采集 / 漂流**之前，会先过一道「洗消息」：命中规则的内容**不会进学习库、也不会进梦库或往外漂**。你可以把它理解成：**不想让 Bot 记住或转述的话，在这里挡掉**。
 
-**当前版本里，这条链路已经接好、可以直接用。** 推荐在 Web 控制台 **「通用配置」** →「消息审查 / 入站过滤」中修改（写入根目录 `.env`）；亦可直接改 `.env`、环境变量，并重启 Bot（或按需刷新缓存），无需再改代码。已接入范围：
+**当前版本里，这条链路已经接好、可以直接用。** 推荐在 Web 控制台 **「通用配置」** →「消息审查 / 入站过滤」中修改（写入 **`data/pallas_config/webui.json`**）；亦可编辑 `config/pallas.toml` 的 `[env]` 或进程环境变量。保存后 hub 会热重载，分片 worker 会在磁盘变更后自动重读。已接入范围：
 
 - **牛牛复读**：群消息在去重之后，若被判定拦截，则整条不再参与学习与后续复读逻辑。
 - **牛牛做梦**：做梦采集里，除「不可以」等业务规则外，同样会走统一审查；拦截则不入库、不漂流。
@@ -18,7 +18,7 @@
 | 你的目标 | 你需要做的大致事情 |
 |----------|-------------------|
 | 先不用审查 | 什么都不配即可。 |
-| 只拦少数固定说法 | 在 `.env` 里配 `PALLAS_INBOUND_FILTER_SUBSTRINGS`（英文逗号分隔，不区分大小写）。 |
+| 只拦少数固定说法 | WebUI 或配置键 `PALLAS_INBOUND_FILTER_SUBSTRINGS`（英文逗号分隔，不区分大小写）。 |
 | 用一份自己的词表 | 准备一个 UTF-8 的 txt（见下文「词表文件」），配 `PALLAS_SCRUB_LEXICON_PATH` 指向它；也可使用仓库 [`resource/message_scrub/politics.txt`](../../../resource/message_scrub/politics.txt) 例子。 |
 | 交给云端判断 | 配置百度 Key，或自建一个符合约定的 HTTP 接口地址（见下文「远程审查」）。 |
 | 本地 + 云端都要 | 可同时配词表/子串与百度或自建网关；会先跑本地，再按顺序跑远程。 |
@@ -33,7 +33,7 @@
 
 1. 用编辑器保存为 **UTF-8**，**一行一个词**；以 `#` 开头的行当注释；空行忽略。
 2. 把文件放在 Bot 机器上任意可读路径（例如 `data/sensitive_lexicon.txt`）。
-3. 在 `.env` 里写一行（路径改成你的实际位置）：
+3. 在 WebUI **通用配置** 或 `data/pallas_config/webui.json` / `pallas.toml` `[env]` 中设置（路径改成你的实际位置）：
 
    ```env
    PALLAS_SCRUB_LEXICON_PATH=data/sensitive_lexicon.txt
@@ -42,7 +42,7 @@
    相对路径是相对于**启动 Bot 时的工作目录**；若你不确定工作目录，用**绝对路径**最省心。
 
 4. **只改词表内容并保存**：一般**不用重启**，下次处理消息时会按文件更新时间自动重建词库。
-5. **改了路径或改了 `.env` 里其它审查相关变量**：重启 Bot 最稳妥；若你在做二次开发，也可调用 `reload_message_scrub_caches()` 清本地缓存和百度 token 缓存。
+5. **改了路径或改了其它审查相关配置键**：WebUI 保存后通常立即生效；若未生效可重启 Bot，或调用 `reload_message_scrub_caches()`。
 
 从 [Sensitive-lexicon](https://github.com/konsheng/Sensitive-lexicon) 等仓库下载的多份 `.txt`，需要你在本机**先合并成一个**符合上面格式的文件，再把这个文件路径配进 `PALLAS_SCRUB_LEXICON_PATH`（合并方式由你自选脚本）。这类大词表在群聊里容易**误拦正常话**，建议先小范围试，再决定是否全量或搭配百度使用。
 
@@ -52,13 +52,13 @@
 
 ### 百度
 
-在 `.env` 里填写 **`PALLAS_SCRUB_BAIDU_API_KEY`** 和 **`PALLAS_SCRUB_BAIDU_SECRET_KEY`**（控制台里应用的 API Key / Secret Key）即可。**不用自己维护 `access_token`**，Bot 会自动换取并缓存。
+在 WebUI **通用配置** 或配置键中填写 **`PALLAS_SCRUB_BAIDU_API_KEY`** 和 **`PALLAS_SCRUB_BAIDU_SECRET_KEY`**（控制台里应用的 API Key / Secret Key）即可。**不用自己维护 `access_token`**，Bot 会自动换取并缓存。
 
 可选：`PALLAS_SCRUB_BAIDU_STRATEGY_ID`（策略中心里的策略）、`PALLAS_SCRUB_BAIDU_BLOCK_SUSPECTED`（是否把「疑似」也当拦截，默认要拦）。
 
 ### 自建 HTTP 网关
 
-适合：你们已有统一审核服务，或想用自己语言写逻辑。在 `.env` 里配置 **`PALLAS_SCRUB_API_URL`**（优先）或 **`PALLAS_INBOUND_FILTER_API_URL`**。
+适合：你们已有统一审核服务，或想用自己语言写逻辑。在 WebUI 或配置键中设置 **`PALLAS_SCRUB_API_URL`**（优先）或 **`PALLAS_INBOUND_FILTER_API_URL`**。
 
 对方接口约定：`POST`，JSON 里是 `plain_text`、`raw_message` 两段字符串；返回 JSON 里必须有 **`blocked`** 布尔值，`true` 表示这条消息要拦。若网关需要鉴权，可配 `PALLAS_INBOUND_FILTER_API_KEY`（会以 `Bearer` 形式带上）。
 
@@ -77,6 +77,8 @@
 ---
 
 ## 环境变量速查
+
+键名与 WebUI 表单项一致；落盘见 **`data/pallas_config/webui.json`** 的 `env` 段。下表便于检索与 Docker `[env]` 注入：
 
 | 变量 | 一句话说明 | 默认 |
 |------|------------|------|

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,8 +1,8 @@
 # 插件文档索引
 
-各插件的「怎么配、怎么用、怎么排障」见子目录 `README.md`（统一结构见 [TEMPLATE.md](./TEMPLATE.md)）；`PluginMetadata` 约定见 [cmd_perm](../common/cmd_perm/README.md) 与 `src/common/cmd_perm/metadata_defaults.py`。
+各插件的「怎么配、怎么用、怎么排障」见子目录 `README.md`（统一结构见 [TEMPLATE.md](./TEMPLATE.md)）；`PluginMetadata` 约定见 [cmd_perm](../common/cmd_perm/README.md)。
 
-配置字段以各插件 `config.py` 为准，推荐在 WebUI **插件 / 通用配置** 中修改。
+**配置**：有 `config.py` 的插件以该文件字段为准；无独立配置的插件（如 `take_name`、`blacklist`）在文档中单独说明。推荐在 WebUI **插件 / 通用配置** 中修改，落盘 **`data/pallas_config/webui.json`**。
 
 ## 远控与运维
 

--- a/docs/plugins/TEMPLATE.md
+++ b/docs/plugins/TEMPLATE.md
@@ -26,7 +26,7 @@
 | --- | --- | --- |
 | … | … | … |
 
-字段以 [`src/plugins/{包名}/config.py`](../../src/plugins/{包名}/config.py) 为准；可在 WebUI **插件** 或 **通用配置** 中修改。
+字段以 [`src/plugins/{包名}/config.py`](../../src/plugins/{包名}/config.py) 为准（**无 `config.py` 的插件删本节**）；可在 WebUI **插件** 或 **通用配置** 中修改，落盘 `data/pallas_config/webui.json`。
 
 ## 排障
 

--- a/docs/plugins/chat/README.md
+++ b/docs/plugins/chat/README.md
@@ -15,7 +15,7 @@
 
 ## 配置
 
-[`config.py`](../../../src/plugins/chat/config.py)：`chat_enable`、`ai_server_host`、`ai_server_port` 等。
+[`config.py`](../../../src/plugins/chat/config.py)：`chat_enable`、`ai_server_host`、`ai_server_port` 等。推荐在 WebUI **插件 → chat** 修改（落盘 `data/pallas_config/webui.json`）。
 
 ## 排障
 

--- a/docs/plugins/greeting/README.md
+++ b/docs/plugins/greeting/README.md
@@ -22,7 +22,7 @@
 
 ## 配置
 
-[`config.py`](../../../src/plugins/greeting/config.py)（如 `enable_kick_ban`）。素材目录 `data/.../greeting/`。
+[`config.py`](../../../src/plugins/greeting/config.py)（如 `enable_kick_ban`）。素材与持久化目录 **`data/greeting/`**；语音资源 **`resource/voices/`**。
 
 ## 排障
 

--- a/docs/plugins/pallas_protocol/README.md
+++ b/docs/plugins/pallas_protocol/README.md
@@ -1,10 +1,24 @@
 # pallas_protocol（协议端管理）
 
-多账号 NapCat/SnowLuma 协议端：创建、启停、日志与配置同步。
+多账号 **NapCat / SnowLuma** 协议端：创建牛牛、启停实例、日志与 OneBot 反向 WebSocket 配置同步。与 Web 控制台共用浏览器登录（口令在 `data/pallas_console/`）。
 
-## 用户命令
+## 入口
 
-无。入口：`/protocol/console`（`help_audience: maintainer`）。
+| 路径 | 说明 |
+| --- | --- |
+| `/protocol/console/` | 协议端管理页（维护者向，`help_audience: maintainer`） |
+| Web 控制台 | 侧边栏可跳转协议端；分片部署时协议端由 **hub** 托管 |
+
+无群内用户口令。
+
+## 典型流程
+
+1. 浏览器登录控制台或协议端页（首次启动口令见 Bot 日志）。
+2. **创建实例**：选择 NapCat 或 SnowLuma，填写 QQ 与反向 WS 地址（指向 Bot 的 `PORT` 或分片 **worker** 端口）。
+3. **启动 / 停止**：在实例列表操作；日志可在页内查看。
+4. **分片**：各牛牛账号的 `ws_url` 应指向所属 worker；`run_sharded_bot.sh start` 会同步注册表与协议端配置。
+
+Docker 下 NapCat 默认不在 Compose 网络内，反向 WS 主机勿盲目填 `pallasbot` 服务名；插件会按 `PALLAS_PROTOCOL_DOCKER_ONEBOT_HOST` 解析。详见 [Docker 部署](../DockerDeployment.md) 与 [FAQ](../FAQ.md#部署排障)。
 
 ## 命令权限
 
@@ -12,14 +26,26 @@
 
 ## 配置
 
-鉴权：`X-Pallas-Protocol-Token` 或 `?token=`。Docker、`runtime_profile` 等见原文档细节于 [`config`](../../../src/plugins/pallas_protocol/config.py)。
+常用项（完整见 [`config.py`](../../../src/plugins/pallas_protocol/config.py)，WebUI **插件 → pallas_protocol** 或 `data/pallas_config/webui.json`）：
+
+| 键 | 说明 |
+| --- | --- |
+| `pallas_protocol_enabled` | 是否加载协议端插件 |
+| `pallas_protocol_webui_enabled` | 是否挂载协议端 Web |
+| `pallas_protocol_instances_root` | 实例根目录，默认 `data/pallas_protocol/instances/` |
+| `pallas_protocol_program_dir` | NapCat 程序根目录（可配合自动下载） |
+| `pallas_protocol_docker_onebot_host` | Docker 下写入 OneBot 客户端的主机名/IP |
+
+API 鉴权：`X-Pallas-Protocol-Token` 或 `?token=`（与控制台会话体系配合）。
 
 ## 排障
 
 | 现象 | 处理 |
 | --- | --- |
-| 账号无法启动 | 查协议端日志与发行包版本 |
-| 与控制台登不上 | 共用 `data/pallas_console/` 口令 |
+| 账号无法启动 | 查实例日志、NapCat/SnowLuma 版本与 `program_dir` |
+| Bot 不回复 | 确认反向 WS 已连上对应 hub/worker 端口 |
+| 与控制台登不上 | 共用 `data/pallas_console/` 口令；遗忘见 [FAQ · 部署排障](../FAQ.md#部署排障) |
+| Docker WS 连不上 | 见 [FAQ · 协议端反向 WebSocket](../FAQ.md#q-协议端管理里反向-websocket-要不要写成主机为-pallasbot与-compose-的-pallasbot-是什么关系) |
 
 ## 实现
 

--- a/docs/plugins/repeater/README.md
+++ b/docs/plugins/repeater/README.md
@@ -20,7 +20,7 @@
 
 ## 配置
 
-见 [`config.py`](../../../src/plugins/repeater/config.py)（`answer_threshold`、`repeat_threshold`、`speak_threshold`、`enable_reaction` 等）。多牛同群接话 fanout：`fanout_enabled` / `fanout_max_bots`（或 `PALLAS_REPEATER_FANOUT_*`）；协调牛只查一次 context，其余牛从 `message_pool` 轻量随机。入库前清洗见 [message_scrub](../../common/message_scrub/README.md)。
+见 [`config.py`](../../../src/plugins/repeater/config.py)（`answer_threshold`、`repeat_threshold`、`speak_threshold`、`enable_reaction` 等）。多牛同群接话 fanout：`fanout_enabled` / `fanout_max_bots`；推荐 WebUI **插件 → repeater** 修改。协调牛只查一次 context，其余牛从 `message_pool` 轻量随机。入库前清洗见 [message_scrub](../../common/message_scrub/README.md)。
 
 ## 排障
 

--- a/docs/plugins/sing/README.md
+++ b/docs/plugins/sing/README.md
@@ -21,13 +21,13 @@ AI 翻唱、续唱、点歌与查歌名；依赖 [Pallas-Bot-AI](https://github.
 
 ## 配置
 
-[`config.py`](../../../src/plugins/sing/config.py)：`sing_enable`、AI 地址、`request_endpoint` 等。
+[`config.py`](../../../src/plugins/sing/config.py)：`sing_enable`、AI 地址、`request_endpoint` 等。推荐在 WebUI **插件 → sing** 或 **通用配置 → 服务网关** 修改（落盘 `data/pallas_config/webui.json`，保存后热重载）。
 
 ## 排障
 
 | 现象 | 处理 |
 | --- | --- |
-| 无语音 | 查 AI 服务、`/callback` 可达性 |
+| 无语音 | 查 AI 服务、`/callback` 可达性；群内发 **牛牛连通** 测唱歌网关 |
 | 点歌失败 | 确认网易云登录状态 |
 
 ## 实现

--- a/docs/plugins/take_name/README.md
+++ b/docs/plugins/take_name/README.md
@@ -15,7 +15,7 @@
 
 ## 配置
 
-[`config.py`](../../../src/plugins/take_name/config.py)。依赖 `repeater` 的 `MessageStore` 取随机语料。
+无独立 `config.py`。行为由 `repeater` 的 `MessageStore` 取随机语料，可在 WebUI **插件** 中开关本插件。
 
 ## 排障
 

--- a/tools/scripts/sync_docs_to_web.py
+++ b/tools/scripts/sync_docs_to_web.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""将主仓 docs/ 同步到 Pallas-Bot-Docs 的 VitePress src/。"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS = REPO_ROOT / "docs"
+
+# docs/ 相对路径 -> VitePress src/ 相对路径
+FILE_MAP: dict[str, str] = {
+    "Deployment.md": "deploy/deployment.md",
+    "DockerDeployment.md": "deploy/docker.md",
+    "Config.md": "deploy/config.md",
+    "FAQ.md": "deploy/faq.md",
+    "Migration-v3.md": "about/migration.md",
+    "architecture/project-structure.md": "architecture/project-structure.md",
+    "architecture/plugin-convention.md": "architecture/plugin-convention.md",
+    "architecture/settings-storage.md": "architecture/settings-storage.md",
+    "architecture/bot_process_sharding.md": "architecture/bot-process-sharding.md",
+    "architecture/site-customization-and-updates.md": "architecture/site-customization-and-updates.md",
+    "common/community_stats.md": "common/community_stats.md",
+    "common/cmd_perm/README.md": "common/cmd_perm.md",
+    "common/webui/README.md": "common/webui.md",
+    "common/message_scrub/README.md": "common/message_scrub.md",
+    "plugins/README.md": "plugins/index.md",
+}
+
+PLUGIN_NAMES = [
+    "blacklist",
+    "block",
+    "bot_status",
+    "callback",
+    "chat",
+    "connectivity",
+    "dream",
+    "drink",
+    "duel",
+    "greeting",
+    "help",
+    "maa",
+    "pallas_image",
+    "pallas_protocol",
+    "pallas_webui",
+    "relogin_bot",
+    "repeater",
+    "request_handler",
+    "roulette",
+    "sing",
+    "take_name",
+]
+
+for name in PLUGIN_NAMES:
+    FILE_MAP[f"plugins/{name}/README.md"] = f"plugins/{name}.md"
+
+GITHUB_SRC = "https://github.com/PallasBot/Pallas-Bot/tree/main/src/"
+
+
+def transform_for_vitepress(text: str) -> str:
+    """相对链接 -> VitePress 站内路径；源码路径 -> GitHub。"""
+    text = re.sub(
+        r"\]\(\.\./\.\./\.\./src/([^)#]+)\)",
+        rf"]({GITHUB_SRC}\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./src/([^)#]+)\)",
+        rf"]({GITHUB_SRC}\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./plugins/([a-z0-9_]+)/README\.md([^)]*)\)",
+        r"](/plugins/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./plugins/([a-z0-9_]+)/README\.md([^)]*)\)",
+        r"](/plugins/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(plugins/([a-z0-9_]+)/README\.md([^)]*)\)",
+        r"](/plugins/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./common/([a-z0-9_]+)/README\.md([^)]*)\)",
+        r"](/common/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./common/([a-z0-9_]+)/README\.md([^)]*)\)",
+        r"](/common/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(common/([a-z0-9_]+)/README\.md([^)]*)\)",
+        r"](/common/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./common/community_stats\.md([^)]*)\)",
+        r"](/common/community_stats\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(architecture/bot_process_sharding\.md([^)]*)\)",
+        r"](/architecture/bot-process-sharding\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(architecture/([a-z0-9_-]+)\.md([^)]*)\)",
+        r"](/architecture/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\./([a-z0-9_]+)/README\.md([^)]*)\)",
+        r"](/plugins/\1\2)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./FAQ\.md([^)]*)\)",
+        r"](/deploy/faq\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./DockerDeployment\.md([^)]*)\)",
+        r"](/deploy/docker\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./Deployment\.md([^)]*)\)",
+        r"](/deploy/deployment\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\./TEMPLATE\.md([^)]*)\)",
+        r"](https://github.com/PallasBot/Pallas-Bot/blob/main/docs/plugins/TEMPLATE.md\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\./VISUAL\.md([^)]*)\)",
+        r"](https://github.com/PallasBot/Pallas-Bot/blob/main/docs/plugins/help/VISUAL.md\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./FAQ\.md([^)]*)\)",
+        r"](/deploy/faq\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./pallas_protocol/README\.md([^)]*)\)",
+        r"](/plugins/pallas_protocol\1)",
+        text,
+    )
+    text = re.sub(r"\]\(Deployment\.md([^)]*)\)", r"](/deploy/deployment\1)", text)
+    text = re.sub(r"\]\(DockerDeployment\.md([^)]*)\)", r"](/deploy/docker\1)", text)
+    text = re.sub(r"\]\(Config\.md([^)]*)\)", r"](/deploy/config\1)", text)
+    text = re.sub(r"\]\(FAQ\.md([^)]*)\)", r"](/deploy/faq\1)", text)
+    text = re.sub(r"\]\(Migration-v3\.md([^)]*)\)", r"](/about/migration\1)", text)
+    text = re.sub(
+        r"\]\(\.\./README\.md([^)]*)\)",
+        r"](https://github.com/PallasBot/Pallas-Bot/blob/main/README.md\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(plugins/README\.md([^)]*)\)",
+        r"](/plugins/index\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./config/([^)#]+)\)",
+        rf"](https://github.com/PallasBot/Pallas-Bot/tree/main/config/\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./tools/([^)#]+)\)",
+        rf"](https://github.com/PallasBot/Pallas-Bot/tree/main/tools/\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./scripts/([^)#]+)\)",
+        rf"](https://github.com/PallasBot/Pallas-Bot/tree/main/scripts/\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./Dockerfile([^)]*)\)",
+        r"](https://github.com/PallasBot/Pallas-Bot/blob/main/Dockerfile\1)",
+        text,
+    )
+    text = re.sub(r"\]\(DockerDeployment\.md([^)]*)\)", r"](/deploy/docker\1)", text)
+    text = re.sub(r"\]\(FAQ\.md([^)]*)\)", r"](/deploy/faq\1)", text)
+    text = re.sub(r"\]\(Migration-v3\.md([^)]*)\)", r"](/about/migration\1)", text)
+    text = re.sub(
+        r"\]\(\.\./\.\./\.\./resource/([^)#]+)\)",
+        rf"]({GITHUB_SRC}../resource/\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./\.\./tools/([^)#]+)\)",
+        rf"](https://github.com/PallasBot/Pallas-Bot/tree/main/tools/\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./\.\./config/([^)#]+)\)",
+        rf"](https://github.com/PallasBot/Pallas-Bot/tree/main/config/\1)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./\.\./docker-compose\.yml\)",
+        r"](https://github.com/PallasBot/Pallas-Bot/blob/main/docker-compose.yml)",
+        text,
+    )
+    text = re.sub(
+        r"\]\(\.\./\.\./\.\./scripts/([^)#]+)\)",
+        rf"](https://github.com/PallasBot/Pallas-Bot/tree/main/scripts/\1)",
+        text,
+    )
+    # 去掉站内链接里的 .md 后缀
+    text = re.sub(
+        r"(\](/(?:deploy|plugins|architecture|common|about|guide)/[a-zA-Z0-9_./-]+)\.md)",
+        r"\1",
+        text,
+    )
+    return text
+
+
+def sync(dest_root: Path) -> int:
+    src_root = dest_root / "src"
+    count = 0
+    for rel_src, rel_dst in FILE_MAP.items():
+        source = DOCS / rel_src
+        if not source.is_file():
+            print(f"skip missing: {rel_src}")
+            continue
+        body = source.read_text(encoding="utf-8")
+        out = src_root / rel_dst
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(transform_for_vitepress(body), encoding="utf-8")
+        count += 1
+        print(f"sync {rel_src} -> src/{rel_dst}")
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sync docs/ to Pallas-Bot-Docs VitePress src/")
+    parser.add_argument(
+        "--dest",
+        type=Path,
+        default=REPO_ROOT.parent / "Pallas-Bot-Docs",
+        help="Pallas-Bot-Docs 仓库根目录",
+    )
+    args = parser.parse_args()
+    if not args.dest.is_dir():
+        raise SystemExit(f"dest not found: {args.dest}")
+    n = sync(args.dest)
+    print(f"done: {n} files")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- 更新 `docs/` 部署、配置、插件与架构说明，新增文档索引与 `Config.md`
- 新增 `tools/scripts/sync_docs_to_web.py`，用于同步到 [Pallas-Bot-Docs](https://github.com/PallasBot/Pallas-Bot-Docs) 文档站
- 精简根目录 README：快速开始 + 独立文档章节（徽章入口），部署细节统一指向在线文档

## Test plan

- [ ] 阅读 README 快速开始与文档章节链接
- [ ] 抽查 `docs/Deployment.md`、`docs/Config.md` 与线上一致性（合并后可运行 sync 脚本验证）