### PR TITLE
支持命令冷却全局配置

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@
 | [开发指南](develop/README.md) | 贡献者阅读顺序：环境、流程、插件与 WebUI |
 | [本地开发环境](develop/environment.md) | `uv`、配置、单进程 / 分片启动 |
 | [贡献与提交流程](develop/workflow.md) | Ruff、pre-commit、测试、PR 约定 |
+| [插件开发 Skill（Agent）](skills/pallas-plugin-development/SKILL.md) | 分章手册，写插件时按需加载 |
 
 ## 社区中心
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@
 | 文档 | 说明 |
 | --- | --- |
 | [命令权限 cmd_perm](common/cmd_perm/README.md) | 帮助菜单「何人可用」 |
+| [命令冷却 command_limits](common/command_limits/README.md) | 统一 CD helper |
 | [WebUI 配置热重载](common/webui/README.md) | `install_hot_reload_config` |
 | [WebUI API 契约](common/webui/api/README.md) | `/pallas/api` 分域说明 |
 | [消息审查 message_scrub](common/message_scrub/README.md) | 复读/做梦入站过滤 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@
 | --- | --- |
 | [命令权限 cmd_perm](common/cmd_perm/README.md) | 帮助菜单「何人可用」 |
 | [WebUI 配置热重载](common/webui/README.md) | `install_hot_reload_config` |
+| [WebUI API 契约](common/webui/api/README.md) | `/pallas/api` 分域说明 |
 | [消息审查 message_scrub](common/message_scrub/README.md) | 复读/做梦入站过滤 |
 | [在线统计与社区主站](common/community_stats.md) | 见上方 [社区中心](#社区中心)；上报与主站名册 |
 | [语料联邦](common/corpus/README.md) | 本机 + 社区共享接话池；WebUI 配置 |

--- a/docs/architecture/common-layers.md
+++ b/docs/architecture/common-layers.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | foundation | `src/foundation/` | `config`、`paths`、`logging`、`db`；`bot_version`、`command_prefix`、`apscheduler_runtime` |
 | platform | `src/platform/` | `shard`、`multi_bot`、`ingress`（**入站调度基础设施**）、`bot_runtime`（含 `ingress_dispatch_runtime`）、`coord`、`federate` |
-| features | `src/features/` | `cmd_perm`、`message_scrub`、`community_stats`、`corpus`、`control_plane`、`ban_gate` |
+| features | `src/features/` | `cmd_perm`、`command_limits`、`message_scrub`、`community_stats`、`corpus`、`control_plane`、`ban_gate` |
 | console | `src/console/` | `webui`、`web` |
 | domain | `src/domain/` | `arknights` 等域共享 |
 | shared | `src/shared/` | `utils`、`adapters`、`service_probe` |

--- a/docs/architecture/plugin-convention.md
+++ b/docs/architecture/plugin-convention.md
@@ -58,6 +58,7 @@
 
 - 需在 WebUI 保存 **`webui.json`** 后立即生效的插件配置：在 `config.py` 使用 `src.console.webui.install_hot_reload_config`（见 [WebUI 插件配置](../common/webui/README.md)）；已有自定义缓存的插件可登记到 `plugin_webui_registry`（如决斗插件）。
 - 可配置命令权限：在 `PluginMetadata.extra` 声明 `command_permissions`，matcher 使用 `src.features.cmd_perm.permission_for_command`（见 [cmd_perm](../common/cmd_perm/README.md)）。
+- 命令冷却：在 handler 内使用 `src.features.command_limits`（见 [command_limits](../common/command_limits/README.md)）；可在 `extra["command_limits"]` 声明默认 CD 供文档与后续扩展。
 
 ### 命令权限与帮助文案（cmd_perm）
 

--- a/docs/common/command_limits/README.md
+++ b/docs/common/command_limits/README.md
@@ -1,0 +1,53 @@
+# 命令冷却（command_limits）
+
+实现：`src/features/command_limits/`。
+
+在 `cmd_perm` 鉴权通过后，对高频命令做**群级 / 私聊级**冷却，避免各插件手写 `GroupConfig(..., cooldown=3)` 时 key 不一致。
+
+## metadata 声明（可选）
+
+在 `PluginMetadata.extra` 增加 `command_limits`（与 `command_permissions` 并列）：
+
+```python
+extra={
+    "command_permissions": [
+        {"id": "my_plugin.demo", "label": "牛牛示例", "default": "everyone"},
+    ],
+    "command_limits": [
+        {"id": "my_plugin.demo", "cd_sec": 10},
+    ],
+}
+```
+
+| 字段 | 说明 |
+| --- | --- |
+| `id` | 命令 ID，与 `command_permissions` / matcher 一致 |
+| `cd_sec` | 冷却秒数（也可用别名 `cd`） |
+| `scope` | `group` / `private` / `auto`（默认 `auto`，按事件类型选存储） |
+
+声明供文档与后续自动拦截扩展；handler 内仍建议显式调用 helper（见下）。
+
+## handler 内用法
+
+```python
+from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
+
+CD_SEC = 10
+
+@demo.handle()
+async def handle_demo(event: GroupMessageEvent):
+    if not await is_command_cooldown_ready(event, "my_plugin.demo", CD_SEC):
+        return
+    await refresh_command_cooldown(event, "my_plugin.demo", CD_SEC)
+    await demo.finish("收到。")
+```
+
+- 群消息：冷却按 **群** 维度（`GroupConfig`）
+- 私聊：按 **Bot + 用户** 维度（`BotConfig`）
+- 存储 key：`cmd_limit:{command_id}`，与插件自建 `cooldown` key 隔离
+
+## 与 cmd_perm 关系
+
+先 `permission_for_command`（或合并 helper）拦截无权用户，再在 handler 开头做 CD。冷却未完成时通常 **静默 return** 或发简短提示，按产品约定即可。
+
+插件开发 Skill：[Matcher 决策 · 冷却](../../skills/pallas-plugin-development/references/02-matchers-decision.md#26-冷却cd）。

--- a/docs/common/webui/README.md
+++ b/docs/common/webui/README.md
@@ -69,3 +69,7 @@ get_my_config = plugin_webui.get
 ## 实现
 
 [`src/console/webui/`](../../../src/console/webui/) · 路由薄层 [`extended_api.py`](../../../src/plugins/pallas_webui/extended_api.py)
+
+## API 契约（按域）
+
+REST 路径、鉴权、写操作与热重载行为见 [api/README.md](api/README.md)（与 WebUI `consoleApi.ts` / OpenAPI 对齐）。

--- a/docs/common/webui/api/01-auth-health.md
+++ b/docs/common/webui/api/01-auth-health.md
@@ -1,0 +1,40 @@
+# 认证与健康检查
+
+基址：`/pallas/api`（下文路径均相对此前缀）。
+
+## 公开 / 半公开
+
+| 方法 | 路径 | 鉴权 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/health` | 无 | Bot 与控制台版本、NoneBot 版本 |
+| POST | `/auth/login` | 无 | Body `{"password": "..."}` → 设置会话 Cookie |
+
+## 需 token / 会话
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/system` | CPU/内存/磁盘、运行时长等（短 TTL 缓存） |
+| GET | `/bots` | 已连接 Bot 实例列表（self_id、适配器、在线状态） |
+
+### `/health` 响应要点
+
+```json
+{
+  "ok": true,
+  "nonebot2": "2.x.x",
+  "pallas_bot": "x.y.z",
+  "console": { "version": "...", "build": "..." }
+}
+```
+
+### `/system` 响应
+
+`data` 为系统资源快照；首页轮询约 5s，服务端有约 0.8s 读缓存。
+
+## 前端对应
+
+- `fetchSystem()` → `/system`
+- `http.get("/health")`（健康探测）
+- 登录：`POST /auth/login`（`public.py` 表单登录走 `/pallas/login`）
+
+实现：`api.py`（health）、`extended_api.py`（system、bots）、`public.py`（login）。

--- a/docs/common/webui/api/02-plugins.md
+++ b/docs/common/webui/api/02-plugins.md
@@ -1,0 +1,58 @@
+# 插件与插件配置
+
+## 插件列表与治理
+
+| 方法 | 路径 | 写 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/plugins` | | 已加载插件 metadata 列表 |
+| GET | `/plugins/help-menu-visibility` | | 帮助图隐藏/忽略集合 |
+| PUT | `/plugins/help-menu-visibility` | 是 | 更新帮助可见性 |
+| GET | `/plugins/global-disable` | | 全局禁用插件名集合 |
+| PUT | `/plugins/global-disable` | 是 | 批量禁用/启用（保护核心插件） |
+| GET | `/plugins/group-fleet-whitelist` | | 群舰队白名单插件 |
+| PUT | `/plugins/group-fleet-whitelist` | 是 | 更新舰队白名单 |
+
+## 单插件配置（WebUI 插件页）
+
+| 方法 | 路径 | 写 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/plugins/{plugin_name}/config` | | 字段 schema + 当前值（无 config 时 `fields: []`） |
+| PUT | `/plugins/{plugin_name}/config` | 是 | Body `{"values": {"KEY": "value", ...}}` |
+| POST | `/plugins/{plugin_name}/config-check` | 是 | 连通性检测（当前主要为 `draw` 网关） |
+
+### GET config `data` 结构（要点）
+
+```json
+{
+  "plugin": "sing",
+  "module": "src.plugins.sing.config",
+  "fields": [
+    {
+      "key": "SING_ENABLE",
+      "value": "true",
+      "default": "true",
+      "type": "bool",
+      "title": "...",
+      "description": "..."
+    }
+  ]
+}
+```
+
+PUT 成功后：
+
+- 写入 `data/pallas_config/webui.json` 的 `env`（键为大写）
+- 已注册 `install_hot_reload_config` 的插件会 **立即 reload**，无需重启
+
+校验失败：400 + Pydantic 格式化 `detail`。
+
+## 前端对应
+
+- `fetchPlugins`、`fetchPluginConfig`、`putPluginConfig`
+- `fetchHelpMenuVisibility`、`putHelpMenuVisibility`
+- `fetchGlobalPluginDisable`、`putGlobalPluginDisable`
+- `fetchGroupFleetWhitelist`、`putGroupFleetWhitelist`
+
+实现：`extended_api.py`；配置读写 `src/console/webui/plugin_api.py`。
+
+插件作者接入： [WebUI 插件配置](../README.md)。

--- a/docs/common/webui/api/03-common-config.md
+++ b/docs/common/webui/api/03-common-config.md
@@ -1,0 +1,34 @@
+# 通用配置
+
+WebUI「通用配置」各段通过统一 REST 暴露；段定义在 `src/console/webui/env_sections.py`。
+
+| 方法 | 路径 | 写 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/common-config/sections` | | 段元数据列表（id、标题、说明） |
+| GET | `/common-config/{section_id}` | | 段内字段与当前值 |
+| PUT | `/common-config/{section_id}` | 是 | Body `{"values": {...}}` |
+| POST | `/common-config/service_gateways/connectivity-check` | 是 | 服务网关草稿连通性探测 |
+
+## 常见 `section_id`
+
+| ID | 用途 |
+| --- | --- |
+| `cmd_perm` | 命令权限覆盖矩阵 |
+| `control_plane` | 联邦控制 |
+| `corpus_federation` | 语料联邦 |
+| `community_stats` | 在线统计与社区主站 |
+| `ingress_fanout` | 入站全员同响口令 |
+| `ingress_dispatch` | 入站调度运行时 |
+| `repeater_learn` | 复读后台学习 |
+| `message_scrub` | 消息审查 |
+| `service_gateways` | 画画 / MAA / 点歌等网关 URL |
+| `pallas_webui` / `pallas_protocol` / `help` | 对应插件控制台子集 |
+
+PUT 落盘 `webui.json`；各段 `apply_webui_env_section_patch` 内触发对应 reload（如 cmd_perm 清缓存、message_scrub 热读）。
+
+## 前端对应
+
+- `fetchCommonConfigSections`、`fetchCommonConfigSection`、`putCommonConfigSection`
+- `postServiceGatewaysConnectivityCheck`
+
+实现：`extended_api.py` + `env_sections.py`；网关探测 `src/plugins/connectivity/`、`service_gateways_section.py`。

--- a/docs/common/webui/api/04-stats-dashboard.md
+++ b/docs/common/webui/api/04-stats-dashboard.md
@@ -1,0 +1,38 @@
+# 仪表盘与统计
+
+## 系统与分片
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/shard-registry` | 分片注册表、rebalance 提示 |
+| GET | `/shard-observability` | 分片 worker 观测聚合 |
+| GET | `/ingress-dispatch` | 中央入站调度指标（lane、matcher 预激活等） |
+
+## 消息与控制台统计
+
+| 方法 | 路径 | Query | 说明 |
+| --- | --- | --- | --- |
+| GET | `/message-stats` | `self_id?` | 收/发消息、API 调用历史等 |
+| GET | `/console-daily-stats` | | 控制台日统计（插件运行、matcher 等） |
+| GET | `/plugin-run-stats` | | Matcher 错误与运行统计（日志错误页） |
+| POST | `/log-errors/cleanup` | 是 | 清理已展示的错误日志缓冲 |
+
+## 社区与语料
+
+| 方法 | 路径 | Query | 说明 |
+| --- | --- | --- | --- |
+| GET | `/community-stats` | | 社区中心公开统计快照 |
+| GET | `/community-corpus-hot` | `period`, `tab`, `mode` | 社区语料热度 |
+| GET | `/local-corpus-hot` | 同上 | 本机语料热度 |
+| GET | `/corpus-status` | | 语料联邦状态 |
+| GET | `/federation-onboarding` | | 联邦接入引导信息 |
+
+## 前端对应
+
+- 首页：`fetchSystem`、`fetchMessageStats`、`fetchConsoleDailyStats`、`fetchShardObservability`、`fetchIngressDispatch`
+- 社区页：`fetchCommunityStats`、`fetchCommunityCorpusHot`、`fetchLocalCorpusHot`
+- 日志错误：`fetchPluginRunStats`、`postLogErrorsCleanup`
+
+实现：`extended_api.py`；社区 `src/features/community_stats/`、语料 `src/features/corpus/`、分片 `src/platform/shard/`。
+
+架构说明：[中央入站调度](../../../architecture/central-ingress-dispatch.md)、[多进程分片](../../../architecture/bot_process_sharding.md)。

--- a/docs/common/webui/api/05-social.md
+++ b/docs/common/webui/api/05-social.md
@@ -1,0 +1,22 @@
+# 好友、群与申请
+
+| 方法 | 路径 | Query | 写 | 说明 |
+| --- | --- | --- | --- | --- |
+| GET | `/friend-requests` | `self_id?` | | 待处理好友申请 |
+| GET | `/friend-list` | `self_id?` | | 好友列表 |
+| GET | `/group-list` | `self_id?` | | 群列表 |
+| GET | `/request-overview` | `self_id?` | | 申请概览（好友+群） |
+| POST | `/request-actions` | | 是 | 单条同意/拒绝 |
+| POST | `/request-actions/batch` | | 是 | 批量处理 |
+
+写操作 Body 含 `self_id`、`flag`、`approve` 等字段（与 OneBot v11 申请 API 对齐）；需写 token。
+
+数据来自在线 OneBot v11 Bot 调用 + 本地 pending 缓存（`request_handler` 落盘）。
+
+## 前端对应
+
+- `FriendsGroupsPage`：`fetchFriendList`、`fetchGroupList`、`fetchRequestOverview`、`postRequestActions` 等
+
+实现：`extended_api.py` 内 OneBot 代理与 pending 读写。
+
+用户向说明：[request_handler 插件](../../../plugins/request_handler/README.md)。

--- a/docs/common/webui/api/06-database.md
+++ b/docs/common/webui/api/06-database.md
@@ -1,0 +1,27 @@
+# 数据库
+
+| 方法 | 路径 | 写 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/db/overview` | | 表概览、行数、后端类型 |
+| GET | `/db/backup/info` | | 备份目录与策略信息 |
+| POST | `/db/backup` | 是 | 发起备份任务 |
+| GET | `/db/backup/jobs/active` | | 进行中任务 |
+| GET | `/db/backup/jobs/{job_id}` | | 单任务状态 |
+| GET | `/db/backup/runs` | | 历史备份记录 |
+| POST | `/db/backup/runs/delete` | 是 | 删除备份文件 |
+| POST | `/db/mongodb/aggregate` | 是 | Mongo 聚合查询（遗留后端） |
+| GET | `/db/table-row` | | 读 config 表行 |
+| PUT | `/db/table-row` | 是 | 更新 bot/group/user config 行 |
+| DELETE | `/db/table-row` | 是 | 删除行 |
+
+`table` 参数限定为 `bot_config` / `group_config` / `user_config`（与控制台数据库页一致）。
+
+备份为异步 job；大表读取有超时（WebUI 使用 `DB_HEAVY_READ_TIMEOUT_MS`）。
+
+## 前端对应
+
+- `DatabasePage`、`DatabaseBackupsPage`：`fetchDbOverview`、`postDbBackup` 等
+
+实现：`extended_api.py` + `src/foundation/db/`；备份脚本见 `tools/scripts/`。
+
+部署说明：[Docker 部署](../../../DockerDeployment.md) 卷挂载需包含 `data/`。

--- a/docs/common/webui/api/07-instances-configs.md
+++ b/docs/common/webui/api/07-instances-configs.md
@@ -1,0 +1,34 @@
+# 实例与账号配置
+
+## 实例 / 协议
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/instances` | Bot 进程、协议端快照（NapCat/Snowluma）、分片角色 |
+
+响应合并 `pallas_protocol` 状态与控制台元信息；WebUI 对 `/instances` 有 45s 内存缓存，写操作后应 `invalidateInstancesCache`。
+
+协议账号的启停/二维码等走 **协议子服务** HTTP（非本 API），见 WebUI `protocolApi.ts`。
+
+## Bot / 群 / 用户配置表
+
+| 方法 | 路径 | 写 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/bot-configs` | | 列表 |
+| GET | `/bot-configs/{account}` | | 单账号 |
+| PUT | `/bot-configs/{account}` | 是 | 更新 |
+| GET | `/group-configs` | `q?` 搜索 | 群列表（可分页） |
+| GET | `/group-configs/{group_id}` | | 单群 |
+| PUT | `/group-configs/{group_id}` | 是 | 更新 |
+| GET | `/user-configs` | `q?` | 用户列表 |
+| GET | `/user-configs/{user_id}` | | 单用户 |
+| PUT | `/user-configs/{user_id}` | 是 | 更新 |
+
+配置存数据库（PostgreSQL 或 Mongo，依 `pallas.toml` 后端）；与 `src.foundation.config` 的 `BotConfig` / `GroupConfig` 同源。
+
+## 前端对应
+
+- `InstancesPage`、`ProtocolManagePage`：`fetchInstances`
+- 社交配置弹窗：`fetchGroupConfigById`、`putGroupConfig`
+
+实现：`extended_api.py`；持久化 `src/foundation/db/`。

--- a/docs/common/webui/api/08-update-ai.md
+++ b/docs/common/webui/api/08-update-ai.md
@@ -1,0 +1,38 @@
+# 更新与 AI 扩展
+
+## WebUI / Bot 更新
+
+| 方法 | 路径 | 写 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/update/check` | | WebUI dist 发行版检查 |
+| POST | `/update/apply` | 是 | 拉取并应用 WebUI 更新 |
+| GET | `/update/bot/check` | | 主仓 Bot 版本检查 |
+| GET | `/update/bot/config-migration/check` | | 配置迁移检查 |
+| POST | `/update/bot/config-migration/apply` | 是 | 应用配置迁移 |
+| POST | `/update/bot/apply` | 是 | 拉取/应用 Bot 更新（git/部署逻辑） |
+
+写操作可能耗时较长；前端需处理进度与错误 `detail`。
+
+## AI 扩展（Pallas-Bot-AI）
+
+| 方法 | 路径 | 写 | 说明 |
+| --- | --- | --- | --- |
+| GET | `/ai-extension/config` | | 扩展配置 |
+| PUT | `/ai-extension/config` | 是 | 保存配置 |
+| POST | `/ai-extension/test` | 是 | 探测 AI 服务 |
+| GET | `/ai-extension/logs` | | 扩展日志 tail |
+| GET | `/ai-extension/ncm/status` | | 网易云登录状态 |
+| POST | `/ai-extension/ncm/send-sms` | 是 | 发送验证码 |
+| POST | `/ai-extension/ncm/verify-sms` | 是 | 验证登录 |
+| POST | `/ai-extension/ncm/logout` | 是 | 退出 NCM |
+
+配置落盘 `data/` 下 AI 扩展专用路径（见 `extended_api` 内 `_ai_extension_config_path`）。
+
+## 前端对应
+
+- `UpdatePage`：`fetchUpdateCheck`、`postUpdateApply`、`fetchBotUpdateCheck` 等
+- `AiExtensionPage`：`fetchAiExtensionConfig`、`putAiExtensionConfig` 等
+
+实现：`extended_api.py` + `pallas_webui/manager.py`（GitHub Release 拉取）。
+
+AI 仓库：[Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI)。

--- a/docs/common/webui/api/README.md
+++ b/docs/common/webui/api/README.md
@@ -1,0 +1,64 @@
+# Pallas WebUI API 契约
+
+控制台 JSON API 由主仓 `pallas_webui` 插件提供；前端 [Pallas-Bot-WebUI](https://github.com/PallasBot/Pallas-Bot-WebUI) 通过 Axios 调用。实现源码：
+
+- 路由注册：`src/plugins/pallas_webui/extended_api.py`（`register_extended_api`）
+- 轻量健康检查：`src/plugins/pallas_webui/api.py`
+- 登录与静态页：`src/plugins/pallas_webui/public.py`
+
+## 基址与格式
+
+| 项 | 值 |
+| --- | --- |
+| 默认控制台基址 | `/pallas/` |
+| API 前缀 | `/pallas/api`（与 `pallas.toml` / WebUI 配置中的 `base` 一致时为 `{base}/api`） |
+| 响应信封 | `{"ok": true, "data": ...}` 或 HTTP 4xx/5xx + `detail` |
+| 在线 Schema | Bot 运行时可访问 `/pallas/api/openapi.json`（FastAPI 自动生成，与本文互补） |
+
+前端类型定义见 WebUI 仓库 `src/api/pallasTypes.ts`；请求封装见 `src/api/consoleApi.ts`。
+
+## 鉴权
+
+| 方式 | 说明 |
+| --- | --- |
+| 浏览器会话 | 登录后 Cookie `pallas_console_session`（`POST /pallas/api/auth/login`） |
+| Header | `X-Pallas-Token: <token>`（与配置中的控制台 token 一致） |
+| Query | `?token=<token>`（部分写操作兼容） |
+
+- **读接口**：`router` 全局依赖 `_pallas_token_dep`（有效 token 或会话）
+- **写接口**（PUT/POST 改配置、备份、申请处理等）：额外 `_check_pallas_write_token`（写 token 可与读 token 相同，由 `pallas_webui` 配置决定）
+
+登录页：`GET/POST /pallas/login`（`public.py`，非 JSON API）。
+
+## 文档分域
+
+| 文档 | 对应 WebUI 页面 / 能力 |
+| --- | --- |
+| [认证与健康检查](01-auth-health.md) | 登录、health、system、bots |
+| [插件与插件配置](02-plugins.md) | 插件列表、单插件 config、帮助可见性、全局禁用、舰队白名单 |
+| [通用配置](03-common-config.md) | CommonConfig、cmd_perm、语料、网关探测 |
+| [仪表盘与统计](04-stats-dashboard.md) | 消息统计、社区、语料热度、分片、入站调度 |
+| [好友群与申请](05-social.md) | 好友/群列表、入群/好友申请 |
+| [数据库](06-database.md) | 概览、备份、表行编辑 |
+| [实例与账号配置](07-instances-configs.md) | instances、bot/group/user config |
+| [更新与 AI 扩展](08-update-ai.md) | WebUI/Bot 更新、AI 扩展、NCM |
+
+## 写操作与热重载
+
+| API 域 | 落盘 | 运行时生效 |
+| --- | --- | --- |
+| `PUT /plugins/{name}/config` | `webui.json` `env` | `install_hot_reload_config` 插件立即 reload |
+| `PUT /common-config/{section_id}` | `webui.json` | 段内字段按段逻辑 reload（cmd_perm、scrub 等） |
+| `PUT /bot-configs/{account}` 等 | 数据库 | 按各 repository 约定 |
+| 备份/更新 | 磁盘 / git | 可能需重启或异步任务 |
+
+插件作者接入新配置项：见 [WebUI 插件配置](../README.md) 与 [插件 Skill · WebUI 配置](../../skills/pallas-plugin-development/references/04-webui-config.md)。
+
+## 扩展新 API
+
+1. 在 `extended_api.py` 的 `register_extended_api` 内增加路由（`include_in_schema=True` 便于 OpenAPI）
+2. 写操作使用 `_check_pallas_write_token`
+3. 在本目录补充对应域文档或新增分域文件
+4. WebUI：在 `consoleApi.ts` + `pallasTypes.ts` 增加类型与请求函数
+
+协议端（NapCat/Snowluma）另有独立 HTTP API，由 `pallas_protocol` 挂载，不在 `/pallas/api` 下；见 [pallas_protocol 文档](../../../plugins/pallas_protocol/README.md)。

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -11,13 +11,14 @@
 | [插件开发入门](plugin/getting-started.md) | 新建插件、注册、最小示例 |
 | [插件结构与约定](plugin/structure.md) | 目录拆分、`data/` / `resource/`、文档与测试 |
 | [插件进阶能力](plugin/advanced.md) | cmd_perm、WebUI 热重载、消息审查、站点插件 |
+| [插件开发 Skill（Agent）](../skills/pallas-plugin-development/SKILL.md) | 分章手册，Cursor Agent 写插件时按需加载 |
 | [WebUI 前端开发](webui.md) | 独立仓库联调、窄屏与构建挂载 |
 
 ## 架构与通用能力（延伸阅读）
 
 | 文档 | 说明 |
 | --- | --- |
-| [项目结构](../architecture/project-structure.md) | 顶层目录与 `src/common` 分层 |
+| [项目结构](../architecture/project-structure.md) | 顶层目录与 `src/` 内核分层 |
 | [插件目录约定](../architecture/plugin-convention.md) | `src/plugins/*` 组织规范 |
 | [站点定制](../architecture/site-customization-and-updates.md) | `local/plugins`、更新策略 |
 | [命令权限 cmd_perm](../common/cmd_perm/README.md) | 帮助「何人可用」与 WebUI 覆盖 |

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -22,6 +22,7 @@
 | [插件目录约定](../architecture/plugin-convention.md) | `src/plugins/*` 组织规范 |
 | [站点定制](../architecture/site-customization-and-updates.md) | `local/plugins`、更新策略 |
 | [命令权限 cmd_perm](../common/cmd_perm/README.md) | 帮助「何人可用」与 WebUI 覆盖 |
+| [命令冷却 command_limits](../common/command_limits/README.md) | 统一 CD helper |
 | [WebUI 插件配置](../common/webui/README.md) | `install_hot_reload_config` |
 | [消息审查 message_scrub](../common/message_scrub/README.md) | 复读/做梦入站过滤 |
 

--- a/docs/develop/plugin/advanced.md
+++ b/docs/develop/plugin/advanced.md
@@ -1,6 +1,6 @@
 # 插件进阶能力
 
-在掌握 [入门](getting-started.md) 与 [结构约定](structure.md) 后，按需接入下列横切能力。
+在掌握 [入门](getting-started.md) 与 [结构约定](structure.md) 后，按需接入下列横切能力。分章说明见 [插件开发 Skill](../../skills/pallas-plugin-development/SKILL.md)。
 
 ## 命令权限（cmd_perm）
 
@@ -13,7 +13,7 @@
 3. 群消息 / 私聊限定使用合并 helper（**禁止** `Permission & Permission`）：
 
 ```python
-from src.common.cmd_perm import (
+from src.features.cmd_perm import (
     group_message_permission_for_command,
     private_message_permission_for_command,
 )
@@ -21,7 +21,13 @@ from src.common.cmd_perm import (
 on_command("群内", permission=group_message_permission_for_command("my_plugin.in_group"))
 ```
 
-4. 消息流中手动判断：`await satisfies_command_permission(bot, event, "my_plugin.action")`
+4. 消息流中手动判断：
+
+```python
+from src.features.cmd_perm import satisfies_command_permission
+
+await satisfies_command_permission(bot, event, "my_plugin.action")
+```
 
 ### 文案禁忌
 
@@ -36,7 +42,7 @@ on_command("群内", permission=group_message_permission_for_command("my_plugin.
 
 ```python
 from pydantic import BaseModel, Field
-from src.common.webui import install_hot_reload_config
+from src.console.webui import install_hot_reload_config
 
 class Config(BaseModel, extra="ignore"):
     threshold: int = Field(default=3, description="触发阈值。")
@@ -54,22 +60,23 @@ get_config = plugin_webui.get
 
 ## 消息审查（message_scrub）
 
-复读、做梦等插件的入站消息可先经统一审查过滤（广告、风控等）。插件侧按 [message_scrub](../../common/message_scrub/README.md) 注册 hook，避免在各插件重复实现。
+复读、做梦等插件的入站消息可先经统一审查过滤（广告、风控等）。插件侧按 [message_scrub](../../common/message_scrub/README.md) 登记 hook，避免在各插件重复实现。
 
-## 跨插件与 common
+## 跨插件与内核层
 
-可复用能力优先沉淀到 `src/common/`：
+可复用能力优先沉淀到 `src/` 内核层（见 [common-layers](../../architecture/common-layers.md)）：
 
-| 包 | 典型用途 |
-| --- | --- |
-| `src/common/config/` | 群/用户/Bot 级配置 |
-| `src/common/cmd_perm/` | 命令权限 |
-| `src/common/webui/` | 控制台配置热重载 |
-| `src/common/paths/` | `data/`、`resource/` 路径 |
-| `src/common/db/` | 数据库访问 |
-| `src/common/shard/` | 分片 presence、协调 |
+| 层 | 路径 | 典型用途 |
+| --- | --- | --- |
+| foundation | `src.foundation.config` | 群/用户/Bot 级配置、冷却 |
+| foundation | `src.foundation.paths` | `data/`、`resource/` 路径 |
+| foundation | `src.foundation.db` | 数据库 repository |
+| features | `src.features.cmd_perm` | 命令权限 |
+| features | `src.features.message_scrub` | 入站审查 |
+| console | `src.console.webui` | 控制台配置热重载 |
+| platform | `src.platform.shard` | 分片 presence、协调 |
 
-引入 common 时保持**语义单一**，避免把某一插件的业务泄漏到 common。
+引入内核层时保持**语义单一**，避免把某一插件的业务泄漏到 `src/features` 或 `src/foundation`。
 
 ## 站点自有插件与覆盖
 
@@ -85,9 +92,9 @@ get_config = plugin_webui.get
 
 - hub / worker 共用 `data/` 卷时，WebUI 配置与各插件 `data/<name>/` 一致
 - worker 侧 `get_*_config()` 可按磁盘 mtime 拾取新配置
-- 涉及 Bot 连接、presence 时使用 `src/common/shard/` 提供的 API，勿假设单进程内存全局状态
+- 涉及 Bot 连接、presence 时使用 `src.platform.shard` 提供的 API，勿假设单进程内存全局状态
 
-见 [多进程分片](../../architecture/bot_process_sharding.md)
+见 [多进程分片](../../architecture/bot_process_sharding.md)、[中央入站调度](../../architecture/central-ingress-dispatch.md)
 
 ## 日志
 
@@ -100,7 +107,7 @@ logger.info(f"bot [{bot_id}] action in group [{group_id}]")
 ## AI 与外部服务
 
 - 对话 / 唱歌 / TTS 等扩展见 [Pallas-Bot-AI](https://github.com/PallasBot/Pallas-Bot-AI) 与文档站「AI 扩展」
-- 画画、MAA 等网关字段见 WebUI「服务网关」与 `src/common/webui/service_gateways_section.py`
+- 画画、MAA 等网关字段见 WebUI「服务网关」与 `src/console/webui/service_gateways_section.py`
 
 ## 测试与排障
 
@@ -112,4 +119,5 @@ logger.info(f"bot [{bot_id}] action in group [{group_id}]")
 
 - [插件开发入门](getting-started.md)
 - [插件结构与约定](structure.md)
+- [插件开发 Skill](../../skills/pallas-plugin-development/SKILL.md)
 - [贡献与提交流程](../workflow.md)

--- a/docs/develop/plugin/advanced.md
+++ b/docs/develop/plugin/advanced.md
@@ -36,6 +36,20 @@ await satisfies_command_permission(bot, event, "my_plugin.action")
 
 完整字段与自检清单：[cmd_perm 接入说明](../../common/cmd_perm/README.md)
 
+## 命令冷却（command_limits）
+
+高频命令在 `cmd_perm` 通过后，用统一 helper 做群级 / 私聊级 CD，存储 key 为 `cmd_limit:{command_id}`：
+
+```python
+from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
+
+if not await is_command_cooldown_ready(event, "my_plugin.demo", 10):
+    return
+await refresh_command_cooldown(event, "my_plugin.demo", 10)
+```
+
+可在 `PluginMetadata.extra["command_limits"]` 声明默认 CD（与 `command_permissions` 并列）。详见 [command_limits](../../common/command_limits/README.md)。
+
 ## WebUI 配置热重载
 
 控制台通过 `data/pallas_config/webui.json` 统一读写插件配置。
@@ -72,6 +86,7 @@ get_config = plugin_webui.get
 | foundation | `src.foundation.paths` | `data/`、`resource/` 路径 |
 | foundation | `src.foundation.db` | 数据库 repository |
 | features | `src.features.cmd_perm` | 命令权限 |
+| features | `src.features.command_limits` | 命令冷却 |
 | features | `src.features.message_scrub` | 入站审查 |
 | console | `src.console.webui` | 控制台配置热重载 |
 | platform | `src.platform.shard` | 分片 presence、协调 |

--- a/docs/develop/plugin/getting-started.md
+++ b/docs/develop/plugin/getting-started.md
@@ -23,19 +23,19 @@ src/plugins/my_plugin/
 
 ### 元数据与帮助文案
 
-使用 `src.common.cmd_perm.metadata_text` 统一 `usage` / `menu_data` 格式：
+使用 `src.features.cmd_perm.metadata_text` 统一 `usage` / `menu_data` 格式：
 
 ```python
 from nonebot import on_command
 from nonebot.plugin import PluginMetadata
 
-from src.common.cmd_perm import group_message_permission_for_command
-from src.common.cmd_perm.metadata_defaults import (
+from src.features.cmd_perm import group_message_permission_for_command
+from src.features.cmd_perm.metadata_defaults import (
     PLUGIN_EXTRA_VERSION,
     PLUGIN_HOMEPAGE,
     PLUGIN_MENU_TEMPLATE,
 )
-from src.common.cmd_perm.metadata_text import SCENE_GROUP, join_usage, usage_line
+from src.features.cmd_perm.metadata_text import SCENE_GROUP, join_usage, usage_line
 
 __plugin_meta__ = PluginMetadata(
     name="示例插件",
@@ -92,7 +92,7 @@ async def handle_demo():
 # config.py
 from pydantic import BaseModel, Field
 
-from src.common.webui import install_hot_reload_config
+from src.console.webui import install_hot_reload_config
 
 class Config(BaseModel, extra="ignore"):
     enable: bool = Field(default=True, description="是否启用。")
@@ -123,9 +123,10 @@ uv run pytest tests/plugins/my_plugin/
 
 - 目录拆分与路径约定：[插件结构与约定](structure.md)
 - cmd_perm、热重载、消息审查、跨插件能力：[插件进阶能力](advanced.md)
+- Agent 分章手册：[插件开发 Skill](../../skills/pallas-plugin-development/SKILL.md)
 - 规范总览：[插件目录约定](../../architecture/plugin-convention.md)
 
-## 外部参考
+## 延伸阅读
 
-- [NoneBot2 文档](https://nonebot.dev/)
-- [OneBot v11](https://github.com/botuniverse/onebot-11)
+- [NoneBot2 文档](https://nonebot.dev/)（Matcher 与事件模型）
+- [OneBot v11](https://github.com/botuniverse/onebot-11)（协议字段）

--- a/docs/develop/plugin/structure.md
+++ b/docs/develop/plugin/structure.md
@@ -27,7 +27,7 @@ my_plugin/
 1. `__init__.py` 避免堆积大段实现
 2. 配置与默认值集中在 `config.py`
 3. 单文件过长时按职责拆分，避免「超大单文件」
-4. 插件内私有逻辑放插件目录；**跨插件复用**再提取到 `src/common/`
+4. 插件内私有逻辑放插件目录；**跨插件复用**再提取到 `src/foundation`、`src/features` 等内核层
 
 ## 路径与持久化
 
@@ -36,7 +36,7 @@ my_plugin/
 | 运行期数据 | `data/<plugin_name>/...` | `plugin_data_dir("my_plugin")` |
 | 静态资源 | `resource/...` | `resource_dir("subdir")` |
 
-使用 `src/common/paths/` 提供的 helper，**不要**硬编码相对路径字符串。
+使用 `src.foundation.paths` 提供的 helper，**不要**硬编码相对路径字符串。
 
 示例（仓库内）：
 
@@ -76,4 +76,4 @@ my_plugin/
 
 ## 下一步
 
-[插件进阶能力](advanced.md) · [插件开发入门](getting-started.md)
+[插件进阶能力](advanced.md) · [插件开发入门](getting-started.md) · [插件开发 Skill](../../skills/pallas-plugin-development/SKILL.md)

--- a/docs/develop/webui.md
+++ b/docs/develop/webui.md
@@ -2,7 +2,7 @@
 
 控制台 UI 由独立仓库 **[Pallas-Bot-WebUI](https://github.com/PallasBot/Pallas-Bot-WebUI)** 构建，产物由主仓 `pallas_webui` 插件挂载，基址 **`/pallas/`**。
 
-后端 API 实现在主仓 `src/plugins/pallas_webui/`（如 `extended_api.py`）；**插件配置热重载**等通用能力在 `src/common/webui/`，一般无需改 API 层即可接入新插件配置（见 [WebUI 插件配置](../common/webui/README.md)）。
+后端 API 实现在主仓 `src/plugins/pallas_webui/`（如 `extended_api.py`）；**插件配置热重载**等通用能力在 `src/console/webui/`，一般无需改 API 层即可接入新插件配置（见 [WebUI 插件配置](../common/webui/README.md)）。
 
 ## 本地联调
 

--- a/docs/skills/pallas-plugin-development/SKILL.md
+++ b/docs/skills/pallas-plugin-development/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: pallas-plugin-development
+description: >
+  当用户要求「写 Pallas 插件」「给插件加命令」「cmd_perm 怎么接」「WebUI 热重载配置」
+  「on_command 还是 on_message」「local/plugins 怎么覆盖」「帮助图 menu_data 怎么写」
+  「message_scrub 要不要接」「插件放哪、路径 helper 用什么」时，优先读取本 SKILL。
+  面向 Pallas-Bot 主仓与 local/plugins 站点插件开发；Agent 应按章节按需加载 references，勿一次性读完全部。
+---
+
+# Pallas 插件开发指南（Agent 入口）
+
+> 本 Skill **描述 Pallas-Bot 仓库约定**（内核分层、cmd_perm、WebUI、多牛分片等）
+> 章节拆在 `references/`；需要某专题时再读对应文件，**不要**把全部 references 塞进上下文。
+> 人类贡献者也可从 [develop/plugin/getting-started.md](../../develop/plugin/getting-started.md) 入门。
+
+## 章节索引
+
+| 章节 | 主题 | 文件 |
+| --- | --- | --- |
+| 一 | 插件基础（目录、入口、公开 API、主仓 vs local） | [references/01-plugin-basics.md](./references/01-plugin-basics.md) |
+| 二 | Matcher 决策树（on_command / on_message / 事件） | [references/02-matchers-decision.md](./references/02-matchers-decision.md) |
+| 三 | cmd_perm 与帮助文案 | [references/03-cmd-perm-and-help.md](./references/03-cmd-perm-and-help.md) |
+| 四 | WebUI 配置热重载 | [references/04-webui-config.md](./references/04-webui-config.md) |
+| 五 | 路径、数据与资源 | [references/05-paths-and-data.md](./references/05-paths-and-data.md) |
+| 六 | message_scrub 入站过滤 | [references/06-message-scrub.md](./references/06-message-scrub.md) |
+| 七 | 测试与文档自检 | [references/07-tests-and-docs.md](./references/07-tests-and-docs.md) |
+| 八 | 完整示例插件 checklist | [references/08-golden-plugin-checklist.md](./references/08-golden-plugin-checklist.md) |
+
+## 推荐流程
+
+1. **新建插件** → [一、插件基础](./references/01-plugin-basics.md)
+2. **选触发方式** → [二、Matcher 决策树](./references/02-matchers-decision.md)
+3. **命令权限与帮助** → [三、cmd_perm](./references/03-cmd-perm-and-help.md)
+4. **控制台可改配置** → [四、WebUI 热重载](./references/04-webui-config.md)
+5. **复读/做梦类入站** → [六、message_scrub](./references/06-message-scrub.md)
+6. **提交前** → [八、checklist](./references/08-golden-plugin-checklist.md)
+
+## 关键概念速记
+
+- **技术栈**：NoneBot2 + OneBot v11；配置 `pallas.toml` + `webui.json`；控制台为 Pallas WebUI（`/pallas/`）。
+- **插件位置**：上游 `src/plugins/<name>/`；站点定制 `local/plugins/<name>/`（同名时 **local 优先**，需 `extra_plugin_dirs` + 重启）。
+- **多牛舰队**（进阶）：入站调度、进程分片见 [central-ingress-dispatch](../../architecture/central-ingress-dispatch.md)、[bot_process_sharding](../../architecture/bot_process_sharding.md)。
+- **导入分层**：业务插件优先 `src.features.*`、`src.foundation.*`、`src.console.webui`；跨插件能力不要深层 import 内核内部文件。见 [一、公开 API](./references/01-plugin-basics.md#公开-api允许-import)。
+- **命令 ID**：`{插件}.{动作}` 须在 metadata、`permission_for_command`、matcher 中**完全一致**。
+- **帮助文案**：`usage` 不写死权限；`trigger_condition` 只写怎么说；权限绑 `command_permission` + WebUI 矩阵。
+- **配置读取**：WebUI 可调项用 `get_config()` / `get_my_config()`，**勿**在模块顶层缓存配置快照。
+- **日志**：loguru 风格，占位用 `{}` 或 f-string，避免 `"%s"` 传统 logging 写法。
+
+## 权威文档（仓库内）
+
+| 文档 | 用途 |
+| --- | --- |
+| [plugin/getting-started.md](../../develop/plugin/getting-started.md) | 人类向最小示例 |
+| [plugin/structure.md](../../develop/plugin/structure.md) | 目录拆分 |
+| [plugin/advanced.md](../../develop/plugin/advanced.md) | 进阶横切能力 |
+| [cmd_perm/README.md](../../common/cmd_perm/README.md) | 权限与 menu 细则 |
+| [webui/README.md](../../common/webui/README.md) | 热重载配置 |
+| [plugin-convention.md](../../architecture/plugin-convention.md) | 插件目录约定 |
+| [AGENTS.md](../../../AGENTS.md) | Agent / CI 协作约定 |

--- a/docs/skills/pallas-plugin-development/references/01-plugin-basics.md
+++ b/docs/skills/pallas-plugin-development/references/01-plugin-basics.md
@@ -1,0 +1,141 @@
+# 一、插件基础结构
+
+Pallas 插件运行在 **NoneBot2** 之上，业务代码落在 `src/plugins/` 或站点 `local/plugins/`；横切能力由 `src/features`、`src/console` 等内核层提供（见 [common-layers](../../architecture/common-layers.md)）。
+
+## 1.1 两种参与方式
+
+| 方式 | 目录 | 适用 |
+| --- | --- | --- |
+| **贡献主仓** | `src/plugins/<name>/` | 可上游合并的功能 |
+| **站点自有** | `local/plugins/<name>/` | 私有定制、避免与主仓 diff 混杂 |
+
+站点插件需在 `config/pallas.toml` 配置 `extra_plugin_dirs`（指向 `local/plugins` 等），**重启后**加载。与主仓同名包时 **local 覆盖**主仓实现。
+
+详见 [站点定制与更新](../../architecture/site-customization-and-updates.md)。
+
+## 1.2 最小目录
+
+```
+my_plugin/
+├── __init__.py    # PluginMetadata + Matcher 注册（保持轻量）
+└── config.py      # 配置模型；需 WebUI 可调时接热重载
+```
+
+按需扩展：`handlers.py`、`models.py`、`services/`、`renderer.py` 等语义化模块。原则见 [plugin/structure.md](../../develop/plugin/structure.md)。
+
+## 1.3 入口 `__init__.py` 职责
+
+1. 定义 `__plugin_meta__`（`PluginMetadata`）
+2. 创建 Matcher（`on_command` / `on_message` 等）
+3. 注册 handler；复杂逻辑放到同目录其它模块
+
+**不要**在 `__init__.py` 堆数百行业务实现。
+
+## 1.4 命名
+
+- 包名：小写 + 下划线，与目录名一致（`my_plugin`）
+- 命令 ID：`my_plugin.action`（插件名 + 动作）
+- 新增函数：非必要不要 `_` 前缀
+
+## 1.5 公开 API（允许 import）
+
+插件应优先从下列包导入；避免 `import` 内核深层私有模块。
+
+| 层 | 路径 | 典型用途 |
+| --- | --- | --- |
+| features | `src.features.cmd_perm` | 命令权限、帮助 metadata 工具 |
+| features | `src.features.message_scrub` | 复读/做梦等入站过滤登记 |
+| features | `src.features.community_stats` | 在线统计（按需） |
+| features | `src.features.corpus` | 语料联邦（按需） |
+| console | `src.console.webui` | `install_hot_reload_config` |
+| foundation | `src.foundation.paths` | `plugin_data_dir`、`resource_dir` |
+| foundation | `src.foundation.config` | `BotConfig` / `GroupConfig`（群级冷却等） |
+| foundation | `src.foundation.db` | 持久化 repository（按需） |
+| shared | `src.shared.utils` | 通用工具（按需） |
+
+内核分层说明：[common-layers.md](../../architecture/common-layers.md)。
+
+**反例**：从 `src.plugins.other_plugin` 直接 import 业务逻辑 → 应把共享能力下沉到 `src/features` 或 `src/foundation`。
+
+## 1.6 最小元数据骨架
+
+```python
+from nonebot import on_command
+from nonebot.plugin import PluginMetadata
+
+from src.features.cmd_perm import group_message_permission_for_command
+from src.features.cmd_perm.metadata_defaults import (
+    PLUGIN_EXTRA_VERSION,
+    PLUGIN_HOMEPAGE,
+    PLUGIN_MENU_TEMPLATE,
+)
+from src.features.cmd_perm.metadata_text import SCENE_GROUP, join_usage, usage_line
+
+__plugin_meta__ = PluginMetadata(
+    name="示例插件",
+    description="一句话说明插件做什么。",
+    usage=join_usage(usage_line("牛牛示例", "触发示例命令")),
+    type="application",
+    homepage=PLUGIN_HOMEPAGE,
+    supported_adapters={"~onebot.v11"},
+    extra={
+        "version": PLUGIN_EXTRA_VERSION,
+        "menu_template": PLUGIN_MENU_TEMPLATE,
+        "command_permissions": [
+            {"id": "my_plugin.demo", "label": "牛牛示例", "default": "everyone"},
+        ],
+        "menu_data": [
+            {
+                "func": "牛牛示例",
+                "trigger_method": "on_command",
+                "trigger_scene": SCENE_GROUP,
+                "trigger_condition": "牛牛示例",
+                "command_permission": "my_plugin.demo",
+                "brief_des": "执行示例",
+                "detail_des": "返回一条确认消息。",
+            },
+        ],
+    },
+)
+
+demo = on_command(
+    "牛牛示例",
+    aliases={"示例"},
+    priority=5,
+    block=True,
+    permission=group_message_permission_for_command("my_plugin.demo"),
+)
+
+
+@demo.handle()
+async def handle_demo():
+    await demo.finish("收到。")
+```
+
+完整拷贝版见 [getting-started.md](../../develop/plugin/getting-started.md)。
+
+## 1.7 配置入口（可选）
+
+```python
+from pydantic import BaseModel, Field
+from src.console.webui import install_hot_reload_config
+
+class Config(BaseModel, extra="ignore"):
+    enable: bool = Field(default=True, description="是否启用。")
+
+plugin_webui = install_hot_reload_config(Config, config_module=__name__)
+get_config = plugin_webui.get
+```
+
+业务代码始终 `get_config()`；详情见 [四、WebUI 配置](./04-webui-config.md) 与 [webui/README.md](../../common/webui/README.md)。
+
+## 1.8 加载与发现
+
+- 主仓 `src/plugins/`：随 Bot 启动自动发现
+- `local/plugins/`：`config/pallas.toml` 的 `extra_plugin_dirs` + **重启**
+- 额外 pip 包：按 `pyproject.toml` 与 NoneBot 插件机制安装，与主仓插件并列加载
+
+## 1.9 下一步
+
+- 选 Matcher → [二、Matcher 决策树](./02-matchers-decision.md)
+- 权限与帮助 → [三、cmd_perm](./03-cmd-perm-and-help.md)

--- a/docs/skills/pallas-plugin-development/references/01-plugin-basics.md
+++ b/docs/skills/pallas-plugin-development/references/01-plugin-basics.md
@@ -46,7 +46,7 @@ my_plugin/
 | features | `src.features.cmd_perm` | 命令权限、帮助 metadata 工具 |
 | features | `src.features.message_scrub` | 复读/做梦等入站过滤登记 |
 | features | `src.features.community_stats` | 在线统计（按需） |
-| features | `src.features.corpus` | 语料联邦（按需） |
+| features | `src.features.command_limits` | 命令 CD（`cmd_limit:{id}`） |
 | console | `src.console.webui` | `install_hot_reload_config` |
 | foundation | `src.foundation.paths` | `plugin_data_dir`、`resource_dir` |
 | foundation | `src.foundation.config` | `BotConfig` / `GroupConfig`（群级冷却等） |

--- a/docs/skills/pallas-plugin-development/references/02-matchers-decision.md
+++ b/docs/skills/pallas-plugin-development/references/02-matchers-decision.md
@@ -76,18 +76,32 @@ chat = on_message(rule=to_me(), priority=99, block=False)
 
 ## 2.6 冷却（CD）
 
-Pallas 在 `src.foundation.config` 提供 **`GroupConfig` / `BotConfig` 冷却**，在 handler 内显式检查：
+Pallas 提供 **`src.features.command_limits`**，在 `GroupConfig` / `BotConfig` 之上统一冷却 key（`cmd_limit:{command_id}`）。
+
+### metadata 声明（推荐）
 
 ```python
-from src.foundation.config import GroupConfig
-
-config = GroupConfig(group_id=event.group_id, cooldown=10)
-if not await config.is_cooldown("my_action"):
-    return
-await config.refresh_cooldown("my_action")
+extra={
+    "command_limits": [
+        {"id": "my_plugin.demo", "cd_sec": 10},
+    ],
+}
 ```
 
-仓库内示例：`chat`、`drink`、`bot_status`、`greeting`。`action_type` 建议用插件内语义化 key，避免与其它插件冲突。
+### handler 内检查
+
+```python
+from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
+
+if not await is_command_cooldown_ready(event, "my_plugin.demo", 10):
+    return
+await refresh_command_cooldown(event, "my_plugin.demo", 10)
+```
+
+- 群消息：按群冷却（`GroupConfig`）
+- 私聊：按 Bot + 用户（`BotConfig`）
+
+详见 [command_limits 说明](../../common/command_limits/README.md)。历史插件仍可直接用 `GroupConfig.is_cooldown`；新插件优先用上述 helper 保持 key 一致。
 
 ## 2.7 分片与多牛（进阶）
 

--- a/docs/skills/pallas-plugin-development/references/02-matchers-decision.md
+++ b/docs/skills/pallas-plugin-development/references/02-matchers-decision.md
@@ -1,0 +1,113 @@
+# 二、Matcher 决策树
+
+Pallas 插件在 `__init__.py` 用 **NoneBot2 Matcher**（`on_command` / `on_message` 等）注册 handler。先选对触发方式，再接 `cmd_perm` 与（按需）`message_scrub`。
+
+## 2.1 决策流程
+
+```
+需要用户明确说一条口令？
+├─ 是 → 群专属还是私聊也可？
+│   ├─ 仅群 → on_command + group_message_permission_for_command
+│   ├─ 仅私聊 → on_command + private_message_permission_for_command
+│   └─ 两者 → 两个 matcher 或 permission_for_command + 事件类型判断
+├─ 否 → 是否监听每条群消息 / 被动接话？
+│   ├─ 是（复读、接话、关键词）→ on_message（常 block=False）+ 考虑 message_scrub
+│   ├─ 是（进群/退群/撤回等通知）→ on_notice
+│   └─ 是（好友/入群申请）→ on_request（参考 request_handler）
+└─ 定时 / 启动逻辑 → APScheduler 或 driver.on_startup（见 foundation apscheduler_runtime）
+```
+
+## 2.2 触发方式对照
+
+| Matcher | 典型场景 | 仓库示例 | cmd_perm |
+| --- | --- | --- | --- |
+| `on_command` | 用户主动口令、帮助、管理命令 | `greeting`、`help`、`duel` | **推荐**：matcher `permission=` |
+| `on_message` | 被动接话、关键词、无固定前缀 | `repeater`、`chat`、`dream` | 多在 handler 内判断或无需 |
+| `on_notice` | 群通知（撤回、成员变动） | `repeater`（撤回联动） | 通常不需要命令 ID |
+| `on_request` | 加群/好友申请 | `request_handler` | 按业务 |
+| `on_metaevent` / 适配器事件 | 戳一戳、特殊 meta | `greeting`（poke） | 按业务 |
+
+## 2.3 `on_command` 要点
+
+```python
+from nonebot import on_command
+from src.features.cmd_perm import group_message_permission_for_command
+
+cmd = on_command(
+    "帮助",
+    aliases={"help"},
+    priority=5,
+    block=True,  # 处理成功后阻断后续 matcher
+    permission=group_message_permission_for_command("help.help"),
+)
+```
+
+- **`priority`**：数字越小越先匹配；被动插件常用较高数字（如 99）避免抢命令。
+- **`block=True`**：命令型功能默认 `True`；被动监听常用 `False`。
+- **aliases**：与主命令共享同一 matcher 与权限 ID。
+
+## 2.4 `on_message` 要点
+
+用于**无固定口令**或**每条消息都要看**的逻辑：
+
+```python
+from nonebot import on_message
+from nonebot.rule import to_me
+
+chat = on_message(rule=to_me(), priority=99, block=False)
+```
+
+仓库内惯例：
+
+- **复读 `repeater`**：`on_message` + 学习/回复 gate；部分 matcher `block=False` 避免挡住其它插件。
+- **做梦 `dream`**：入站先经 `message_scrub`；长文本生成类。
+- **聊天 `chat`**：关键词 + 冷却（`GroupConfig.is_cooldown`）。
+
+**慎用**：`on_message` 无过滤时会增加每条消息的 CPU；应用 `rule`（`to_me`、自定义 rule）收窄范围。
+
+## 2.5 入站审查（message_scrub）
+
+复读、做梦等插件在消费用户文本前，应登记 [message_scrub](../../common/message_scrub/README.md) hook，统一过滤广告/风控，而不是每个插件各自写正则。
+
+决策：
+
+- 插件会**大量读用户原文**并学习/生成 → **应接** message_scrub
+- 纯 `on_command` 且只解析命令参数 → 通常不必
+
+## 2.6 冷却（CD）
+
+Pallas 在 `src.foundation.config` 提供 **`GroupConfig` / `BotConfig` 冷却**，在 handler 内显式检查：
+
+```python
+from src.foundation.config import GroupConfig
+
+config = GroupConfig(group_id=event.group_id, cooldown=10)
+if not await config.is_cooldown("my_action"):
+    return
+await config.refresh_cooldown("my_action")
+```
+
+仓库内示例：`chat`、`drink`、`bot_status`、`greeting`。`action_type` 建议用插件内语义化 key，避免与其它插件冲突。
+
+## 2.7 分片与多牛（进阶）
+
+多进程分片或中央入站调度下，部分插件需声明 shard 行为或走 ingress gate。涉及：
+
+- `ingress_gate` 插件
+- `docs/architecture/central-ingress-dispatch.md`
+- `docs/architecture/bot_process_sharding.md`
+
+**默认新插件**按单 matcher 编写即可；只有「全群消息洪峰」「多牛同群」类功能才需提前读上述文档。
+
+## 2.8 自检
+
+- [ ] 能用 `on_command` 的口令型功能没有用宽泛 `on_message`
+- [ ] `on_message` 已设合理 `priority` / `block` / `rule`
+- [ ] 命令型已绑 `command_permissions` 与 matcher `permission`
+- [ ] 被动文本类已评估 message_scrub
+- [ ] 高频路径避免同步阻塞与巨型 handler
+
+## 2.9 下一步
+
+- 权限与帮助文案 → [三、cmd_perm](./03-cmd-perm-and-help.md)
+- WebUI 配置 → [四、WebUI 配置](./04-webui-config.md)

--- a/docs/skills/pallas-plugin-development/references/03-cmd-perm-and-help.md
+++ b/docs/skills/pallas-plugin-development/references/03-cmd-perm-and-help.md
@@ -1,0 +1,140 @@
+# 三、cmd_perm 与帮助文案
+
+实现包：`src/features/cmd_perm/`。人类向细则：[cmd_perm/README.md](../../common/cmd_perm/README.md)。
+
+## 3.1 命令 ID 规则
+
+- 格式：`{插件包名}.{动作}`，例如 `duel.start`、`help.help`
+- **同一 ID** 必须出现在：
+  - `extra["command_permissions"]`
+  - matcher 的 `permission_for_command(...)` 或合并 helper
+  - `menu_data` 的 `command_permission` / `command_permissions`
+- WebUI「命令权限」矩阵与帮助图「何人可用」都依赖这套 ID
+
+## 3.2 默认等级
+
+在 `PluginMetadata.extra` 声明：
+
+```python
+"command_permissions": [
+    {"id": "my_plugin.demo", "label": "牛牛示例", "default": "everyone"},
+    {"id": "my_plugin.admin", "label": "管理操作", "default": "group_moderator"},
+],
+```
+
+| `default` 值 | 含义 |
+| --- | --- |
+| `everyone` | 不额外限制（仍受群/私聊场景约束） |
+| `bot_moderator` | 号主 |
+| `group_moderator` | 群管/群主 |
+| `staff` | 群管或号主 |
+| `superuser` | 超管 |
+
+运行中可由 WebUI 覆盖（`webui.json` → `PALLAS_COMMAND_PERMISSION_OVERRIDES`），**通常无需重启**。
+
+## 3.3 Matcher 权限 helper
+
+```python
+from src.features.cmd_perm import (
+    group_message_permission_for_command,
+    private_message_permission_for_command,
+    permission_for_command,
+)
+
+# 仅群消息
+on_command("群内", permission=group_message_permission_for_command("my_plugin.in_group"))
+
+# 仅私聊
+on_command("私聊", permission=private_message_permission_for_command("my_plugin.in_private"))
+
+# 群+私聊同一等级
+on_command("通用", permission=permission_for_command("my_plugin.any"))
+```
+
+**禁止** `Permission & permission_for_command(...)` 叠 Permission；用上述合并 helper。
+
+## 3.4 handler 内手动鉴权
+
+Matcher 无法表达时（例如一条 handler 内分支）：
+
+```python
+from src.features.cmd_perm import satisfies_command_permission
+
+if not await satisfies_command_permission(bot, event, "my_plugin.action"):
+    return
+```
+
+## 3.5 帮助 `usage` 与 `menu_data`
+
+### `usage`（PluginMetadata.usage）
+
+```python
+from src.features.cmd_perm.metadata_text import SCENE_GROUP, join_usage, usage_line
+
+usage=join_usage(
+    usage_line("牛牛帮助", "查看帮助"),
+    usage_line("牛牛状态", "查看状态"),
+),
+```
+
+- ≥2 条时 `join_usage` 自动编号
+- `description` 一句句号结尾
+- **不要在 usage 末尾写**「仅群管可用」——帮助图会根据权限**自动**展示「何人可用」
+
+### `menu_data`（二级/三级帮助图）
+
+```python
+"menu_data": [
+    {
+        "func": "牛牛示例",
+        "trigger_method": "on_command",      # 或 on_message 等，与真实 matcher 一致
+        "trigger_scene": SCENE_GROUP,        # SCENE_GROUP / SCENE_PRIVATE / SCENE_AUTO
+        "trigger_condition": "牛牛示例",     # 只写怎么说，不写权限
+        "command_permission": "my_plugin.demo",
+        "brief_des": "简短说明。",
+        "detail_des": "详情；与权限无关的前提写在这里。",
+    },
+],
+```
+
+多命令绑同一菜单项时用 `command_permissions` 列表。
+
+### 与 cmd_perm 无关的条件
+
+例如「须本 Bot 为 QQ 群管理员」→ 写在 `detail_des` 或 `docs/plugins/<name>/README.md`，**不要**塞进 `usage` / `trigger_condition`。
+
+## 3.6 metadata 模板字段
+
+与仓库其它插件对齐：
+
+```python
+from src.features.cmd_perm.metadata_defaults import (
+    PLUGIN_EXTRA_VERSION,
+    PLUGIN_HOMEPAGE,
+    PLUGIN_MENU_TEMPLATE,
+)
+
+extra={
+    "version": PLUGIN_EXTRA_VERSION,
+    "menu_template": PLUGIN_MENU_TEMPLATE,
+    "homepage": PLUGIN_HOMEPAGE,  # 也可写在 PluginMetadata.homepage
+    ...
+}
+```
+
+## 3.7 插件 README 表格
+
+开发者向文档可用表格列出**代码默认等级**，并注明以 WebUI / cmd_perm 为准。用户向 README 模板：[plugins/TEMPLATE.md](../../plugins/TEMPLATE.md)。
+
+## 3.8 自检清单
+
+- [ ] 每个需鉴权的 matcher 都有对应 `command_permissions` 项
+- [ ] `menu_data.command_permission` 与 matcher ID 一致
+- [ ] `usage` / `trigger_condition` 无写死权限角色
+- [ ] 群/私聊限定用了 `group_message_permission_for_command` 等，未手写 `Permission &`
+- [ ] WebUI 保存权限后，帮助图「何人可用」与实鉴权一致（改默认等级需重启或重载插件）
+
+## 3.9 下一步
+
+- WebUI 配置热重载 → [四、WebUI 配置](./04-webui-config.md)
+- 测试与文档 → [七、测试与文档](./07-tests-and-docs.md)

--- a/docs/skills/pallas-plugin-development/references/04-webui-config.md
+++ b/docs/skills/pallas-plugin-development/references/04-webui-config.md
@@ -1,0 +1,52 @@
+# 四、WebUI 配置热重载
+
+控制台插件页与通用配置写入 `data/pallas_config/webui.json`（**WebUI 落盘优先级最高**）。详情：[webui/README.md](../../common/webui/README.md)。
+
+## 4.1 标准接入
+
+```python
+from pydantic import BaseModel, Field
+from src.console.webui import install_hot_reload_config
+
+class Config(BaseModel, extra="ignore"):
+    threshold: int = Field(default=3, description="触发阈值。")
+
+plugin_webui = install_hot_reload_config(Config, config_module=__name__)
+get_config = plugin_webui.get
+```
+
+业务代码**始终** `get_config()`；不要在模块 import 时把配置存到全局变量。
+
+## 4.2 Field description 即 WebUI 文案
+
+`Field(..., description="...")` 会出现在控制台表单；写清楚用户能看懂的说明。
+
+环境变量键名：由插件名与字段名推导，落盘为大写（见 `plugin_api`）。
+
+## 4.3 进阶：`parse_env_value` / `on_reload`
+
+复杂类型（列表、枚举、URL）参考 `draw/config.py`：
+
+- `parse_env_value`：把 webui.json 字符串解析成模型字段
+- `on_reload`：配置变更后刷新运行时单例（缓存、连接池）
+
+已有自定义缓存的插件可登记 `plugin_webui_registry`（如决斗插件）。
+
+## 4.4 未接热重载时
+
+仍可用 `get_plugin_config(Config)`，但**保存后需重启**进程才与磁盘一致。新插件默认应接热重载。
+
+## 4.5 通用配置段（非单插件页）
+
+横切能力在 WebUI「通用配置」注册段，见 `src/console/webui/env_sections.py`：cmd_perm、message_scrub、ingress_fanout 等。插件作者扩展新**全局段**需改内核并同步 WebUI 前端——一般优先用插件自己的 `config.py` + 热重载。
+
+## 4.6 自检
+
+- [ ] 所有可调项在 Pydantic `Config` 中有 `Field(description=...)`
+- [ ] handler 内 `get_config()` 而非读缓存
+- [ ] 复杂解析已测 WebUI 保存 → 行为立即变化
+
+## 4.7 下一步
+
+- 路径与数据 → [五、路径与数据](./05-paths-and-data.md)
+- message_scrub → [六、message_scrub](./06-message-scrub.md)

--- a/docs/skills/pallas-plugin-development/references/04-webui-config.md
+++ b/docs/skills/pallas-plugin-development/references/04-webui-config.md
@@ -2,6 +2,8 @@
 
 控制台插件页与通用配置写入 `data/pallas_config/webui.json`（**WebUI 落盘优先级最高**）。详情：[webui/README.md](../../common/webui/README.md)。
 
+后端 REST 契约（路径、鉴权、写操作）：[webui/api/README.md](../../common/webui/api/README.md) · 插件配置域 [02-plugins.md](../../common/webui/api/02-plugins.md)。
+
 ## 4.1 标准接入
 
 ```python

--- a/docs/skills/pallas-plugin-development/references/05-paths-and-data.md
+++ b/docs/skills/pallas-plugin-development/references/05-paths-and-data.md
@@ -1,0 +1,34 @@
+# 五、路径、数据与资源
+
+## 5.1 约定
+
+| 类型 | 位置 | Helper |
+| --- | --- | --- |
+| 运行期数据 | `data/<plugin_name>/` | `plugin_data_dir("my_plugin")` |
+| 静态资源 | `resource/<subdir>/` | `resource_dir("voices")` 等 |
+
+```python
+from src.foundation.paths import plugin_data_dir, resource_dir
+
+DATA = plugin_data_dir("my_plugin")
+VOICES = resource_dir("voices")
+```
+
+**不要**硬编码 `data/`、`resource/` 相对路径字符串；工作目录变化会导致漂移。
+
+## 5.2 备份与排障
+
+`data/<plugin_name>/` 按插件隔离，便于备份与按插件清理。大文件、缓存、下载物放数据目录；可复用静态素材放 `resource/`。
+
+## 5.3 数据库
+
+持久化优先走 `src.foundation.db` repository 模式；表结构与迁移遵循仓库现有插件（如 blacklist、request_handler）。新表需考虑 PostgreSQL 与 CI。
+
+## 5.4 测试中的路径
+
+测试可使用临时目录或 fixture；参考 `tests/plugins/` 下既有写法，避免写真实 `data/`。
+
+## 5.5 下一步
+
+- 入站过滤 → [六、message_scrub](./06-message-scrub.md)
+- 测试 → [七、测试与文档](./07-tests-and-docs.md)

--- a/docs/skills/pallas-plugin-development/references/06-message-scrub.md
+++ b/docs/skills/pallas-plugin-development/references/06-message-scrub.md
@@ -1,0 +1,32 @@
+# 六、message_scrub 入站过滤
+
+实现：`src/features/message_scrub/`。用户向说明：[message_scrub/README.md](../../common/message_scrub/README.md)。
+
+## 6.1 何时需要
+
+| 场景 | 建议 |
+| --- | --- |
+| 复读学习、做梦采集、大量读用户原文 | **应评估**接入审查链 |
+| 纯 `on_command` 只解析命令参数 | 通常不必 |
+| 出站生成（Bot 自己发的话） | 不由 message_scrub 管 |
+
+## 6.2 插件侧
+
+复读、做梦等已在内核路径调用审查；**新插件**若自建「学用户说话」逻辑，应：
+
+1. 读 [message_scrub README](../../common/message_scrub/README.md) 的 hook 登记方式
+2. 在入库前调用统一审查 API，勿复制一份关键词列表
+
+## 6.3 运维配置
+
+WebUI：**通用配置 → 消息审查与入站过滤**。启用需 `message-scrub` deploy profile 或 `PALLAS_MESSAGE_SCRUB_ENABLED=true`。
+
+保存后 hub 热重载；分片 worker 按 mtime 重读。
+
+## 6.4 与 ingress / 分片
+
+多进程部署时审查配置需在各 worker 一致；见架构文档 [bot_process_sharding](../../architecture/bot_process_sharding.md)。
+
+## 6.5 下一步
+
+- 提交前检查 → [七、测试与文档](./07-tests-and-docs.md)

--- a/docs/skills/pallas-plugin-development/references/07-tests-and-docs.md
+++ b/docs/skills/pallas-plugin-development/references/07-tests-and-docs.md
@@ -1,0 +1,29 @@
+# 七、测试与文档
+
+## 7.1 测试
+
+- 目录：`tests/plugins/<plugin_name>/`，尽量镜像 `src/plugins/<plugin_name>/`
+- 运行：`uv run pytest tests/plugins/my_plugin/`
+- 至少覆盖：配置解析、核心纯函数、权限/规则边界（可参考 `tests/plugins/blacklist/`、`tests/plugins/repeater/`）
+
+提交前：
+
+```bash
+uv run ruff check src/
+uv run ruff format --check src/
+```
+
+## 7.2 用户向文档
+
+- `docs/plugins/<name>/README.md`（可复制 [TEMPLATE.md](../../plugins/TEMPLATE.md)）
+- 在 [plugins/README.md](../../plugins/README.md) 索引登记
+- 表格可列代码默认命令等级，注明以 WebUI 为准
+
+## 7.3 Agent / 贡献者
+
+- 协作约定：[AGENTS.md](../../../AGENTS.md)、[CONTRIBUTING.md](../../../CONTRIBUTING.md)
+- 提交流程：[develop/workflow.md](../../develop/workflow.md)
+
+## 7.4 完整插件 checklist
+
+见 [八、golden plugin checklist](./08-golden-plugin-checklist.md)

--- a/docs/skills/pallas-plugin-development/references/08-golden-plugin-checklist.md
+++ b/docs/skills/pallas-plugin-development/references/08-golden-plugin-checklist.md
@@ -1,0 +1,39 @@
+# 八、完整插件 checklist（提交前）
+
+新建或较大改动插件时，逐项勾选：
+
+## 结构与代码
+
+- [ ] `__init__.py` 轻量；业务已拆到语义化模块
+- [ ] `config.py` 存在；WebUI 可调项已接 `install_hot_reload_config`
+- [ ] 路径用 `plugin_data_dir` / `resource_dir`
+- [ ] 导入来自 `src.features` / `src.foundation` / `src.console` 公开 API
+- [ ] `uv run ruff check src/` 与 `format --check` 通过
+
+## Matcher 与权限
+
+- [ ] 口令型用 `on_command`；被动型 `on_message` 有合理 priority/block/rule
+- [ ] 每个鉴权命令有 `command_permissions` + matcher permission
+- [ ] `menu_data` 与命令 ID 一致
+- [ ] `usage` / `trigger_condition` 无写死权限文案
+
+## 横切能力
+
+- [ ] 读用户原文学习/生成类已评估 message_scrub
+- [ ] 高频路径无同步阻塞；日志用 `{}` / f-string
+
+## 测试与文档
+
+- [ ] `tests/plugins/<name>/` 有最小测试
+- [ ] `docs/plugins/<name>/README.md` + 索引更新
+
+## 站点插件（local）
+
+- [ ] 放在 `local/plugins/<name>/`
+- [ ] `pallas.toml` 已配 `extra_plugin_dirs`
+- [ ] 与主仓同名时确认覆盖意图
+
+## 可选增强
+
+- [ ] 需 CD 时已用 `GroupConfig` / `BotConfig`，`action_type` 命名清晰
+- [ ] 多牛 / 分片部署已读 [central-ingress-dispatch](../../architecture/central-ingress-dispatch.md)、[bot_process_sharding](../../architecture/bot_process_sharding.md)

--- a/docs/skills/pallas-plugin-development/references/08-golden-plugin-checklist.md
+++ b/docs/skills/pallas-plugin-development/references/08-golden-plugin-checklist.md
@@ -35,5 +35,5 @@
 
 ## 可选增强
 
-- [ ] 需 CD 时已用 `GroupConfig` / `BotConfig`，`action_type` 命名清晰
+- [ ] 需 CD 时已用 `src.features.command_limits`（或 `GroupConfig` / `BotConfig`），key 与 `command_id` 一致
 - [ ] 多牛 / 分片部署已读 [central-ingress-dispatch](../../architecture/central-ingress-dispatch.md)、[bot_process_sharding](../../architecture/bot_process_sharding.md)

--- a/src/console/webui/env_sections.py
+++ b/src/console/webui/env_sections.py
@@ -256,6 +256,20 @@ def _cmd_perm_section() -> WebuiEnvSection:
     )
 
 
+def _command_limits_section() -> WebuiEnvSection:
+    from src.features.command_limits.config import CommandLimitsConfig, get_command_limits_config
+
+    return WebuiEnvSection(
+        id="command_limits",
+        title="命令冷却",
+        module_label="src.features.command_limits",
+        model_cls=CommandLimitsConfig,
+        read_current=get_command_limits_config,
+        field_to_env={"command_limit_overrides": "PALLAS_COMMAND_LIMIT_OVERRIDES"},
+        skip_fields=frozenset(),
+    )
+
+
 _sections_cache: tuple[WebuiEnvSection, ...] | None = None
 
 
@@ -264,7 +278,7 @@ def _registered_sections() -> tuple[WebuiEnvSection, ...]:
     if _sections_cache is not None:
         return _sections_cache
     parts: list[WebuiEnvSection] = []
-    parts.append(_cmd_perm_section())
+    parts.extend((_cmd_perm_section(), _command_limits_section()))
     if (SRC_ROOT / "features" / "control_plane" / "webui_config.py").is_file():
         parts.append(_control_plane_section())
     if (SRC_ROOT / "platform" / "ingress" / "config.py").is_file():
@@ -308,6 +322,7 @@ def _registered_sections() -> tuple[WebuiEnvSection, ...]:
 
 _COMMON_CONFIG_SECTION_ORDER: tuple[str, ...] = (
     "cmd_perm",
+    "command_limits",
     "control_plane",
     "corpus_federation",
     "community_stats",
@@ -427,6 +442,9 @@ def webui_env_section_payload(
     if section_id == "cmd_perm":
         perm_src = s.model_cls.model_validate(current_values) if current_values is not None else cfg_obj
         base.update(_cmd_perm_payload_extras(perm_src))
+    elif section_id == "command_limits":
+        limit_src = s.model_cls.model_validate(current_values) if current_values is not None else cfg_obj
+        base.update(_command_limits_payload_extras(limit_src))
     elif section_id == "pallas_webui":
         base.update(_pallas_webui_payload_extras())
     elif section_id == "ingress_dispatch":
@@ -525,6 +543,27 @@ def _cmd_perm_payload_extras(cfg_obj: Any) -> dict[str, Any]:
     return {"command_perm_ui": build_command_perm_ui({str(k): str(v) for k, v in overrides.items()})}
 
 
+def _command_limits_payload_extras(cfg_obj: Any) -> dict[str, Any]:
+    from src.features.command_limits.schema import build_command_limits_ui
+
+    overrides = getattr(cfg_obj, "command_limit_overrides", None) or {}
+    if not isinstance(overrides, dict):
+        overrides = {}
+    clean: dict[str, int] = {}
+    for key, value in overrides.items():
+        cid = str(key).strip()
+        if not cid:
+            continue
+        try:
+            cd_sec = int(value)
+        except (TypeError, ValueError):
+            continue
+        if cd_sec < 1:
+            continue
+        clean[cid] = cd_sec
+    return {"command_limits_ui": build_command_limits_ui(clean)}
+
+
 def apply_webui_env_section_patch(section_id: str, patch: dict[str, Any]) -> dict[str, Any]:
     from .community_stats_section import COMMUNITY_STATS_SECTION_ID, apply_community_stats_patch
     from .control_plane_section import CONTROL_PLANE_SECTION_ID, apply_control_plane_patch
@@ -564,6 +603,13 @@ def apply_webui_env_section_patch(section_id: str, patch: dict[str, Any]) -> dic
             from src.features.cmd_perm import clear_cmd_perm_cache
 
             clear_cmd_perm_cache()
+        except Exception:
+            pass
+    elif section_id == "command_limits":
+        try:
+            from src.features.command_limits import clear_command_limits_cache
+
+            clear_command_limits_cache()
         except Exception:
             pass
     elif section_id == "ingress_fanout":

--- a/src/console/webui/field_labels.py
+++ b/src/console/webui/field_labels.py
@@ -23,6 +23,7 @@ FIELD_LABELS: dict[str, str] = {
     "chat_enable": "启用 chat 服务",
     "chat_endpoint": "聊天接口路径",
     "claim_ttl_sec": "去重保留秒数",
+    "command_limit_overrides": "命令冷却覆盖",
     "command_permission_overrides": "命令权限覆盖",
     "community_api_base": "共享语料服务地址",
     "community_contribute": "上传本机新回复",

--- a/src/features/command_limits/__init__.py
+++ b/src/features/command_limits/__init__.py
@@ -1,0 +1,41 @@
+"""插件命令冷却（CD）统一 helper。"""
+
+from .config import CommandLimitsConfig, clear_command_limits_cache, get_command_limits_config
+from .cooldown import (
+    command_limit_action_key,
+    config_for_message_event,
+    get_command_cooldown_sec,
+    is_command_cooldown_ready,
+    refresh_command_cooldown,
+)
+from .metadata import (
+    CommandLimitDecl,
+    command_limit_for_id,
+    command_limits_from_metadata,
+    parse_command_limit_decl,
+)
+from .schema import (
+    build_command_limits_ui,
+    clear_merged_command_limits_cache,
+    effective_command_limit_for,
+    merged_default_command_limits,
+)
+
+__all__ = [
+    "CommandLimitDecl",
+    "CommandLimitsConfig",
+    "build_command_limits_ui",
+    "clear_command_limits_cache",
+    "clear_merged_command_limits_cache",
+    "command_limit_action_key",
+    "command_limit_for_id",
+    "command_limits_from_metadata",
+    "config_for_message_event",
+    "effective_command_limit_for",
+    "get_command_cooldown_sec",
+    "get_command_limits_config",
+    "is_command_cooldown_ready",
+    "merged_default_command_limits",
+    "parse_command_limit_decl",
+    "refresh_command_cooldown",
+]

--- a/src/features/command_limits/config.py
+++ b/src/features/command_limits/config.py
@@ -1,0 +1,97 @@
+"""WebUI / .env：PALLAS_COMMAND_LIMIT_OVERRIDES JSON 覆盖默认命令冷却。"""
+
+from __future__ import annotations
+
+import json
+import os
+from threading import Lock
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.console.webui.field_help import field_help
+from src.foundation.config.dotenv import merged_repo_dotenv_upper, repo_layered_dotenv_files_exist
+
+
+class CommandLimitsConfig(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True, extra="ignore")
+
+    command_limit_overrides: dict[str, int] = Field(
+        default_factory=dict,
+        description=field_help(
+            "覆盖各命令默认冷却秒数",
+            "JSON 对象：键为命令编号，值为正整数秒数",
+            "未写的命令仍用插件默认；本页下方表格可图形化编辑",
+        ),
+    )
+
+    @classmethod
+    def from_env(cls) -> Self:
+        merged = merged_repo_dotenv_upper()
+        raw = ""
+        if "PALLAS_COMMAND_LIMIT_OVERRIDES" in os.environ:
+            raw = (os.environ.get("PALLAS_COMMAND_LIMIT_OVERRIDES") or "").strip()
+        elif "PALLAS_COMMAND_LIMIT_OVERRIDES" in merged:
+            raw = (merged.get("PALLAS_COMMAND_LIMIT_OVERRIDES") or "").strip()
+        elif not repo_layered_dotenv_files_exist():
+            try:
+                from nonebot import get_driver
+
+                cfg = get_driver().config
+                if "pallas_command_limit_overrides" in (getattr(cfg, "model_fields_set", None) or set()):
+                    v = getattr(cfg, "pallas_command_limit_overrides", None)
+                    if isinstance(v, dict):
+                        return cls(command_limit_overrides=_normalize_overrides(v))
+                    if isinstance(v, str) and v.strip():
+                        raw = v.strip()
+            except ValueError:
+                pass
+        if not raw:
+            return cls()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return cls()
+        if not isinstance(data, dict):
+            return cls()
+        return cls(command_limit_overrides=_normalize_overrides(data))
+
+
+def _normalize_overrides(raw: dict[object, object]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for key, value in raw.items():
+        cid = str(key).strip()
+        if not cid:
+            continue
+        try:
+            cd_sec = int(value)
+        except (TypeError, ValueError):
+            continue
+        if cd_sec < 0:
+            continue
+        out[cid] = cd_sec
+    return out
+
+
+_config_lock = Lock()
+_cached: CommandLimitsConfig | None = None
+
+
+def clear_command_limits_cache() -> None:
+    global _cached
+    with _config_lock:
+        _cached = None
+    try:
+        from . import schema as command_limits_schema
+
+        command_limits_schema.clear_merged_command_limits_cache()
+    except Exception:
+        pass
+
+
+def get_command_limits_config() -> CommandLimitsConfig:
+    global _cached
+    with _config_lock:
+        if _cached is None:
+            _cached = CommandLimitsConfig.from_env()
+        return _cached

--- a/src/features/command_limits/cooldown.py
+++ b/src/features/command_limits/cooldown.py
@@ -1,0 +1,57 @@
+"""命令冷却：复用 foundation 配置存储，统一 key 前缀。"""
+
+from __future__ import annotations
+
+from nonebot.adapters.onebot.v11 import GroupMessageEvent, MessageEvent, PrivateMessageEvent
+
+from src.features.command_limits.config import get_command_limits_config
+from src.features.command_limits.schema import effective_command_limit_for
+from src.foundation.config import BotConfig, GroupConfig
+
+LIMIT_KEY_PREFIX = "cmd_limit"
+
+
+def command_limit_action_key(command_id: str) -> str:
+    return f"{LIMIT_KEY_PREFIX}:{command_id.strip()}"
+
+
+def config_for_message_event(event: MessageEvent, cd_sec: int) -> GroupConfig | BotConfig:
+    if cd_sec < 1:
+        raise ValueError("cd_sec 须 >= 1")
+    if isinstance(event, GroupMessageEvent):
+        return GroupConfig(event.group_id, cooldown=cd_sec)
+    if isinstance(event, PrivateMessageEvent):
+        return BotConfig(int(event.self_id), int(event.get_user_id()), cooldown=cd_sec)
+    raise TypeError("仅支持群消息或私聊消息事件")
+
+
+def get_command_cooldown_sec(command_id: str, default_cd_sec: int | None = None) -> int | None:
+    cfg = get_command_limits_config()
+    cd_sec = effective_command_limit_for(command_id, cfg.command_limit_overrides)
+    if cd_sec is not None:
+        return cd_sec
+    return default_cd_sec
+
+
+async def is_command_cooldown_ready(
+    event: MessageEvent, command_id: str, cd_sec: int | None = None, *, default_cd_sec: int | None = None
+) -> bool:
+    effective_cd = cd_sec if cd_sec is not None else get_command_cooldown_sec(command_id, default_cd_sec)
+    if effective_cd is None:
+        raise ValueError(f"命令 {command_id} 未声明默认冷却，且未显式传入 cd_sec")
+    if effective_cd <= 0:
+        return True
+    cfg = config_for_message_event(event, effective_cd)
+    return await cfg.is_cooldown(command_limit_action_key(command_id))
+
+
+async def refresh_command_cooldown(
+    event: MessageEvent, command_id: str, cd_sec: int | None = None, *, default_cd_sec: int | None = None
+) -> None:
+    effective_cd = cd_sec if cd_sec is not None else get_command_cooldown_sec(command_id, default_cd_sec)
+    if effective_cd is None:
+        raise ValueError(f"命令 {command_id} 未声明默认冷却，且未显式传入 cd_sec")
+    if effective_cd <= 0:
+        return
+    cfg = config_for_message_event(event, effective_cd)
+    await cfg.refresh_cooldown(command_limit_action_key(command_id))

--- a/src/features/command_limits/metadata.py
+++ b/src/features/command_limits/metadata.py
@@ -1,0 +1,52 @@
+"""从 PluginMetadata.extra 解析 command_limits 声明。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+if TYPE_CHECKING:
+    from nonebot.plugin import PluginMetadata
+
+
+class CommandLimitDecl(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1, description="与 command_permissions 相同的命令 ID")
+    cd_sec: int = Field(ge=0, description="冷却秒数；0 表示关闭冷却")
+    scope: Literal["group", "private", "auto"] = "auto"
+
+
+def parse_command_limit_decl(raw: dict[str, Any]) -> CommandLimitDecl | None:
+    try:
+        item = dict(raw)
+        if "cd_sec" not in item and "cd" in item:
+            item["cd_sec"] = item.pop("cd")
+        return CommandLimitDecl.model_validate(item)
+    except (ValidationError, TypeError, ValueError):
+        return None
+
+
+def command_limits_from_metadata(meta: PluginMetadata | None) -> list[CommandLimitDecl]:
+    if meta is None or not meta.extra:
+        return []
+    raw_list = meta.extra.get("command_limits")
+    if not isinstance(raw_list, list):
+        return []
+    out: list[CommandLimitDecl] = []
+    for raw in raw_list:
+        if not isinstance(raw, dict):
+            continue
+        decl = parse_command_limit_decl(raw)
+        if decl is not None:
+            out.append(decl)
+    return out
+
+
+def command_limit_for_id(meta: PluginMetadata | None, command_id: str) -> CommandLimitDecl | None:
+    cid = command_id.strip()
+    for decl in command_limits_from_metadata(meta):
+        if decl.id == cid:
+            return decl
+    return None

--- a/src/features/command_limits/schema.py
+++ b/src/features/command_limits/schema.py
@@ -1,0 +1,93 @@
+"""从 PluginMetadata.extra['command_limits'] 聚合默认命令冷却，并生成 WebUI 数据。"""
+
+from __future__ import annotations
+
+from operator import itemgetter
+from typing import Any
+
+from nonebot import get_loaded_plugins
+
+from .metadata import command_limits_from_metadata
+
+_merged_defaults_cache: dict[str, int] | None = None
+
+
+def clear_merged_command_limits_cache() -> None:
+    global _merged_defaults_cache
+    _merged_defaults_cache = None
+
+
+def merged_default_command_limits() -> dict[str, int]:
+    global _merged_defaults_cache
+    if _merged_defaults_cache is not None:
+        return _merged_defaults_cache
+    merged: dict[str, int] = {}
+    for plugin in get_loaded_plugins():
+        if not plugin.name:
+            continue
+        meta = getattr(plugin, "metadata", None)
+        for row in command_limits_from_metadata(meta):
+            merged[row.id] = row.cd_sec
+    _merged_defaults_cache = merged
+    return _merged_defaults_cache
+
+
+def effective_command_limit_for(command_id: str, overrides: dict[str, int] | None = None) -> int | None:
+    cid = (command_id or "").strip()
+    if not cid:
+        return None
+    override_map = overrides or {}
+    if cid in override_map:
+        return override_map[cid]
+    return merged_default_command_limits().get(cid)
+
+
+def build_command_limits_ui(overrides: dict[str, int]) -> dict[str, Any]:
+    defaults = merged_default_command_limits()
+    meta_rows: dict[str, tuple[str, str, str]] = {}
+    for plugin in get_loaded_plugins():
+        if not plugin.name:
+            continue
+        meta = getattr(plugin, "metadata", None)
+        title = (getattr(meta, "name", None) or plugin.name or "").strip() or plugin.name
+        for row in command_limits_from_metadata(meta):
+            meta_rows[row.id] = (plugin.name, title, row.id)
+
+    groups: dict[str, dict[str, Any]] = {}
+    for cid, default_cd in sorted(defaults.items(), key=itemgetter(0)):
+        effective_cd = overrides.get(cid, default_cd)
+        if cid in meta_rows:
+            pname, ptitle, label = meta_rows[cid]
+        else:
+            from src.features.cmd_perm.ui_labels import (
+                command_label_for_id,
+                plugin_name_for_command_id,
+                plugin_title_for_name,
+            )
+
+            pname = plugin_name_for_command_id(cid)
+            ptitle = plugin_title_for_name(pname)
+            label = command_label_for_id(cid)
+        group = groups.setdefault(pname, {"plugin": pname, "title": ptitle, "commands": []})
+        group["commands"].append({
+            "command_id": cid,
+            "label": label,
+            "default_cd_sec": default_cd,
+            "effective_cd_sec": effective_cd,
+        })
+    for group in groups.values():
+        group["commands"].sort(key=itemgetter("label", "command_id"))
+    plugins_out = sorted(groups.values(), key=itemgetter("plugin"))
+    commands_out = [
+        {
+            "id": row["command_id"],
+            "label": row["label"],
+            "default_cd_sec": row["default_cd_sec"],
+            "effective_cd_sec": row["effective_cd_sec"],
+            "plugin": group["plugin"],
+            "title": group["title"],
+        }
+        for group in plugins_out
+        for row in group["commands"]
+    ]
+    return {"plugins": plugins_out, "commands": commands_out}

--- a/src/plugins/bot_status/__init__.py
+++ b/src/plugins/bot_status/__init__.py
@@ -25,6 +25,7 @@ from src.features.cmd_perm.metadata_text import (
     join_usage,
     usage_line,
 )
+from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
 from src.platform.shard import context as shard_ctx
 
 from .bot_monitor import (
@@ -54,6 +55,10 @@ __plugin_meta__ = PluginMetadata(
             {"id": "bot_status.status", "label": "牛牛在吗", "default": "bot_moderator"},
             {"id": "bot_status.test_mail", "label": "测试邮件", "default": "superuser"},
             {"id": "bot_status.count", "label": "牛牛报数 / 牛牛出列", "default": "everyone"},
+        ],
+        "command_limits": [
+            {"id": "bot_status.status", "cd_sec": 10},
+            {"id": "bot_status.count", "cd_sec": 10},
         ],
         "ingress_fanout": {
             "scope": "shard_only",
@@ -186,13 +191,10 @@ async def _(bot: Bot, event: MessageEvent) -> None:
 @bot_status_cmd.handle()
 async def handle_bot_status(bot: Bot, event: MessageEvent) -> None:
     """处理状态查询命令"""
-    from src.foundation.config import GroupConfig
-
     if isinstance(event, GroupMessageEvent):
-        config = GroupConfig(group_id=event.group_id, cooldown=10)
-        if not await config.is_cooldown(STATUS_COOLDOWN_KEY):
+        if not await is_command_cooldown_ready(event, "bot_status.status"):
             return
-        await config.refresh_cooldown(STATUS_COOLDOWN_KEY)
+        await refresh_command_cooldown(event, "bot_status.status")
 
     # 获取牛牛状态信息
     online_bots, offline_bots_filtered = await get_bot_status_info()
@@ -224,8 +226,6 @@ async def handle_bot_status(bot: Bot, event: MessageEvent) -> None:
 @bot_count_cmd.handle()
 async def handle_bot_count(bot: Bot, event: MessageEvent) -> None:
     """处理牛牛报数命令"""
-    from src.foundation.config import GroupConfig
-
     if not isinstance(event, GroupMessageEvent):
         await bot_count_cmd.finish("牛牛报数仅支持群聊中使用")
 
@@ -239,10 +239,9 @@ async def handle_bot_count(bot: Bot, event: MessageEvent) -> None:
     if not group_bot_ids:
         return
 
-    config = GroupConfig(group_id=event.group_id, cooldown=10)
-    if not await config.is_cooldown(COUNT_COOLDOWN_KEY):
+    if not await is_command_cooldown_ready(event, "bot_status.count"):
         return
-    await config.refresh_cooldown(COUNT_COOLDOWN_KEY)
+    await refresh_command_cooldown(event, "bot_status.count")
 
     seed_text = f"{datetime.now().strftime('%Y-%m-%d')}:{event.group_id}"
     random.Random(seed_text).shuffle(group_bot_ids)

--- a/src/plugins/connectivity/__init__.py
+++ b/src/plugins/connectivity/__init__.py
@@ -22,6 +22,9 @@ __plugin_meta__ = PluginMetadata(
         "command_permissions": [
             {"id": "connectivity.probe", "label": "牛牛连通", "default": "everyone"},
         ],
+        "command_limits": [
+            {"id": "connectivity.probe", "cd_sec": 3},
+        ],
         "menu_data": [
             {
                 "func": "牛牛连通",

--- a/src/plugins/connectivity/commands.py
+++ b/src/plugins/connectivity/commands.py
@@ -5,12 +5,10 @@ from nonebot.internal.adapter import Event
 from nonebot.permission import Permission
 
 from src.features.cmd_perm import satisfies_command_permission
-from src.foundation.config import GroupConfig
+from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
 from src.shared.service_probe import format_probe_text
 
 from .probe_collect import probe_all_connectivity
-
-CONNECTIVITY_COOLDOWN_KEY = "connectivity_probe_command"
 
 
 def connectivity_message_permission() -> Permission:
@@ -52,10 +50,9 @@ async def run_connectivity_probe(matcher) -> None:
 
 async def handle_connectivity_probe(event: MessageEvent, matcher) -> None:
     if isinstance(event, GroupMessageEvent):
-        config = GroupConfig(event.group_id, cooldown=3)
-        if not await config.is_cooldown(CONNECTIVITY_COOLDOWN_KEY):
+        if not await is_command_cooldown_ready(event, "connectivity.probe"):
             return
-        await config.refresh_cooldown(CONNECTIVITY_COOLDOWN_KEY)
+        await refresh_command_cooldown(event, "connectivity.probe")
     await run_connectivity_probe(matcher)
 
 

--- a/src/plugins/draw/__init__.py
+++ b/src/plugins/draw/__init__.py
@@ -25,6 +25,9 @@ __plugin_meta__ = PluginMetadata(
             {"id": "draw.draw", "label": "牛牛画画", "default": "everyone"},
             {"id": "draw.gateway", "label": "牛牛网关", "default": "everyone"},
         ],
+        "command_limits": [
+            {"id": "draw.draw", "cd_sec": 3},
+        ],
         "menu_data": [
             {
                 "func": "牛牛画画",

--- a/src/plugins/draw/draw.py
+++ b/src/plugins/draw/draw.py
@@ -13,6 +13,7 @@ from nonebot.params import CommandArg
 from nonebot.permission import SUPERUSER
 
 from src.features.cmd_perm import group_message_permission_for_command
+from src.features.command_limits import get_command_cooldown_sec
 from src.features.message_scrub import is_message_scrub_blocked_async
 from src.features.message_scrub.log_preview import scrub_intercept_log_preview
 from src.foundation.config import GroupConfig
@@ -169,7 +170,7 @@ def draw_should_count_usage(group_id: int, user_id: int) -> bool:
 
 async def draw_group_cooldown_ready(group_id: int) -> bool:
     """仅检查群冷却是否已过，不扣减。"""
-    seconds = image_gen_config.draw_command_cooldown
+    seconds = get_command_cooldown_sec("draw.draw", image_gen_config.draw_command_cooldown) or 0
     if seconds <= 0:
         return True
     gconf = GroupConfig(group_id, cooldown=seconds)
@@ -178,7 +179,7 @@ async def draw_group_cooldown_ready(group_id: int) -> bool:
 
 async def consume_draw_group_cooldown(group_id: int) -> None:
     """真正开始画画时扣减群冷却。"""
-    seconds = image_gen_config.draw_command_cooldown
+    seconds = get_command_cooldown_sec("draw.draw", image_gen_config.draw_command_cooldown) or 0
     if seconds <= 0:
         return
     gconf = GroupConfig(group_id, cooldown=seconds)
@@ -187,7 +188,7 @@ async def consume_draw_group_cooldown(group_id: int) -> None:
 
 async def refund_draw_group_cooldown(group_id: int) -> None:
     """画画未成功出图时退还群冷却。"""
-    seconds = image_gen_config.draw_command_cooldown
+    seconds = get_command_cooldown_sec("draw.draw", image_gen_config.draw_command_cooldown) or 0
     if seconds <= 0:
         return
     gconf = GroupConfig(group_id, cooldown=seconds)
@@ -297,7 +298,7 @@ async def pallas_draw_handle(bot: Bot, event: GroupMessageEvent, args: Message =
             message_at_user(user_id, "牛牛正在给其他小伙伴画画，请稍后再试。"),
         )
 
-    cheer_gate = image_gen_config.draw_command_cooldown
+    cheer_gate = get_command_cooldown_sec("draw.draw", image_gen_config.draw_command_cooldown) or 0
     if not await try_begin_group_owned_gate("draw", group_id, bot_id, gate_sec=cheer_gate):
         return
     await consume_draw_group_cooldown(group_id)

--- a/src/plugins/duel/__init__.py
+++ b/src/plugins/duel/__init__.py
@@ -72,6 +72,10 @@ __plugin_meta__ = PluginMetadata(
                 "default": "group_moderator",
             },
         ],
+        "command_limits": [
+            {"id": "duel.duel", "cd_sec": 5},
+            {"id": "duel.cage", "cd_sec": 5},
+        ],
         "ingress_fanout": {
             "scope": "always",
             "regexes": [r"^八角笼(?:牛|斗)(?:\s*\d{1,2}\s*(?:幕|回合))?\s*$"],
@@ -251,7 +255,7 @@ async def run_duel_match(
     bot_mode = dual_bot or (challenger_is_bot and defender_is_bot)
 
     if command_gate is None:
-        gate = await begin_duel_command(event.group_id)
+        gate = await begin_duel_command(event.group_id, command_id="duel.duel")
     else:
         gate = command_gate
     if gate == "busy":
@@ -312,7 +316,7 @@ async def duel_bot_pair(
         return
     if not duel_handler_is_narrator(event, a, b, dual_bot=True):
         return
-    gate = await begin_duel_command(event.group_id)
+    gate = await begin_duel_command(event.group_id, command_id="duel.duel")
     if gate == "busy":
         await send_duel_user_reply(matcher, event.group_id, "此群台上正有决斗未散，且待战歌落幕。")
         return
@@ -433,7 +437,7 @@ async def _(bot: Bot, event: GroupMessageEvent, state: T_State) -> None:
     from src.platform.shard.coord.duel_group import try_reclaim_orphan_duel_group
 
     await try_reclaim_orphan_duel_group(event.group_id)
-    gate = await begin_duel_command(event.group_id)
+    gate = await begin_duel_command(event.group_id, command_id="duel.cage")
     if gate == "busy":
         if not await send_duel_user_reply_owned(
             cage_msg,

--- a/src/plugins/duel/duel_round_engine.py
+++ b/src/plugins/duel/duel_round_engine.py
@@ -12,6 +12,7 @@ from nonebot.adapters import Bot  # noqa: TC002
 from nonebot.adapters.onebot.v11 import Message
 from nonebot.matcher import Matcher  # noqa: TC002
 
+from src.features.command_limits import get_command_cooldown_sec
 from src.foundation.config import GroupConfig
 from src.platform.multi_bot.group import claim_group_message_event, try_acquire_group_broadcast_slot
 from src.plugins.duel.config import plugin_config
@@ -160,7 +161,7 @@ def end_duel_group(group_id: int) -> None:
     release(group_id)
 
 
-async def begin_duel_command(group_id: int) -> DuelCommandGate:
+async def begin_duel_command(group_id: int, *, command_id: str = "duel.duel") -> DuelCommandGate:
     """群级互斥 + 群级指令 CD。"""
     from src.platform.shard.coord.duel_group import _LOCK
     from src.plugins.duel.duel_session import get_duel_pair
@@ -168,7 +169,10 @@ async def begin_duel_command(group_id: int) -> DuelCommandGate:
     gate = await _LOCK.begin(group_id, local_alive=lambda: get_duel_pair(group_id))
     if gate == "busy":
         return "busy"
-    group_cfg = GroupConfig(group_id, cooldown=plugin_config.duel_bot_cooldown_sec)
+    cooldown_sec = get_command_cooldown_sec(command_id, plugin_config.duel_bot_cooldown_sec) or 0
+    if cooldown_sec <= 0:
+        return "ok"
+    group_cfg = GroupConfig(group_id, cooldown=cooldown_sec)
     if not await group_cfg.is_cooldown(DUEL_GROUP_COOLDOWN_KEY):
         end_duel_group(group_id)
         return "cooldown"

--- a/src/plugins/help/__init__.py
+++ b/src/plugins/help/__init__.py
@@ -12,6 +12,7 @@ from src.features.cmd_perm.metadata_defaults import (
     PLUGIN_MENU_TEMPLATE,
 )
 from src.features.cmd_perm.metadata_text import SCENE_BOTH, SCENE_GROUP, join_usage, usage_line
+from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
 from src.foundation.command_prefix import matches_command_prefix
 from src.foundation.config import BotConfig, GroupConfig
 
@@ -64,6 +65,9 @@ __plugin_meta__ = PluginMetadata(
             {"id": "help.plugin_disable", "label": "牛牛关闭（单插件）", "default": "staff"},
             {"id": "help.plugin_enable_all", "label": "牛牛开启全部功能", "default": "staff"},
             {"id": "help.plugin_disable_all", "label": "牛牛关闭全部功能", "default": "staff"},
+        ],
+        "command_limits": [
+            {"id": "help.help", "cd_sec": 3},
         ],
         "menu_data": [
             {
@@ -168,11 +172,10 @@ plugin_disable_all_cmd = on_command(
 async def handle_help_cmd(bot: Bot, event: GroupMessageEvent | PrivateMessageEvent, state: T_State):
     """处理帮助命令"""
     if isinstance(event, GroupMessageEvent):
-        config = GroupConfig(event.group_id, cooldown=3)
-        if not await config.is_cooldown(HELP_COOLDOWN_KEY):
+        if not await is_command_cooldown_ready(event, "help.help"):
             await help_cmd.finish()
             return
-        await config.refresh_cooldown(HELP_COOLDOWN_KEY)
+        await refresh_command_cooldown(event, "help.help")
 
     await handle_help_command(bot, event, state, plugin_config, AVAILABLE_STYLES, DEFAULT_STYLE_NAME, help_cmd)
 

--- a/tests/features/command_limits/test_command_limits.py
+++ b/tests/features/command_limits/test_command_limits.py
@@ -1,0 +1,121 @@
+from nonebot.plugin import PluginMetadata
+
+from src.features.command_limits.metadata import command_limits_from_metadata
+
+
+def _import_command_limit_plugins() -> None:
+    import src.plugins.bot_status  # noqa: F401
+    import src.plugins.connectivity  # noqa: F401
+    import src.plugins.help  # noqa: F401
+
+
+def _patch_loaded_plugins(monkeypatch):
+    from types import SimpleNamespace
+
+    from src.plugins.bot_status import __plugin_meta__ as bot_status_meta
+    from src.plugins.connectivity import __plugin_meta__ as connectivity_meta
+    from src.plugins.help import __plugin_meta__ as help_meta
+
+    plugins = [
+        SimpleNamespace(name="bot_status", metadata=bot_status_meta),
+        SimpleNamespace(name="connectivity", metadata=connectivity_meta),
+        SimpleNamespace(name="help", metadata=help_meta),
+    ]
+    monkeypatch.setattr("src.features.command_limits.schema.get_loaded_plugins", lambda: plugins)
+
+
+def test_command_limits_from_metadata():
+    meta = PluginMetadata(
+        name="t",
+        description="t。",
+        usage="",
+        extra={
+            "command_limits": [
+                {"id": "t.demo", "cd": 5},
+                {"id": "bad", "cd_sec": 0},
+            ],
+        },
+    )
+    limits = command_limits_from_metadata(meta)
+    assert len(limits) == 2
+    assert limits[0].id == "t.demo"
+    assert limits[0].cd_sec == 5
+    assert limits[1].id == "bad"
+    assert limits[1].cd_sec == 0
+
+
+def test_command_limit_action_key():
+    from src.features.command_limits import command_limit_action_key
+
+    assert command_limit_action_key("my_plugin.demo") == "cmd_limit:my_plugin.demo"
+
+
+def test_existing_plugin_metadata_declares_command_limits():
+    from src.plugins.bot_status import __plugin_meta__ as bot_status_meta
+    from src.plugins.connectivity import __plugin_meta__ as connectivity_meta
+    from src.plugins.help import __plugin_meta__ as help_meta
+
+    assert [item.id for item in command_limits_from_metadata(bot_status_meta)] == [
+        "bot_status.status",
+        "bot_status.count",
+    ]
+    assert [item.id for item in command_limits_from_metadata(connectivity_meta)] == ["connectivity.probe"]
+    assert [item.id for item in command_limits_from_metadata(help_meta)] == ["help.help"]
+
+
+def test_command_limits_ui_groups_existing_plugins(monkeypatch):
+    from src.features.command_limits.schema import build_command_limits_ui
+
+    _import_command_limit_plugins()
+    _patch_loaded_plugins(monkeypatch)
+    ui = build_command_limits_ui({})
+    commands = {row["id"]: row for row in ui["commands"]}
+
+    assert commands["help.help"]["default_cd_sec"] == 3
+    assert commands["help.help"]["effective_cd_sec"] == 3
+    assert commands["help.help"]["plugin"] == "help"
+    assert commands["bot_status.status"]["plugin"] == "bot_status"
+    assert commands["connectivity.probe"]["plugin"] == "connectivity"
+
+
+def test_command_limits_ui_uses_override_values(monkeypatch):
+    from src.features.command_limits.schema import build_command_limits_ui
+
+    _import_command_limit_plugins()
+    _patch_loaded_plugins(monkeypatch)
+    ui = build_command_limits_ui({"help.help": 9})
+    commands = {row["id"]: row for row in ui["commands"]}
+    assert commands["help.help"]["effective_cd_sec"] == 9
+
+
+def test_effective_command_limit_prefers_override(monkeypatch):
+    from src.features.command_limits.schema import effective_command_limit_for
+
+    _import_command_limit_plugins()
+    _patch_loaded_plugins(monkeypatch)
+    assert effective_command_limit_for("help.help", {"help.help": 7}) == 7
+    assert effective_command_limit_for("help.help", {}) == 3
+
+
+def test_get_command_cooldown_sec_reads_config_override(monkeypatch):
+    from src.features.command_limits.cooldown import get_command_cooldown_sec
+
+    class DummyCfg:
+        command_limit_overrides = {"help.help": 12}
+
+    _import_command_limit_plugins()
+    _patch_loaded_plugins(monkeypatch)
+    monkeypatch.setattr("src.features.command_limits.cooldown.get_command_limits_config", lambda: DummyCfg())
+    assert get_command_cooldown_sec("help.help") == 12
+
+
+def test_zero_command_cooldown_disables_limit(monkeypatch):
+    from src.features.command_limits.cooldown import get_command_cooldown_sec
+
+    class DummyCfg:
+        command_limit_overrides = {"help.help": 0}
+
+    _import_command_limit_plugins()
+    _patch_loaded_plugins(monkeypatch)
+    monkeypatch.setattr("src.features.command_limits.cooldown.get_command_limits_config", lambda: DummyCfg())
+    assert get_command_cooldown_sec("help.help") == 0

--- a/tests/plugins/test_webui_env_sections.py
+++ b/tests/plugins/test_webui_env_sections.py
@@ -2,14 +2,29 @@ from pathlib import Path
 
 import pytest
 
-_MS_CFG = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "features"
-    / "message_scrub"
-    / "config.py"
-)
+_MS_CFG = Path(__file__).resolve().parents[2] / "src" / "features" / "message_scrub" / "config.py"
 skip_no_message_scrub = pytest.mark.skipif(not _MS_CFG.is_file(), reason="无 message_scrub 配置模块")
+
+
+def _import_command_limit_plugins() -> None:
+    import src.plugins.bot_status  # noqa: F401
+    import src.plugins.connectivity  # noqa: F401
+    import src.plugins.help  # noqa: F401
+
+
+def _patch_loaded_command_limit_plugins(monkeypatch: pytest.MonkeyPatch) -> None:
+    from types import SimpleNamespace
+
+    from src.plugins.bot_status import __plugin_meta__ as bot_status_meta
+    from src.plugins.connectivity import __plugin_meta__ as connectivity_meta
+    from src.plugins.help import __plugin_meta__ as help_meta
+
+    plugins = [
+        SimpleNamespace(name="bot_status", metadata=bot_status_meta),
+        SimpleNamespace(name="connectivity", metadata=connectivity_meta),
+        SimpleNamespace(name="help", metadata=help_meta),
+    ]
+    monkeypatch.setattr("src.features.command_limits.schema.get_loaded_plugins", lambda: plugins)
 
 
 def test_list_webui_env_sections_contains_ingress_dispatch():
@@ -80,14 +95,14 @@ def test_list_webui_env_sections_hides_message_scrub_by_default(monkeypatch: pyt
     )
     monkeypatch.setattr(
         "src.foundation.config.dotenv.merged_repo_dotenv_upper",
-        lambda: {},
+        dict,
     )
     monkeypatch.setattr(
         "src.foundation.config.dotenv.repo_layered_dotenv_files_exist",
         lambda: True,
     )
-    from src.foundation.deploy_profile import clear_deploy_profile_cache
     from src.features.message_scrub import reload_message_scrub_caches
+    from src.foundation.deploy_profile import clear_deploy_profile_cache
 
     clear_deploy_profile_cache()
     reload_message_scrub_caches()
@@ -103,6 +118,7 @@ def test_list_webui_env_sections_contains_plugin_common_sections():
 
     rows = list_webui_env_sections()
     ids = {r["id"] for r in rows}
+    assert "command_limits" in ids
     assert "pallas_webui" in ids
     assert "pallas_protocol" in ids
     assert "help" in ids
@@ -122,6 +138,31 @@ def test_service_gateways_payload_shape():
     assert "pallas_image_base_url" in names
     assert "maa_public_base_url" in names
     assert "sing_enable" in names
+
+
+def test_command_limits_section_payload_shape(monkeypatch: pytest.MonkeyPatch):
+    from src.console.webui import webui_env_section_payload
+
+    _import_command_limit_plugins()
+    _patch_loaded_command_limit_plugins(monkeypatch)
+    data = webui_env_section_payload("command_limits")
+    assert data["plugin"] == "command_limits"
+    assert data["module"] == "src.features.command_limits"
+    assert "command_limits_ui" in data
+    assert any(row["id"] == "help.help" for row in data["command_limits_ui"]["commands"])
+
+
+def test_command_limits_patch_writes_json_override(tmp_path, monkeypatch):
+    import json
+
+    from src.console.webui import apply_webui_env_section_patch
+    from src.foundation.config import repo_settings as rs
+
+    webui_file = tmp_path / "webui.json"
+    monkeypatch.setattr(rs, "repo_webui_settings_path", lambda: webui_file)
+    apply_webui_env_section_patch("command_limits", {"command_limit_overrides": {"help.help": 11}})
+    data = json.loads(webui_file.read_text(encoding="utf-8"))
+    assert json.loads(data["env"]["PALLAS_COMMAND_LIMIT_OVERRIDES"]) == {"help.help": 11}
 
 
 def test_field_to_env_uppercase_keys_matches_plugin_api():
@@ -150,8 +191,8 @@ def test_pallas_webui_section_payload_env_keys_uppercase():
 def test_pallas_webui_patch_writes_uppercase_env(tmp_path, monkeypatch):
     import json
 
-    from src.foundation.config import repo_settings as rs
     from src.console.webui import apply_webui_env_section_patch
+    from src.foundation.config import repo_settings as rs
 
     webui_file = tmp_path / "webui.json"
     monkeypatch.setattr(rs, "repo_webui_settings_path", lambda: webui_file)


### PR DESCRIPTION
## Summary
- 将用户可感知的命令冷却抽成全局 command_limits 配置，并接入 WebUI common-config
- 为 help、bot_status、connectivity、draw、duel 接入统一冷却读取，保留插件内部节流逻辑不进 WebUI
- 补充命令冷却文档与测试，设计文档未纳入提交

## Test Plan
- uv run ruff check src/ tests/features/command_limits/test_command_limits.py tests/plugins/test_webui_env_sections.py tests/plugins/draw/test_draw_handler_gates.py
- uv run ruff format --check src/features/command_limits src/console/webui/env_sections.py src/console/webui/field_labels.py src/plugins/help/__init__.py src/plugins/bot_status/__init__.py src/plugins/connectivity/__init__.py src/plugins/connectivity/commands.py src/plugins/draw/__init__.py src/plugins/draw/draw.py src/plugins/duel/__init__.py src/plugins/duel/duel_round_engine.py tests/features/command_limits/test_command_limits.py tests/plugins/test_webui_env_sections.py tests/plugins/draw/test_draw_handler_gates.py
- uv run pytest tests/features/command_limits/test_command_limits.py tests/plugins/test_webui_env_sections.py tests/plugins/draw/test_draw_handler_gates.py -q

## Summary by Sourcery

通过与 WebUI 集成的统一指令冷却时间（command_limits）功能，并将其应用到多个核心插件，同时更新相关文档和测试。

新功能：
- 新增 `command_limits` 功能，用于统一管理指令冷却配置，包括元数据声明、运行时辅助工具以及基于 WebUI 的覆盖配置。
- 暴露一个新的 WebUI `common-config` 配置区域，用于管理指令冷却覆盖项，并可可视化每个指令的实际生效冷却时间。
- 提供结构化的、面向 Agent 的插件开发 Skill 文档集，为插件作者提供指导，其中包含关于 matchers、`cmd_perm`、WebUI 配置等专题章节。

增强改进：
- 重构 `help`、`bot_status`、`connectivity`、`draw` 和 `duel` 插件，使其使用统一的指令冷却辅助工具，而不是零散的 `GroupConfig` 用法，同时在需要的地方保留内部节流行为。
- 扩展现有的 WebUI 测试，并新增测试以覆盖 `command_limits` 区域的 payload、JSON 覆盖写入以及 `command_limits` 的 schema 行为。
- 更新开发者和架构文档，以反映 `src/ foundation/features/console/platform` 分层结构、新增的 `command_limits` 能力，以及更加清晰的 WebUI API 约定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a unified command cooldown (command_limits) feature with WebUI integration and apply it to several core plugins while updating related documentation and tests.

New Features:
- Add a command_limits feature to centralize command cooldown configuration, including metadata declarations, runtime helpers, and WebUI-backed overrides.
- Expose a new WebUI common-config section for managing command cooldown overrides and visualizing per-command effective cooldowns.
- Provide a structured Agent-oriented plugin development Skill documentation set to guide plugin authors, including dedicated sections on matchers, cmd_perm, WebUI config, and related topics.

Enhancements:
- Refactor help, bot_status, connectivity, draw, and duel plugins to consume the unified command cooldown helpers instead of ad-hoc GroupConfig usage, while preserving internal throttling behavior where needed.
- Extend existing WebUI tests and add new tests to cover the command_limits section payload, JSON override writing, and command_limits schema behavior.
- Update developer and architecture documentation to reflect the src/ foundation/features/console/platform layering, new command_limits capability, and clarified WebUI API contracts.

</details>