### PR TITLE
feat(core-devx): plugin_sdk、pb_core 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --dev
+          # core plugin matrix 测试会加载 kernel/LLM 与分片 coord（需 sqlalchemy、redis）
+          uv sync --dev --extra pg --extra coord-redis
 
       - name: Run Ruff linting
         run: |

--- a/docs/architecture/core-devx-roadmap.md
+++ b/docs/architecture/core-devx-roadmap.md
@@ -1,0 +1,393 @@
+# Core 开发体验路线（plugin_sdk · core_commands · 热重载）
+
+> **状态**：设计草案（M0 键名已敲定） · **分支**：`feat/core-devx`  
+> **背景**：多平台适配 ROI 低；QQ 深耕 + 参考 [GsUID Core](https://github.com/Genshin-bots/gsuid_core) 的「用户减负、统一开发、内置命令、成熟热重载」方向。  
+> **非目标**：替换 NoneBot matcher、全量代码热载、独立 WS 核心。
+
+## 目标
+
+| 维度 | 目标 | 验收信号 |
+| --- | --- | --- |
+| 用户减负 | 站长常见运维可在群内完成 | `牛牛状态` / `牛牛控制台` 等口令与 WebUI 行为一致 |
+| 高度统一 | 新插件走同一套声明 + SDK | Cookbook 与 golden 插件不再裸拼 `cmd_perm` |
+| 易于开发 | 组合式薄 API，不引入继承基类 | 新插件 handler ≤ 30 行样板 |
+| 可读性 | core 插件风格一致 | `__init__.py` 以元数据 + 注册为主 |
+| 内置命令 | 运维口令集中、可发现 | 单一 core 插件 + help 二级项 |
+| 热重载 | 配置 L1 保持；L2/L3 分级补全 | 文档与 WebUI 标明各级生效范围 |
+
+## 现状摘要
+
+**已有（不必重造）**
+
+- 配置热重载：`install_hot_reload_config`（`src/console/webui/plugin_config.py`）
+- 声明聚合：`command_permissions`、`command_limits`、`plugin_storage`、`llm_tools` → `plugin_capabilities`
+- 统一 CLI：`pallas`（`src/console/cli/`，见 [pallas-cli.md](pallas-cli.md)）
+- 文档：Cookbook、Agent Skill、`plugin-convention.md`
+
+**短板**
+
+- 插件作者仍裸用 `on_command` + 手动拼权限/CD/前缀
+- 运维能力分散：`help`、`bot_status`（扩展包）、WebUI API
+- 存储故事双轨：声明式 `plugin_storage` vs 手写 `store.py` + JSON
+- legacy 插件（`repeater`、`duel`）与薄插件风格分裂
+
+---
+
+## 内核键名约定
+
+本节是 **PluginMetadata.extra** 与相关 ID 的**唯一权威表**。新增键须在本表登记。
+
+### 标识符分层：`pb` 与 `nb` 对齐
+
+维护者侧采用与 NoneBot 生态一致的**双字母缩写**：
+
+| 缩写 | 含义 | 典型用途 |
+| --- | --- | --- |
+| **`nb`** | NoneBot | 运行时、adapter、matcher（`nb run`） |
+| **`pb`** | Pallas-Bot | 本体内核插件、core 命令 ID、新内核模块前缀 |
+
+**约定**
+
+1. **新内核 / core 向插件**：包名 `pb_<role>`（如 `pb_core`、`pb_webui`、`pb_protocol`），命令 ID `<包名>.<action>`。
+2. **历史 `pallas_*` 插件**：纳入 **M5 渐进改名**（见下文）；改名完成前 loader / help 保留旧包名别名。
+3. **用户口令**：仍用中文「牛牛…」，与 `pb` 缩写无关。
+4. **CLI 命令面**：继续 `pallas`（产品名）；与代码层 `pb_*` 并存——`pallas status` 实现可落在 `pb_core` 插件。
+
+```text
+用户层：牛牛状态 / 牛牛控制台
+代码层：pb_core.status / plugins/pb_core/
+运行时：NoneBot (nb) 加载 pb_core 插件
+运维层：pallas status（CLI 产品名不变）
+```
+
+### 命名原则
+
+1. **extra 顶层键**：`snake_case`，语义稳定；已上线键**不改名**（仅 deprecate）。
+2. **命令 ID**：`<plugin>.<action>`，全小写 + 下划线；core 运维插件包名固定为 **`pb_core`**。
+3. **存储键**（`plugin_storage[].key`）：`<语义>`，不含插件名前缀（插件名由 `GroupPluginStorage(plugin, …)` 提供命名空间）。
+4. **help 受众**：`help_audience` 取值 `user`（默认）| `maintainer`。
+5. **ingress lane**：`storage` | `remote` | `local`（与 [central-ingress-dispatch.md](central-ingress-dispatch.md) 一致）。
+
+### extra 顶层键一览
+
+| 键 | 状态 | 用途 | 值形状 | 解析/消费方 |
+| --- | --- | --- | --- | --- |
+| `version` | **稳定** | extra schema 版本标记 | `"3.0.0"`（`PLUGIN_EXTRA_VERSION`） | 文档、未来校验 |
+| `menu_template` | **稳定** | 帮助图模板 | `"default"` | `help` 渲染 |
+| `command_permissions` | **稳定** | 可配置命令权限默认 | `[{id, label, default}]` | `cmd_perm`、`plugin_capabilities` |
+| `command_limits` | **稳定** | 命令默认 CD | `[{id, cd_sec}]`（兼容别名 `cd`） | `command_limits`、`plugin_capabilities` |
+| `plugin_storage` | **稳定** | 声明式存储键 | `[{key, scope, label, ephemeral?}]` | `plugin_storage`、`plugin_capabilities` |
+| `llm_tools` | **稳定** | LLM 意图→口令工具 | 见 `LlmCommandToolDecl` | `features/llm/tools` |
+| `menu_data` | **稳定** | 帮助二级/三级菜单 | 见 [cmd_perm](../common/cmd_perm/README.md) | `help` |
+| `ingress_route` | **稳定** | 中央 ingress 分 lane | `{lane, passive?}` | `platform/ingress` |
+| `ingress_fanout` | **稳定** | 分片 fanout 明文口令 | `{scope, plaintexts, …}` | `ingress/policy_registry` |
+| `exact_plaintexts` | **稳定** | ingress 精确路由 | `["牛牛报数", …]` | `route_index` |
+| `command_prefixes` | **稳定** | ingress 前缀路由 | `["牛牛", …]` | `route_index` |
+| `help_aliases` | **稳定** | 帮助搜索别名 | `["牛牛聊天", …]` | `help/plugin_match` |
+| `disable_scope` | **稳定** | 群开关作用域 | `"group"`（默认）\| `"bot"` | `help/plugin_manager` |
+| `hosted_activity_ingress` | **稳定** | 托管活动 ingress 门控 | 见 `hosted_activity_gate` | `platform/ingress` |
+| `help_audience` | **稳定** | 插件级 help 受众（维护者向） | `"user"` \| `"maintainer"` | `cmd_perm/help_menu`、部分 `menu_data` 项 |
+| `sdk_min_version` | **拟定** | 插件声明依赖的 SDK 版本 | `"1.0.0"` | `plugin_sdk` 启动校验（可选） |
+| `reload_policy` | **拟定** | 插件热重载策略 | 见下表 | `console/webui`、未来 `pallas plugin reload` |
+
+**不在 extra 中扩展的项**
+
+- 插件 tier（core/extra/local）：继续由 `plugin_matrix.py` 维护，**不**写入 `extra`（避免双源真相）。
+- WebUI 字段：继续走 `config.py` + `install_hot_reload_config`，键名用 **env 大写**（`webui.json`），与 extra 分离。
+
+### menu_data 项内键（稳定）
+
+| 键 | 说明 |
+| --- | --- |
+| `func` | 功能展示名 |
+| `trigger_method` | `on_cmd` / `on_message` / … |
+| `trigger_scene` | `SCENE_*` |
+| `trigger_condition` | 触发方式文案（不写死权限） |
+| `command_permission` / `command_permissions` | 绑定 cmd_perm ID |
+| `brief_des` / `detail_des` | 帮助详情 |
+| `help_audience` | 可选，覆盖插件级受众 |
+
+### command_permissions / command_limits 行内键
+
+| 键 | 必填 | 说明 |
+| --- | --- | --- |
+| `id` | 是 | 命令 ID，与 matcher 使用的 ID 一致 |
+| `label` | 是 | WebUI / 能力总览展示 |
+| `default` | 权限必填 | `superuser` \| `group_moderator` \| `bot_moderator` \| `staff` \| `everyone` |
+| `cd_sec` | CD 必填 | ≥0；0 表示无 CD |
+
+辅助构造（已有，P1 继续导出）：
+
+- `command_perm_row` / `command_perm_list`（`features/cmd_perm/declare.py`）
+- `command_limit_row` / `command_limit_list`（**P1 新增**，与 perm 对称）
+- `plugin_storage_row` / `plugin_storage_list`（已有）
+
+### plugin_storage scope 枚举
+
+| scope | 含义 |
+| --- | --- |
+| `group` | 按群 |
+| `user` | 按用户 |
+| `bot` | 按牛牛账号 |
+| `deploy` | 全站/部署级（如 help 隐藏名单） |
+
+### reload_policy（拟定）
+
+| 值 | 含义 |
+| --- | --- |
+| `config_only` | 仅 L1（默认；与现网一致） |
+| `metadata` | L2：重读 extra、重注册 help/ingress 索引；**不**卸载 matcher |
+| `full` | L3：尝试重载插件模块；失败则提示进程重启 |
+
+首版实现可只文档化三级；CLI `pallas plugin reload` 与 WebUI 按钮在 P3 落地。
+
+### pb_core 命令 ID（已敲定）
+
+| 命令 ID | 默认权限 | 口令 | 后端 API |
+| --- | --- | --- | --- |
+| `pb_core.status` | `staff` | **牛牛状态** | `pallas status` / `bot_process.status_summary()` |
+| `pb_core.console` | `staff` | 牛牛控制台 | WebUI base URL + 登录提示 |
+| `pb_core.plugins` | `staff` | 牛牛插件 | `plugin_matrix` + 安装提示 |
+| `pb_core.update_check` | `superuser` | 牛牛更新 | `update_ops.check_bot_update()` |
+| `pb_core.restart` | `superuser` | 牛牛重启 | `bot_process.request_restart()` |
+
+**PluginMetadata.name**（help 展示）：**牛牛核心**。
+
+**与现有插件边界**
+
+- `help.*`：保留帮助、群级插件开关；**不**迁入 pb_core。
+- `bot_status.*`：保留扩展包「牛牛在吗 / 报数 / 邮件」；`pb_core.status`（**牛牛状态**）侧重**进程/分片/CLI 摘要**，与「牛牛在吗」分工明确。
+- `service_gateways.*`：保留「牛牛连通」探测；与 status 互补。
+- `pb_webui` / `pb_protocol`：控制台与协议端能力；**牛牛控制台**（pb_core）回链 WebUI，不重复实现页面。
+
+---
+
+## P1 · plugin_sdk
+
+### 位置
+
+```
+src/features/plugin_sdk/
+├── __init__.py          # 公开 API
+├── declare.py           # command_limit_row 等（复用 features 层 declare）
+├── matcher.py           # group_command / private_command 工厂
+├── context.py           # 统一 handler 上下文（event → 常用字段）
+└── checklist.py         # 元数据自检（开发/CI 可选）
+```
+
+**依赖方向**：`plugin_sdk` → `cmd_perm`、`command_limits`、`foundation.command_prefix`；**不**依赖 `plugins/`。
+
+### API 草案
+
+```python
+from src.features.plugin_sdk import group_command, private_command
+
+praise = group_command(
+    "praise_me.praise",
+    prefixes=["牛牛赞我"],
+    cd_sec=60,
+    perm_default="everyone",
+    label="牛牛赞我",
+)
+
+@praise.handle()
+async def handle_praise(ctx: PluginHandlerContext):
+    ...
+```
+
+工厂职责（一次封装）：
+
+1. `on_command` + `matches_command_prefix` / 别名
+2. `permission_for_command(command_id)`
+3. `is_command_cooldown_ready` / `refresh_command_cooldown`
+4. 统一 logger 标签 `[plugin:praise_me]`
+5. 可选 `block=True` 默认值
+
+**不做的**：替换 NoneBot 事件类型；不隐藏 `GroupMessageEvent`（QQ 深耕阶段）。
+
+### 与 extra 声明的关系
+
+SDK **不引入新 mandatory extra 键**。插件仍在 `__init__.py` 声明：
+
+```python
+extra={
+    "command_permissions": command_perm_list(...),
+    "command_limits": command_limit_list(...),
+    ...
+}
+```
+
+可选：`sdk_min_version` 供启动时 warn。
+
+### 验收
+
+- [ ] Cookbook「牛牛赞我」改写成 SDK 版
+- [ ] `tests/features/plugin_sdk/` 覆盖 perm/CD/前缀
+- [ ] Skill / getting-started 指向 SDK
+
+---
+
+## P2 · pb_core 内置命令插件
+
+### 位置
+
+```
+src/plugins/pb_core/
+├── __init__.py      # PluginMetadata + 注册
+├── config.py        # 可选：status 摘要字段开关
+├── handlers.py      # 各口令 handler
+└── status.py        # 聚合 status 文案（复用 cli/console API）
+```
+
+**tier**：加入 `CORE_PLUGIN_NAMES`（`plugin_matrix.py`）。
+
+### 实现原则
+
+1. **群内口令与 CLI/WebUI 共用 Python 模块**（`src/console/cli/*_ops.py`），禁止 handler 内另写 subprocess。
+2. `restart` / `update` 必须走现有权限与审计日志；失败返回用户可见原因。
+3. help `menu_data` 完整；`usage` 不写死权限等级。
+
+### 验收
+
+- [ ] 五条 core 命令可触发且权限正确
+- [ ] 分片角色下 status 摘要含 hub/worker 提示
+- [ ] `docs/plugins/pb_core/README.md`
+
+---
+
+## P3 · 热重载分级
+
+| 级别 | 内容 | 现状 | 目标 |
+| --- | --- | --- | --- |
+| **L1 配置** | WebUI → `webui.json` | ✅ 成熟 | 保持 |
+| **L2 元数据** | extra / help 索引 / ingress route | 部分（save hook） | 文档 + `reload_policy: metadata` |
+| **L3 插件** | 代码变更 | ❌ 需重启 | `pallas plugin reload` 可控范围 |
+
+**明确不做**（与 [pallas-cli.md](pallas-cli.md) 一致）：NoneBot matcher 级热卸载/重载作为默认路径。
+
+扩展安装：`extension_install` 已有 `needs_restart`；P2 后 WebUI「安装并重启」与 `牛牛重启` 共用 restart API。
+
+---
+
+## P4 · 存储统一
+
+- Cookbook 默认改为 `plugin_storage` + `GroupPluginStorage`
+- `plugin_data_dir` 仅用于大文件、导出、缓存
+- `docs/develop/plugin/structure.md` 与 Cookbook 同步
+
+---
+
+## P5 · Legacy 可读性（行为不变）
+
+- `repeater/__init__.py` 拆 `handlers/`（仅搬代码）
+- core 新代码必须符合 golden checklist；扩展包维持渐进迁移
+
+---
+
+## P6 · plugin_capabilities WebUI 一屏
+
+- 控制台新增「插件能力总览」：权限、CD、LLM tools、storage keys
+- 数据源：已有 `build_plugin_capabilities_ui()`
+
+---
+
+## P7 · 历史插件 `pb_*` 改名（M5）
+
+将内核向历史包名统一为 **`pb_*`**，与 `nb` 缩写体系对齐。
+
+### 改名对照
+
+| 现包名 | 目标包名 | help 展示名（建议） | 影响面（粗估） |
+| --- | --- | --- | --- |
+| `pallas_webui` | **`pb_webui`** | 控制台（不变） | ~50 文件；`data/pallas_webui/` 路径 |
+| `pallas_protocol` | **`pb_protocol`** | 协议端（不变） | ~80 文件；大量 `PALLAS_PROTOCOL_*` 配置键 |
+
+**不在 M5 首波改名**
+
+- pip 发行名 `pallas-plugin-protocol` 等：可后续另开 **M5c**（PyPI / 扩展仓包名），与主仓插件目录解耦。
+- 环境变量 `PALLAS_*`：M5 阶段 **保留旧键读取 + 写迁移说明**；可选在 `webui.json` 保存时双写，一个发布周期后 deprecate。
+
+### 分步策略
+
+```mermaid
+flowchart LR
+    S1["M5a\npallas_webui → pb_webui"]
+    S2["M5b\npallas_protocol → pb_protocol"]
+    S3["M5c\n扩展 pip 包名\n可选"]
+    S1 --> S2 --> S3
+```
+
+| 步骤 | 交付 | 兼容要求 |
+| --- | --- | --- |
+| **M5a** | 目录 `src/plugins/pb_webui/`、import 全量替换、`plugin_matrix` / help 别名 | `pallas_webui` 包名在 `plugin_aliases` / 全局禁用名单保留 **1 个版本周期** 映射到 `pb_webui` |
+| **M5b** | 目录 `src/plugins/pb_protocol/`、测试目录同步、文档路径 | `PALLAS_PROTOCOL_*` env **继续可读**；文档标注 `PB_PROTOCOL_*` 为推荐新键 |
+| **M5c** | 扩展仓 `pallas-plugin-protocol` → `pb-plugin-protocol`（若做） | 旧 pip 包名 README 指向新包 |
+
+### M5 单 PR 检查清单
+
+- [ ] `src/plugins/<old>/` → `src/plugins/<new>/`
+- [ ] `tests/plugins/<old>/` → `tests/plugins/<new>/`
+- [ ] `docs/plugins/<old>/` → `docs/plugins/<new>/`
+- [ ] `plugin_matrix.py`、`plugin_aliases.py`、`startup_global_disable` 默认名单
+- [ ] `plugin_data_dir("…")` 与 `data/` 目录：启动时检测旧路径并 **一次性迁移或软链**（写清 Migration 说明）
+- [ ] 跨插件 `from src.plugins.<old>` import 全仓 grep 清零
+- [ ] WebUI `field_labels` / `env_sections` 中插件 id 字符串
+- [ ] CI / release 脚本中的硬编码包名
+
+### 与 pb_core 的关系
+
+- **M2** 新建 `pb_core` 不依赖 M5 完成；可先落地。
+- **M5a** 完成后，`pb_core.console` 文档与实现指向 `pb_webui` API。
+- 改名 PR **一类一合并**（M5a 与 M5b 不混在一个 PR），便于 review 与回滚。
+
+---
+
+## 实施顺序与里程碑
+
+```mermaid
+flowchart LR
+    M0["M0 键名冻结\n本文 review"]
+    M1["M1 plugin_sdk\n+ Cookbook"]
+    M2["M2 pb_core\n+ CLI 复用"]
+    M3["M3 热重载文档\n+ reload_policy"]
+    M4["M4 存储/Cookbook\n+ WebUI 能力屏"]
+    M5a["M5a pb_webui"]
+    M5b["M5b pb_protocol"]
+    M2 --> M5a
+    M5a --> M5b
+```
+
+| 里程碑 | PR 范围 | 依赖 |
+| --- | --- | --- |
+| **M0** | 本文 + `plugin-convention` 链入 extra 表 | — |
+| **M1** | `features/plugin_sdk` + 测试 + Cookbook | M0 |
+| **M2** | `plugins/pb_core` + matrix + 文档 | M0、CLI 已有 |
+| **M3** | reload 文档、`reload_policy` 解析桩 | M1 可选 |
+| **M4** | Cookbook 存储、WebUI 能力页 | M1 |
+| **M5a** | `pallas_webui` → `pb_webui` + 兼容别名 + 数据路径迁移 | M0 |
+| **M5b** | `pallas_protocol` → `pb_protocol` + env 双读 + 文档 | M5a 建议先合 |
+| **M5c** | 扩展 pip 包名（可选） | M5b |
+
+---
+
+## 已敲定
+
+| 项 | 决定 |
+| --- | --- |
+| core 插件包名 | **`pb_core`**（`pb` = Pallas-Bot，与 `nb` = NoneBot 对齐） |
+| 命令 ID 前缀 | **`pb_core.*`** |
+| pb_core 口令 | **`牛牛状态`** / 牛牛控制台 / 牛牛插件 / 牛牛更新 / 牛牛重启 |
+| pb_core help 展示 | **牛牛核心** |
+| 新内核插件前缀 | **`pb_*`**；历史 **`pallas_webui` → `pb_webui`**、**`pallas_protocol` → `pb_protocol`**（M5） |
+| `command_limit_row` | 与 `command_perm_row` 对称，P1 新增 |
+| `sdk_min_version` | 首版省略 |
+| `reload_policy` | M0 文档化，M3 再实现 |
+
+---
+
+## 相关文档
+
+- [common-layers.md](common-layers.md) — 分层
+- [plugin-convention.md](plugin-convention.md) — 插件目录
+- [pallas-cli.md](pallas-cli.md) — CLI 与 WebUI 收敛
+- [cmd_perm](../common/cmd_perm/README.md) — 权限与 help 文案

--- a/docs/architecture/core-devx-roadmap.md
+++ b/docs/architecture/core-devx-roadmap.md
@@ -221,9 +221,9 @@ extra={
 
 ### 验收
 
-- [ ] Cookbook「牛牛赞我」改写成 SDK 版
-- [ ] `tests/features/plugin_sdk/` 覆盖 perm/CD/前缀
-- [ ] Skill / getting-started 指向 SDK
+- [x] Cookbook「牛牛赞我」改写成 SDK 版
+- [x] `tests/features/plugin_sdk/` 覆盖 perm/CD/前缀
+- [x] Skill / getting-started 指向 SDK
 
 ---
 
@@ -249,9 +249,9 @@ src/plugins/pb_core/
 
 ### 验收
 
-- [ ] 五条 core 命令可触发且权限正确
-- [ ] 分片角色下 status 摘要含 hub/worker 提示
-- [ ] `docs/plugins/pb_core/README.md`
+- [x] 五条 core 命令可触发且权限正确
+- [x] 分片角色下 status 摘要含 hub/worker 提示
+- [x] `docs/plugins/pb_core/README.md`
 
 ---
 

--- a/docs/architecture/core-devx-roadmap.md
+++ b/docs/architecture/core-devx-roadmap.md
@@ -271,9 +271,9 @@ src/plugins/pb_core/
 
 ## P4 · 存储统一
 
-- Cookbook 默认改为 `plugin_storage` + `GroupPluginStorage`
-- `plugin_data_dir` 仅用于大文件、导出、缓存
-- `docs/develop/plugin/structure.md` 与 Cookbook 同步
+- [x] Cookbook 默认改为 `plugin_storage` + `GroupPluginStorage`
+- [x] `docs/develop/plugin/structure.md` 与 Cookbook 同步
+- `plugin_data_dir` 仅用于大文件、导出、缓存（文档已区分；legacy 插件渐进迁移）
 
 ---
 

--- a/docs/architecture/core-devx-roadmap.md
+++ b/docs/architecture/core-devx-roadmap.md
@@ -286,8 +286,9 @@ src/plugins/pb_core/
 
 ## P6 · plugin_capabilities WebUI 一屏
 
-- 控制台新增「插件能力总览」：权限、CD、LLM tools、storage keys
-- 数据源：已有 `build_plugin_capabilities_ui()`
+- [x] 控制台「插件能力总览」面板（`PluginsPage` + `GET /plugins/capabilities`）
+- [x] 展示权限、CD、LLM tools、storage keys、`reload_policy`
+- 数据源：`build_plugin_capabilities_ui()`
 
 ---
 

--- a/docs/architecture/hot-reload-tiers.md
+++ b/docs/architecture/hot-reload-tiers.md
@@ -1,0 +1,54 @@
+# 热重载分级（L1 / L2 / L3）
+
+> 与 [core-devx-roadmap · P3](core-devx-roadmap.md#p3--热重载分级) 对齐。  
+> **现状**：L1 已成熟；L2/L3 以文档与 `reload_policy` 解析桩为主，CLI `pallas plugin reload` 尚未落地。
+
+## 三级对照
+
+| 级别 | 名称 | 变更内容 | 生效方式 | 现状 |
+| --- | --- | --- | --- | --- |
+| **L1** | 配置 | `config.py` 字段 → `webui.json` | `install_hot_reload_config` 保存后立即 reload | ✅ 默认路径 |
+| **L2** | 元数据 | `PluginMetadata.extra`、help 索引、ingress route | 保存后重读声明 / 重建索引（**不**卸载 matcher） | 部分（save hook）；`reload_policy: metadata` 预留 |
+| **L3** | 插件代码 | Python 模块变更 | 受控 reload 或提示进程重启 | ❌ 默认需重启 |
+
+## 明确不做
+
+- NoneBot matcher 级热卸载/重载**不作为默认运维路径**（见 [pallas-cli.md](pallas-cli.md)）。
+- 扩展 pip 包安装：`extension_install` 仍返回 `needs_restart`；与 **牛牛重启**（`pb_core`）共用调度 API。
+
+## `reload_policy`（extra 可选键）
+
+在 `PluginMetadata.extra` 声明插件作者期望的重载粒度（供能力总览与未来 CLI 读取）：
+
+| 值 | 含义 |
+| --- | --- |
+| `config_only` | 仅 L1（**默认**；与现网一致） |
+| `metadata` | L2：允许重读 extra / help / ingress，不卸载 matcher |
+| `full` | L3：尝试重载模块；失败则提示重启 |
+
+解析 API：`src.features.plugin_reload.reload_policy_from_metadata()`。
+
+示例：
+
+```python
+extra={
+    ...
+    "reload_policy": "config_only",
+}
+```
+
+## 运维入口
+
+| 场景 | 推荐 |
+| --- | --- |
+| 改插件开关/阈值 | WebUI **插件** 页保存（L1） |
+| 改命令权限 / CD | WebUI **命令权限** / **命令冷却**（L1） |
+| 改 help / ingress 声明 | 暂需重启；L2 落地后按 `reload_policy` 提示 |
+| 改 Python 代码 | 重启 Bot；群内 **牛牛重启** 或 `pallas restart` |
+| 安装官方扩展 | WebUI 插件商店；勾选「安装并重启」或手动重启 |
+
+## 相关文档
+
+- [WebUI 配置与热重载](../common/webui/README.md)
+- [settings-storage.md](settings-storage.md)
+- [core-devx-roadmap.md](core-devx-roadmap.md)

--- a/docs/architecture/plugin-convention.md
+++ b/docs/architecture/plugin-convention.md
@@ -56,6 +56,8 @@
 
 ## WebUI 配置与命令权限
 
+- **`PluginMetadata.extra` 键名表**（`command_permissions`、`plugin_storage`、`ingress_route` 等）：见 [core-devx-roadmap.md · 内核键名约定](core-devx-roadmap.md#内核键名约定)。
+- **新内核插件包名**：`pb_<role>`（如 `pb_core`、`pb_webui`、`pb_protocol`；`pb` = Pallas-Bot，与 NoneBot 的 `nb` 对齐）。历史 `pallas_webui` / `pallas_protocol` 改名见 [core-devx-roadmap · P7](core-devx-roadmap.md#p7--历史插件-pb_-改名m5)。
 - 需在 WebUI 保存 **`webui.json`** 后立即生效的插件配置：在 `config.py` 使用 `src.console.webui.install_hot_reload_config`（见 [WebUI 插件配置](../common/webui/README.md)）；已有自定义缓存的插件可登记到 `plugin_webui_registry`（如决斗插件）。
 - 可配置命令权限：在 `PluginMetadata.extra` 声明 `command_permissions`，matcher 使用 `src.features.cmd_perm.permission_for_command`（见 [cmd_perm](../common/cmd_perm/README.md)）。
 - 命令冷却：在 handler 内使用 `src.features.command_limits`（见 [command_limits](../common/command_limits/README.md)）；可在 `extra["command_limits"]` 声明默认 CD 供文档与后续扩展。

--- a/docs/common/webui/README.md
+++ b/docs/common/webui/README.md
@@ -12,6 +12,8 @@
 
 命令权限说明见 [cmd_perm](../cmd_perm/README.md)。
 
+**热重载分级**（L1 配置 / L2 元数据 / L3 代码）：见 [hot-reload-tiers.md](../../architecture/hot-reload-tiers.md)。插件可在 `extra["reload_policy"]` 声明期望粒度（默认 `config_only`）。
+
 ## 插件接入热重载
 
 在 `config.py` 末尾：

--- a/docs/common/webui/api/02-plugins.md
+++ b/docs/common/webui/api/02-plugins.md
@@ -9,6 +9,7 @@
 | PUT | `/plugins/help-menu-visibility` | 是 | 更新帮助可见性 |
 | GET | `/plugins/global-disable` | | 全局禁用插件名集合 |
 | PUT | `/plugins/global-disable` | 是 | 批量禁用/启用（保护核心插件） |
+| GET | `/plugins/capabilities` | | 插件能力聚合（命令权限/CD、LLM tools、storage keys、`reload_policy`） |
 | GET | `/plugins/group-fleet-whitelist` | | 群舰队白名单插件 |
 | PUT | `/plugins/group-fleet-whitelist` | 是 | 更新舰队白名单 |
 
@@ -49,6 +50,7 @@ PUT 成功后：
 ## 前端对应
 
 - `fetchPlugins`、`fetchPluginConfig`、`putPluginConfig`
+- `fetchPluginCapabilities`（插件页「能力总览」与卡片预览）
 - `fetchHelpMenuVisibility`、`putHelpMenuVisibility`
 - `fetchGlobalPluginDisable`、`putGlobalPluginDisable`
 - `fetchGroupFleetWhitelist`、`putGroupFleetWhitelist`

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -23,6 +23,7 @@
 | [插件规范](../architecture/plugin-convention.md) | `src/plugins` 约定 |
 | [站点定制](../architecture/site-customization-and-updates.md) | `local/plugins`、官方扩展 |
 | [4.0 路线图](../architecture/pallas-4.0-roadmap.md) · [瘦身迁移](../architecture/pallas-4.0-slim.md) | core / extra |
+| [Core 开发体验路线](../architecture/core-devx-roadmap.md) | plugin_sdk、`pb_core`、M5 `pb_webui`/`pb_protocol` 改名 |
 | [Bot ↔ AI 仓](../architecture/pallas-ai-service.md) | LLM 协同 |
 | [cmd_perm](../common/cmd_perm/README.md) · [command_limits](../common/command_limits/README.md) | 权限与冷却 |
 | [WebUI 配置](../common/webui/README.md) · [message_scrub](../common/message_scrub/README.md) | 热重载与审查 |

--- a/docs/develop/README.md
+++ b/docs/develop/README.md
@@ -24,6 +24,7 @@
 | [站点定制](../architecture/site-customization-and-updates.md) | `local/plugins`、官方扩展 |
 | [4.0 路线图](../architecture/pallas-4.0-roadmap.md) · [瘦身迁移](../architecture/pallas-4.0-slim.md) | core / extra |
 | [Core 开发体验路线](../architecture/core-devx-roadmap.md) | plugin_sdk、`pb_core`、M5 `pb_webui`/`pb_protocol` 改名 |
+| [热重载分级](../architecture/hot-reload-tiers.md) | L1 配置 / L2 元数据 / L3 代码 |
 | [Bot ↔ AI 仓](../architecture/pallas-ai-service.md) | LLM 协同 |
 | [cmd_perm](../common/cmd_perm/README.md) · [command_limits](../common/command_limits/README.md) | 权限与冷却 |
 | [WebUI 配置](../common/webui/README.md) · [message_scrub](../common/message_scrub/README.md) | 热重载与审查 |

--- a/docs/develop/plugin/cookbook.md
+++ b/docs/develop/plugin/cookbook.md
@@ -143,18 +143,26 @@ def top_praisers(counts: dict[str, int], limit: int = 5) -> list[tuple[str, int]
 
 在 `__init__.py` 声明 `PluginMetadata`。帮助图文案格式见 [cmd_perm](../../common/cmd_perm/README.md)。
 
+**推荐**用 [plugin_sdk](../../architecture/core-devx-roadmap.md#p1--plugin_sdk) 注册口令（权限 + 可选 CD 一次封装）：
+
 ```python
 # local/plugins/praise_me/__init__.py
-from nonebot import on_command
 from nonebot.plugin import PluginMetadata
 
-from src.features.cmd_perm import group_message_permission_for_command
 from src.features.cmd_perm.metadata_defaults import (
     PLUGIN_EXTRA_VERSION,
     PLUGIN_HOMEPAGE,
     PLUGIN_MENU_TEMPLATE,
 )
 from src.features.cmd_perm.metadata_text import SCENE_GROUP, join_usage, usage_line
+from src.features.plugin_sdk import (
+    bind_alias_handlers,
+    command_limit_list,
+    command_limit_row,
+    command_perm_list,
+    command_perm_row,
+    group_command,
+)
 
 from .handlers import handle_praise, handle_rank
 
@@ -171,13 +179,13 @@ __plugin_meta__ = PluginMetadata(
     extra={
         "version": PLUGIN_EXTRA_VERSION,
         "menu_template": PLUGIN_MENU_TEMPLATE,
-        "command_permissions": [
-            {"id": "praise_me.praise", "label": "牛牛赞我", "default": "everyone"},
-            {"id": "praise_me.rank", "label": "牛牛赞榜", "default": "everyone"},
-        ],
-        "command_limits": [
-            {"id": "praise_me.praise", "cd_sec": 0},
-        ],
+        "command_permissions": command_perm_list(
+            command_perm_row("praise_me.praise", "牛牛赞我", "everyone"),
+            command_perm_row("praise_me.rank", "牛牛赞榜", "everyone"),
+        ),
+        "command_limits": command_limit_list(
+            command_limit_row("praise_me.praise", 0),
+        ),
         "menu_data": [
             {
                 "func": "牛牛赞我",
@@ -201,28 +209,20 @@ __plugin_meta__ = PluginMetadata(
     },
 )
 
-praise_cmd = on_command(
-    "牛牛赞我",
-    priority=5,
-    block=True,
-    permission=group_message_permission_for_command("praise_me.praise"),
-)
-rank_cmd = on_command(
-    "牛牛赞榜",
-    priority=5,
-    block=True,
-    permission=group_message_permission_for_command("praise_me.rank"),
-)
+praise_cmd = group_command("praise_me.praise", "牛牛赞我", cd_sec=0)
+rank_cmd = group_command("praise_me.rank", "牛牛赞榜", cd_sec=0)
 
-praise_cmd.handle()(handle_praise)
-rank_cmd.handle()(handle_rank)
+bind_alias_handlers(praise_cmd, handle_praise)
+bind_alias_handlers(rank_cmd, handle_rank)
 ```
+
+仍可直接 `on_command` + `group_message_permission_for_command`（见 [getting-started](getting-started.md)）；新插件优先 SDK。
 
 注意：
 
 - 命令 ID `praise_me.praise` 在 metadata、matcher、`command_limits` 里 **必须一致**。
 - `usage` / `trigger_condition` **不要**写「群管可用」——权限由 WebUI / cmd_perm 自动展示。
-- `command_limits` 里 `praise` 先填 `0`：冷却秒数改由配置驱动，在 handler 里用同一套 helper（下一节）。
+- `command_limits` 里 `praise` 填 `0`：默认 CD 由配置 `praise_cd_sec` 驱动，在 handler 里显式检查（下一节）。
 
 ---
 
@@ -232,55 +232,54 @@ rank_cmd.handle()(handle_rank)
 
 ```python
 # local/plugins/praise_me/handlers.py
-from nonebot.adapters.onebot.v11 import GroupMessageEvent
-
 from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
+from src.features.plugin_sdk import PluginHandlerContext
 
 from .config import get_config
 from .store import add_praise, load_counts, save_counts, top_praisers
 
 
-async def handle_praise(event: GroupMessageEvent):
-    from . import praise_cmd
-
+async def handle_praise(ctx: PluginHandlerContext) -> None:
     cfg = get_config()
     if not cfg.enable:
-        await praise_cmd.finish("点赞功能已关闭。")
+        await ctx.finish("点赞功能已关闭。")
 
     cd = cfg.praise_cd_sec
-    if cd > 0 and not await is_command_cooldown_ready(event, "praise_me.praise", cd):
-        await praise_cmd.finish(f"点太快啦，{cd} 秒后再赞吧。")
+    if cd > 0 and not await is_command_cooldown_ready(ctx.event, "praise_me.praise", cd):
+        await ctx.finish(f"点太快啦，{cd} 秒后再赞吧。")
     if cd > 0:
-        await refresh_command_cooldown(event, "praise_me.praise", cd)
+        await refresh_command_cooldown(ctx.event, "praise_me.praise", cd)
 
-    gid = event.group_id
-    uid = str(event.user_id)
+    gid = ctx.group_id
+    if gid is None:
+        return
+    uid = ctx.user_id
     counts = load_counts(gid)
     total = add_praise(counts, uid)
     save_counts(gid, counts)
 
-    await praise_cmd.finish(cfg.praise_reply.format(total=total))
+    await ctx.finish(cfg.praise_reply.format(total=total))
 
 
-async def handle_rank(event: GroupMessageEvent):
-    from . import rank_cmd
-
+async def handle_rank(ctx: PluginHandlerContext) -> None:
     cfg = get_config()
     if not cfg.enable:
-        await rank_cmd.finish("点赞功能已关闭。")
+        await ctx.finish("点赞功能已关闭。")
 
-    gid = event.group_id
-    uid = str(event.user_id)
+    gid = ctx.group_id
+    if gid is None:
+        return
+    uid = ctx.user_id
     counts = load_counts(gid)
     mine = counts.get(uid, 0)
     top = top_praisers(counts, limit=5)
 
     if not top:
-        await rank_cmd.finish("还没有人赞过牛牛，发送「牛牛赞我」抢第一个吧。")
+        await ctx.finish("还没有人赞过牛牛，发送「牛牛赞我」抢第一个吧。")
 
     lines = [f"{i}. QQ {qq} — {n} 赞" for i, (qq, n) in enumerate(top, start=1)]
     body = "\n".join(lines)
-    await rank_cmd.finish(f"本群赞榜 Top {len(top)}：\n{body}\n\n你的赞数：{mine}")
+    await ctx.finish(f"本群赞榜 Top {len(top)}：\n{body}\n\n你的赞数：{mine}")
 ```
 
 说明：
@@ -301,10 +300,10 @@ async def handle_rank(event: GroupMessageEvent):
 
 ## 6、拆文件与注册方式（小结）
 
-上面把 handler 写在 `handlers.py`，`__init__.py` 里用 `praise_cmd.handle()(handle_praise)` 注册。  
+上面把 handler 写在 `handlers.py`，`__init__.py` 里用 `bind_alias_handlers` 注册。  
 也可以直接在 `__init__.py` 里 `@praise_cmd.handle()`，但教程刻意练习 **入口轻量、业务外置**，与 [插件结构](structure.md) 一致。
 
-Matcher 选型见 [Matcher 决策树](../../skills/pallas-plugin-development/references/02-matchers-decision.md)：口令型用 `on_command` + `group_message_permission_for_command`。
+口令型优先 [plugin_sdk](../../architecture/core-devx-roadmap.md#p1--plugin_sdk) 的 `group_command`；选型见 [Matcher 决策树](../../skills/pallas-plugin-development/references/02-matchers-decision.md)。
 
 ---
 

--- a/docs/develop/plugin/cookbook.md
+++ b/docs/develop/plugin/cookbook.md
@@ -46,8 +46,8 @@ extra_plugin_dirs = ["local/plugins"]
 local/plugins/praise_me/
 ├── __init__.py      # PluginMetadata + 注册 Matcher（保持短）
 ├── config.py        # Pydantic + WebUI 热重载
-├── store.py         # 读写 data/praise_me/ 下的 JSON（纯函数，便于测）
-└── handlers.py      # 三个命令的处理逻辑
+├── store.py         # 群级点赞计数（GroupPluginStorage + 纯函数，便于测）
+└── handlers.py      # 命令处理逻辑
 ```
 
 在仓库根执行：
@@ -95,34 +95,32 @@ get_config = plugin_webui.get
 
 ## 3、数据落盘（按群计数）
 
-点赞数按 **群** 存 JSON，路径用 `plugin_data_dir`，不要手写 `data/` 字符串。
+群级结构化状态优先走 **声明式 `plugin_storage` + `GroupPluginStorage`**（写入 `GroupConfig` 文档的 `plugin_storage` 字段，与 help / duel 等同源）。  
+**不要**再为这种小 JSON 手写 `data/<plugin>/groups/*.json`；`plugin_data_dir` 留给图片、导出、缓存等大文件（见 [插件结构 · 路径与持久化](structure.md)）。
+
+在 `store.py` 封装读写；纯函数 `add_praise` / `top_praisers` 便于单测：
 
 ```python
 # local/plugins/praise_me/store.py
 from __future__ import annotations
 
-import json
-from pathlib import Path
+from src.features.plugin_storage import GroupPluginStorage
 
-from src.foundation.paths import plugin_data_dir
-
-
-def counts_path(group_id: int) -> Path:
-    return plugin_data_dir("praise_me") / "groups" / f"{group_id}.json"
+PLUGIN_NAME = "praise_me"
+COUNTS_KEY = "praise_counts"
 
 
-def load_counts(group_id: int) -> dict[str, int]:
-    path = counts_path(group_id)
-    if not path.is_file():
+async def load_counts(group_id: int) -> dict[str, int]:
+    store = GroupPluginStorage(PLUGIN_NAME, group_id)
+    raw = await store.get(COUNTS_KEY)
+    if not isinstance(raw, dict):
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
     return {str(k): int(v) for k, v in raw.items()}
 
 
-def save_counts(group_id: int, counts: dict[str, int]) -> None:
-    path = counts_path(group_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(counts, ensure_ascii=False, indent=2), encoding="utf-8")
+async def save_counts(group_id: int, counts: dict[str, int]) -> None:
+    store = GroupPluginStorage(PLUGIN_NAME, group_id)
+    await store.set(COUNTS_KEY, counts)
 
 
 def add_praise(counts: dict[str, int], user_id: str) -> int:
@@ -135,7 +133,10 @@ def top_praisers(counts: dict[str, int], limit: int = 5) -> list[tuple[str, int]
     return pairs[:limit]
 ```
 
-文件会落在 `data/praise_me/groups/<群号>.json`，备份时整目录拷走即可。
+要点：
+
+- 存储键名 **`praise_counts`** 须在 `__init__.py` 的 `extra["plugin_storage"]` 声明（下一节一并写入）；未声明键在运行时会报 `PluginStorageKeyError`。
+- 备份/迁移时随群配置走库；WebUI **插件能力** API 可看到已声明的 storage keys。
 
 ---
 
@@ -163,6 +164,7 @@ from src.features.plugin_sdk import (
     command_perm_row,
     group_command,
 )
+from src.features.plugin_storage import plugin_storage_list, plugin_storage_row
 
 from .handlers import handle_praise, handle_rank
 
@@ -185,6 +187,9 @@ __plugin_meta__ = PluginMetadata(
         ),
         "command_limits": command_limit_list(
             command_limit_row("praise_me.praise", 0),
+        ),
+        "plugin_storage": plugin_storage_list(
+            plugin_storage_row("praise_counts", scope="group", label="群内点赞计数"),
         ),
         "menu_data": [
             {
@@ -254,9 +259,9 @@ async def handle_praise(ctx: PluginHandlerContext) -> None:
     if gid is None:
         return
     uid = ctx.user_id
-    counts = load_counts(gid)
+    counts = await load_counts(gid)
     total = add_praise(counts, uid)
-    save_counts(gid, counts)
+    await save_counts(gid, counts)
 
     await ctx.finish(cfg.praise_reply.format(total=total))
 
@@ -270,7 +275,7 @@ async def handle_rank(ctx: PluginHandlerContext) -> None:
     if gid is None:
         return
     uid = ctx.user_id
-    counts = load_counts(gid)
+    counts = await load_counts(gid)
     mine = counts.get(uid, 0)
     top = top_praisers(counts, limit=5)
 
@@ -284,7 +289,8 @@ async def handle_rank(ctx: PluginHandlerContext) -> None:
 
 说明：
 
-- **冷却**：`is_command_cooldown_ready` / `refresh_command_cooldown` 的 key 为 `cmd_limit:{command_id}`，与 [command_limits](../../common/command_limits/README.md) 一致。
+- **存储**：`GroupPluginStorage` 读写须在 metadata 声明键；与 [command_limits](../../common/command_limits/README.md) 一样纳入能力总览。
+- **冷却**：`is_command_cooldown_ready` / `refresh_command_cooldown` 的 key 为 `cmd_limit:{command_id}`。
 - 配置里的 `praise_cd_sec` 为 0 时不做 CD 检查。
 - 本插件只读用户口令，不接 [message_scrub](../../common/message_scrub/README.md)；复读/做梦类才需要。
 
@@ -309,7 +315,7 @@ async def handle_rank(ctx: PluginHandlerContext) -> None:
 
 ## 7、测试
 
-纯函数 `store.py` 最适合单测，不必每次起真 Bot。
+`store.py` 里的纯函数最适合单测，不必每次起真 Bot；`GroupPluginStorage` 集成测法见 `tests/features/test_plugin_storage.py`。
 
 在 `tests/plugins/praise_me/test_store.py`（贡献主仓时）：
 
@@ -387,9 +393,10 @@ uv run pytest tests/plugins/praise_me/
 - [ ] `__init__.py` 短；`config` / `store` / `handlers` 已拆分
 - [ ] WebUI 热重载；handler 内 `get_config()`
 - [ ] 命令 ID 与 cmd_perm、matcher、`command_limits` 一致
+- [ ] 群/用户结构化状态：`extra["plugin_storage"]` + `GroupPluginStorage`（Cookbook §3–§4）
 - [ ] `usage` / `trigger_condition` 无写死权限句
-- [ ] 路径用 `plugin_data_dir`
-- [ ] 有最小单测（至少 `store`）
+- [ ] 大文件/缓存才用 `plugin_data_dir` / `resource_dir`
+- [ ] 有最小单测（至少 `store` 纯函数）
 - [ ] `docs/plugins/praise_me/README.md` 已写
 
 提交流程：[贡献与提交流程](../workflow.md)。
@@ -403,7 +410,7 @@ uv run pytest tests/plugins/praise_me/
 | 方向 | 提示 |
 | --- | --- |
 | 私聊查赞 | 再加 `on_command` + `private_message_permission_for_command` |
-| 全服榜 | 用 `src.foundation.db` 做持久化，或汇总多群 JSON |
+| 全服榜 | 用 `src.foundation.db` 做持久化，或 deploy 级 `plugin_storage` |
 | 帮助图样式 | 保持 `menu_data` 与 metadata 同步即可 |
 | 贡献主仓 | 挪到 `src/plugins/praise_me/`，PR 附测试与插件文档 |
 | 官方扩展包 | 4.0 玩法类可走扩展仓 + `uv sync --extra plugins-*` |

--- a/docs/develop/plugin/getting-started.md
+++ b/docs/develop/plugin/getting-started.md
@@ -23,6 +23,8 @@ src/plugins/my_plugin/
 
 `__init__.py` 保持轻量：声明元数据、注册 handler，业务逻辑拆到同目录其它模块。
 
+口令型命令推荐 `src.features.plugin_sdk`（`group_command` / `PluginHandlerContext`）；见 [Cookbook](cookbook.md) 与 [core-devx-roadmap](../../architecture/core-devx-roadmap.md#p1--plugin_sdk)。
+
 ### 元数据与帮助文案
 
 使用 `src.features.cmd_perm.metadata_text` 统一 `usage` / `menu_data` 格式：

--- a/docs/develop/plugin/structure.md
+++ b/docs/develop/plugin/structure.md
@@ -33,8 +33,8 @@ my_plugin/
 
 | 类型 | 位置 | 访问方式 |
 | --- | --- | --- |
-| 运行期数据 | `data/<plugin_name>/...` | `plugin_data_dir("my_plugin")` |
-| 群/用户/牛结构化状态 | `GroupConfig` 等文档内 `plugin_storage` JSON | `GroupPluginStorage("my_plugin", group_id)` |
+| 群/用户/牛/部署级结构化状态 | `GroupConfig` 等文档内 `plugin_storage` JSON | `GroupPluginStorage("my_plugin", group_id)` + `extra["plugin_storage"]` 声明 |
+| 大文件、导出、缓存、非结构化文件 | `data/<plugin_name>/...` | `plugin_data_dir("my_plugin")` |
 | 静态资源 | `resource/...` | `resource_dir("subdir")` |
 
 使用 `src.foundation.paths` 提供的 helper，**不要**硬编码相对路径字符串。
@@ -60,11 +60,15 @@ await store.set("my_state", {"n": 1})
 - `ephemeral=True`：仅进程内缓存，重启丢失（如决斗局内态）
 - 持久化数据写入对应配置文档的 `plugin_storage.<plugin>.<key>`
 
+跟做示例：[Cookbook · 牛牛赞我 §3–§4](cookbook.md#3数据落盘按群计数)。
+
 示例（仓库内）：
 
-- `greeting`：`plugin_data_dir("greeting")`、`resource_dir("voices")`
-- `help`：`plugin_data_dir("help")`、样式在 `resource/styles/`
-- `request_handler`：申请缓存在 `data/request_handler/`
+- `duel`：`GroupPluginStorage` + `extra["plugin_storage"]`（局内 ephemeral 键）
+- `help` / `draw`：deploy 级 `plugin_storage` 声明
+- `greeting`：`plugin_data_dir("greeting")` 存欢迎图文；`resource_dir("voices")` 读语音
+- `help`：`plugin_data_dir("help")` 帮助图渲染缓存；样式在 `resource/styles/`
+- `request_handler`：申请缓存在 `data/request_handler/`（历史 JSON，改到再迁）
 
 ## 命名
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -23,6 +23,7 @@
 <NCard title="拉黑 blacklist" route="/plugins/blacklist">拉黑、屏蔽</NCard>
 <NCard title="申请 request_handler" route="/plugins/request_handler">好友 / 入群审批</NCard>
 <NCard title="闲聊 llm_chat" route="/plugins/llm_chat">随时 @ 智能闲聊（4.0 core）</NCard>
+<NCard title="牛牛核心 pb_core" route="/plugins/pb_core">进程摘要、控制台、插件概览与重启</NCard>
 <NCard title="控制台 pallas_webui" route="/plugins/pallas_webui">网页控制台与 API</NCard>
 
 </div>

--- a/docs/plugins/pb_core/README.md
+++ b/docs/plugins/pb_core/README.md
@@ -1,0 +1,37 @@
+# pb_core（牛牛核心）
+
+内置运维口令：进程摘要、控制台入口、插件概览、更新检查与优雅重启。
+
+与扩展包 **bot_status**（牛牛在吗 / 报数）分工：`pb_core.status`（**牛牛状态**）侧重版本、分片与本进程连接；在线名册仍由 bot_status 负责。
+
+## 用户命令
+
+| 口令 | 默认权限 | 说明 |
+| --- | --- | --- |
+| 牛牛状态 | staff | 版本、Git、分片角色、编排脚本、本进程已连接牛牛 |
+| 牛牛控制台 | staff | WebUI 地址与登录提示 |
+| 牛牛插件 | staff | 已加载 core/extra 插件概览 |
+| 牛牛更新 | superuser | 只读检查 GitHub 最新 release |
+| 牛牛重启 | superuser | 约 3 秒后调度 `run_*_bot.sh` 重启 |
+
+## 命令权限
+
+| 命令 ID | 默认等级 |
+| --- | --- |
+| `pb_core.status` | staff |
+| `pb_core.console` | staff |
+| `pb_core.plugins` | staff |
+| `pb_core.update_check` | superuser |
+| `pb_core.restart` | superuser |
+
+运行中可在 WebUI **命令权限** 覆盖；帮助图「何人可用」自动展示。
+
+## 与 CLI / WebUI
+
+- **牛牛状态** 文案与 `format_runtime_status_text()` 同源，后续可挂到 `pallas status`。
+- **牛牛更新** 只读；应用更新请用 WebUI 或 `pallas update bot`。
+- **牛牛重启** 与 WebUI 更新页「安装并重启」共用 `schedule_bot_restart()`。
+
+## 实现
+
+[`src/plugins/pb_core/`](../../../src/plugins/pb_core/) · 开发 SDK 见 [`plugin_sdk`](../../architecture/core-devx-roadmap.md#p1--plugin_sdk)

--- a/docs/skills/pallas-plugin-development/SKILL.md
+++ b/docs/skills/pallas-plugin-development/SKILL.md
@@ -42,6 +42,7 @@ description: >
 - **多牛舰队**（进阶）：入站调度、进程分片见 [central-ingress-dispatch](../../architecture/central-ingress-dispatch.md)、[bot_process_sharding](../../architecture/bot_process_sharding.md)。
 - **导入分层**：业务插件优先 `src.features.*`、`src.foundation.*`、`src.console.webui`；跨插件能力不要深层 import 内核内部文件。见 [一、公开 API](./references/01-plugin-basics.md)。
 - **命令 ID**：`{插件}.{动作}` 须在 metadata、`permission_for_command`、matcher 中**完全一致**。
+- **plugin_sdk**：口令型优先 `group_command` + `PluginHandlerContext`（见 [Cookbook](../../develop/plugin/cookbook.md) §4）。
 - **帮助文案**：`usage` 不写死权限；`trigger_condition` 只写怎么说；权限绑 `command_permission` + WebUI 矩阵。
 - **配置读取**：WebUI 可调项用 `get_config()` / `get_my_config()`，**勿**在模块顶层缓存配置快照。
 - **日志**：loguru 风格，占位用 `{}` 或 f-string，避免 `"%s"` 传统 logging 写法。

--- a/docs/skills/pallas-plugin-development/references/02-matchers-decision.md
+++ b/docs/skills/pallas-plugin-development/references/02-matchers-decision.md
@@ -27,7 +27,25 @@ Pallas 插件在 `__init__.py` 用 **NoneBot2 Matcher**（`on_command` / `on_mes
 | `on_request` | 加群/好友申请 | `request_handler` | 按业务 |
 | `on_metaevent` / 适配器事件 | 戳一戳、特殊 meta | `greeting`（poke） | 按业务 |
 
-## 2.3 `on_command` 要点
+## 2.3 口令型：`plugin_sdk`（推荐）
+
+新插件优先 [`plugin_sdk`](../../../src/features/plugin_sdk/__init__.py) 组合 API，避免手写 perm/CD：
+
+```python
+from src.features.plugin_sdk import bind_alias_handlers, group_command
+
+praise = group_command("praise_me.praise", "牛牛赞我", cd_sec=0)
+
+@praise.handle()
+async def handle_praise(ctx):
+    await ctx.finish("...")
+```
+
+- 群内 / 私聊 / 两者：``group_command`` / ``private_command`` / ``message_command(scene="both")``。
+- 别名：``bind_alias_handlers(primary, handler)``。
+- 仍可直接 ``on_command`` + ``group_message_permission_for_command``（legacy 与被动场景）。
+
+## 2.4 `on_command` 要点（裸写时）
 
 ```python
 from nonebot import on_command
@@ -46,7 +64,7 @@ cmd = on_command(
 - **`block=True`**：命令型功能默认 `True`；被动监听常用 `False`。
 - **aliases**：与主命令共享同一 matcher 与权限 ID。
 
-## 2.4 `on_message` 要点
+## 2.5 `on_message` 要点
 
 用于**无固定口令**或**每条消息都要看**的逻辑：
 
@@ -65,7 +83,7 @@ chat = on_message(rule=to_me(), priority=99, block=False)
 
 **慎用**：`on_message` 无过滤时会增加每条消息的 CPU；应用 `rule`（`to_me`、自定义 rule）收窄范围。
 
-## 2.5 入站审查（message_scrub）
+## 2.6 入站审查（message_scrub）
 
 复读、做梦等插件在消费用户文本前，应登记 [message_scrub](../../common/message_scrub/README.md) hook，统一过滤广告/风控，而不是每个插件各自写正则。
 
@@ -74,7 +92,7 @@ chat = on_message(rule=to_me(), priority=99, block=False)
 - 插件会**大量读用户原文**并学习/生成 → **应接** message_scrub
 - 纯 `on_command` 且只解析命令参数 → 通常不必
 
-## 2.6 冷却（CD）
+## 2.7 冷却（CD）
 
 Pallas 提供 **`src.features.command_limits`**，在 `GroupConfig` / `BotConfig` 之上统一冷却 key（`cmd_limit:{command_id}`）。
 
@@ -103,7 +121,7 @@ await refresh_command_cooldown(event, "my_plugin.demo", 10)
 
 详见 [command_limits 说明](../../common/command_limits/README.md)。历史插件仍可直接用 `GroupConfig.is_cooldown`；新插件优先用上述 helper 保持 key 一致。
 
-## 2.7 分片与多牛（进阶）
+## 2.8 分片与多牛（进阶）
 
 多进程分片或中央入站调度下，部分插件需声明 shard 行为或走 ingress gate。涉及：
 
@@ -113,7 +131,7 @@ await refresh_command_cooldown(event, "my_plugin.demo", 10)
 
 **默认新插件**按单 matcher 编写即可；只有「全群消息洪峰」「多牛同群」类功能才需提前读上述文档。
 
-## 2.8 自检
+## 2.9 自检
 
 - [ ] 能用 `on_command` 的口令型功能没有用宽泛 `on_message`
 - [ ] `on_message` 已设合理 `priority` / `block` / `rule`
@@ -121,7 +139,7 @@ await refresh_command_cooldown(event, "my_plugin.demo", 10)
 - [ ] 被动文本类已评估 message_scrub
 - [ ] 高频路径避免同步阻塞与巨型 handler
 
-## 2.9 下一步
+## 2.10 下一步
 
 - 权限与帮助文案 → [三、cmd_perm](./03-cmd-perm-and-help.md)
 - WebUI 配置 → [四、WebUI 配置](./04-webui-config.md)

--- a/docs/skills/pallas-plugin-development/references/05-paths-and-data.md
+++ b/docs/skills/pallas-plugin-development/references/05-paths-and-data.md
@@ -4,21 +4,37 @@
 
 | 类型 | 位置 | Helper |
 | --- | --- | --- |
-| 运行期数据 | `data/<plugin_name>/` | `plugin_data_dir("my_plugin")` |
+| 群/用户/牛/部署级结构化状态 | DB 内 `plugin_storage` 字段 | `GroupPluginStorage("my_plugin", group_id)` + `extra["plugin_storage"]` |
+| 大文件、缓存、导出 | `data/<plugin_name>/` | `plugin_data_dir("my_plugin")` |
 | 静态资源 | `resource/<subdir>/` | `resource_dir("voices")` 等 |
 
 ```python
+from src.features.plugin_storage import GroupPluginStorage, plugin_storage_list, plugin_storage_row
 from src.foundation.paths import plugin_data_dir, resource_dir
 
-DATA = plugin_data_dir("my_plugin")
+# 结构化群状态（须在 PluginMetadata.extra 声明键）
+store = GroupPluginStorage("my_plugin", group_id)
+await store.set("my_state", {"n": 1})
+
+# 非结构化文件
+CACHE = plugin_data_dir("my_plugin")
 VOICES = resource_dir("voices")
 ```
 
 **不要**硬编码 `data/`、`resource/` 相对路径字符串；工作目录变化会导致漂移。
 
-## 5.2 备份与排障
+完整跟做：[Cookbook · 牛牛赞我 §3](../../develop/plugin/cookbook.md#3数据落盘按群计数)。
 
-`data/<plugin_name>/` 按插件隔离，便于备份与按插件清理。大文件、缓存、下载物放数据目录；可复用静态素材放 `resource/`。
+## 5.2 何时用哪种
+
+| 场景 | 推荐 |
+| --- | --- |
+| 群开关、计数、小 JSON 状态 | `plugin_storage` + `GroupPluginStorage` |
+| 图片/语音文件、日志、导出 zip | `plugin_data_dir` |
+| 只读素材 | `resource_dir` |
+| 跨群关系、审计、复杂查询 | `src.foundation.db` repository |
+
+`data/<plugin_name>/` 仍按插件隔离，便于备份与清理。
 
 ## 5.3 数据库
 

--- a/docs/skills/pallas-plugin-development/references/08-golden-plugin-checklist.md
+++ b/docs/skills/pallas-plugin-development/references/08-golden-plugin-checklist.md
@@ -6,7 +6,7 @@
 
 - [ ] `__init__.py` 轻量；业务已拆到语义化模块
 - [ ] `config.py` 存在；WebUI 可调项已接 `install_hot_reload_config`
-- [ ] 路径用 `plugin_data_dir` / `resource_dir`
+- [ ] 结构化状态：`extra["plugin_storage"]` + `GroupPluginStorage`（或 deploy 级声明）；大文件才用 `plugin_data_dir` / `resource_dir`
 - [ ] 导入来自 `src.features` / `src.foundation` / `src.console` 公开 API
 - [ ] `uv run ruff check src/` 与 `format --check` 通过
 

--- a/src/features/plugin_capabilities/schema.py
+++ b/src/features/plugin_capabilities/schema.py
@@ -10,6 +10,7 @@ from src.features.cmd_perm.schema import build_command_perm_ui
 from src.features.command_limits.config import get_command_limits_config, normalize_command_limit_overrides
 from src.features.command_limits.schema import build_command_limits_ui
 from src.features.llm.tools.metadata import iter_loaded_plugin_llm_tools
+from src.features.plugin_reload import reload_policy_from_metadata
 from src.features.plugin_storage.schema import build_plugin_storage_ui
 
 
@@ -35,6 +36,7 @@ def build_plugin_capabilities_ui() -> dict[str, Any]:
                 "commands": {},
                 "llm_tools": [],
                 "storage_keys": [],
+                "reload_policy": None,
             }
             plugins[plugin] = bucket
         elif title and bucket["title"] == bucket["plugin"]:
@@ -81,6 +83,20 @@ def build_plugin_capabilities_ui() -> dict[str, Any]:
         bucket = ensure_plugin(str(row.get("plugin") or ""), str(row.get("title") or ""))
         bucket["storage_keys"] = list(row.get("keys") or [])
 
+    try:
+        from nonebot import get_loaded_plugins
+
+        for plugin in get_loaded_plugins():
+            name = str(getattr(plugin, "name", "") or "").strip()
+            if not name:
+                continue
+            meta = getattr(plugin, "metadata", None)
+            title = str(getattr(meta, "name", "") or name).strip() if meta else name
+            bucket = ensure_plugin(name, title)
+            bucket["reload_policy"] = reload_policy_from_metadata(meta)
+    except Exception:
+        pass
+
     rows_out: list[dict[str, Any]] = []
     for bucket in plugins.values():
         commands = list(bucket["commands"].values())
@@ -95,6 +111,7 @@ def build_plugin_capabilities_ui() -> dict[str, Any]:
             "commands": commands,
             "llm_tools": llm_tools,
             "storage_keys": storage_keys,
+            "reload_policy": bucket.get("reload_policy"),
         })
     rows_out.sort(key=itemgetter("plugin"))
     return {"plugins": rows_out, "levels": perm_ui.get("levels", [])}

--- a/src/features/plugin_reload/__init__.py
+++ b/src/features/plugin_reload/__init__.py
@@ -1,0 +1,17 @@
+"""插件热重载策略声明（L1–L3 分级；当前仅解析 extra）。"""
+
+from src.features.plugin_reload.metadata import (
+    DEFAULT_RELOAD_POLICY,
+    VALID_RELOAD_POLICIES,
+    ReloadPolicy,
+    normalize_reload_policy,
+    reload_policy_from_metadata,
+)
+
+__all__ = [
+    "DEFAULT_RELOAD_POLICY",
+    "VALID_RELOAD_POLICIES",
+    "ReloadPolicy",
+    "normalize_reload_policy",
+    "reload_policy_from_metadata",
+]

--- a/src/features/plugin_reload/metadata.py
+++ b/src/features/plugin_reload/metadata.py
@@ -1,0 +1,31 @@
+"""从 PluginMetadata.extra 解析 reload_policy（M3 桩；L3 重载尚未实现）。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from nonebot.plugin import PluginMetadata
+
+ReloadPolicy = Literal["config_only", "metadata", "full"]
+
+DEFAULT_RELOAD_POLICY: ReloadPolicy = "config_only"
+VALID_RELOAD_POLICIES: frozenset[str] = frozenset({"config_only", "metadata", "full"})
+
+
+def normalize_reload_policy(raw: str | None) -> ReloadPolicy:
+    value = (raw or DEFAULT_RELOAD_POLICY).strip().lower()
+    if value not in VALID_RELOAD_POLICIES:
+        return DEFAULT_RELOAD_POLICY
+    return value  # type: ignore[return-value]
+
+
+def reload_policy_from_metadata(meta: PluginMetadata | None) -> ReloadPolicy:
+    if meta is None or not meta.extra:
+        return DEFAULT_RELOAD_POLICY
+    raw = meta.extra.get("reload_policy")
+    if raw is None:
+        return DEFAULT_RELOAD_POLICY
+    if not isinstance(raw, str):
+        return DEFAULT_RELOAD_POLICY
+    return normalize_reload_policy(raw)

--- a/src/features/plugin_sdk/__init__.py
+++ b/src/features/plugin_sdk/__init__.py
@@ -1,0 +1,22 @@
+"""插件开发 SDK：组合式 matcher + 声明 helper。"""
+
+from src.features.cmd_perm.declare import command_perm_list, command_perm_row
+
+from .checklist import missing_command_declarations
+from .context import PluginHandlerContext
+from .declare import command_limit_list, command_limit_row
+from .matcher import PluginCommand, bind_alias_handlers, group_command, message_command, private_command
+
+__all__ = [
+    "PluginCommand",
+    "PluginHandlerContext",
+    "bind_alias_handlers",
+    "command_limit_list",
+    "command_limit_row",
+    "command_perm_list",
+    "command_perm_row",
+    "group_command",
+    "message_command",
+    "missing_command_declarations",
+    "private_command",
+]

--- a/src/features/plugin_sdk/checklist.py
+++ b/src/features/plugin_sdk/checklist.py
@@ -1,0 +1,26 @@
+"""插件元数据最小自检（开发/测试用）。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def missing_command_declarations(
+    extra: dict[str, Any] | None,
+    *,
+    command_ids: set[str] | frozenset[str],
+) -> list[str]:
+    if not command_ids:
+        return []
+    extra = extra or {}
+    perm_ids = {
+        str(row.get("id") or "").strip() for row in extra.get("command_permissions") or [] if isinstance(row, dict)
+    }
+    limit_ids = {str(row.get("id") or "").strip() for row in extra.get("command_limits") or [] if isinstance(row, dict)}
+    missing: list[str] = []
+    for cid in sorted(command_ids):
+        if cid not in perm_ids:
+            missing.append(f"{cid}: command_permissions")
+        if cid not in limit_ids:
+            missing.append(f"{cid}: command_limits")
+    return missing

--- a/src/features/plugin_sdk/context.py
+++ b/src/features/plugin_sdk/context.py
@@ -1,0 +1,53 @@
+"""插件 handler 统一上下文。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nonebot.adapters.onebot.v11 import GroupMessageEvent, MessageEvent, PrivateMessageEvent
+
+if TYPE_CHECKING:
+    from nonebot.adapters import Bot
+    from nonebot.matcher import Matcher
+
+
+class PluginHandlerContext:
+    def __init__(
+        self,
+        *,
+        bot: Bot,
+        event: MessageEvent,
+        command_id: str,
+        matcher: Matcher,
+        plugin_tag: str = "",
+    ) -> None:
+        self.bot = bot
+        self.event = event
+        self.command_id = command_id
+        self.matcher = matcher
+        self.plugin_tag = (plugin_tag or command_id.split(".", 1)[0]).strip()
+
+    @property
+    def is_group(self) -> bool:
+        return isinstance(self.event, GroupMessageEvent)
+
+    @property
+    def is_private(self) -> bool:
+        return isinstance(self.event, PrivateMessageEvent)
+
+    @property
+    def group_id(self) -> int | None:
+        if isinstance(self.event, GroupMessageEvent):
+            return int(self.event.group_id)
+        return None
+
+    @property
+    def user_id(self) -> str:
+        return str(self.event.get_user_id())
+
+    @property
+    def plain_text(self) -> str:
+        return str(getattr(self.event, "get_plaintext", lambda: "")() or "")
+
+    async def finish(self, message: Any = None, **kwargs: Any) -> None:
+        await self.matcher.finish(message, **kwargs)

--- a/src/features/plugin_sdk/declare.py
+++ b/src/features/plugin_sdk/declare.py
@@ -1,0 +1,14 @@
+"""PluginMetadata.extra 声明辅助，与 cmd_perm 对称。"""
+
+from __future__ import annotations
+
+
+def command_limit_row(command_id: str, cd_sec: int) -> dict[str, str | int]:
+    cid = (command_id or "").strip()
+    if not cid:
+        raise ValueError("command_id 不能为空")
+    return {"id": cid, "cd_sec": max(0, int(cd_sec))}
+
+
+def command_limit_list(*rows: dict[str, str | int]) -> list[dict[str, str | int]]:
+    return list(rows)

--- a/src/features/plugin_sdk/matcher.py
+++ b/src/features/plugin_sdk/matcher.py
@@ -1,0 +1,183 @@
+"""组合式命令 matcher：权限、冷却与日志标签一次封装。"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Literal
+
+from nonebot import logger, on_command
+from nonebot.adapters import Bot  # noqa: TC002
+from nonebot.adapters.onebot.v11 import MessageEvent  # noqa: TC002
+from nonebot.matcher import Matcher  # noqa: TC002
+from nonebot.permission import Permission  # noqa: TC002
+
+from src.features.cmd_perm import (
+    group_message_permission_for_command,
+    group_or_private_message_permission_for_command,
+    private_message_permission_for_command,
+)
+from src.features.command_limits import is_command_cooldown_ready, refresh_command_cooldown
+
+from .context import PluginHandlerContext
+
+HandlerFunc = Callable[[PluginHandlerContext], Awaitable[None] | None]
+Scene = Literal["group", "private", "both"]
+
+
+class PluginCommand:
+    """单个 on_command matcher 与元数据的绑定。"""
+
+    def __init__(
+        self,
+        *,
+        matcher: Matcher,
+        command_id: str,
+        default_cd_sec: int | None,
+        plugin_tag: str,
+    ) -> None:
+        self.matcher = matcher
+        self.command_id = command_id
+        self.default_cd_sec = default_cd_sec
+        self.plugin_tag = plugin_tag
+
+    def handle(self, func: HandlerFunc | None = None) -> Callable[[HandlerFunc], HandlerFunc]:
+        def decorator(handler: HandlerFunc) -> HandlerFunc:
+            @self.matcher.handle()
+            async def _wrapper(bot: Bot, event: MessageEvent) -> None:
+                if self.default_cd_sec is not None and self.default_cd_sec > 0:
+                    if not await is_command_cooldown_ready(
+                        event,
+                        self.command_id,
+                        default_cd_sec=self.default_cd_sec,
+                    ):
+                        return
+                    await refresh_command_cooldown(
+                        event,
+                        self.command_id,
+                        default_cd_sec=self.default_cd_sec,
+                    )
+                ctx = PluginHandlerContext(
+                    bot=bot,
+                    event=event,
+                    command_id=self.command_id,
+                    matcher=self.matcher,
+                    plugin_tag=self.plugin_tag,
+                )
+                logger.debug("[plugin:{}] command={} user={}", self.plugin_tag, self.command_id, ctx.user_id)
+                result = handler(ctx)
+                if result is not None:
+                    await result
+
+            return handler
+
+        if func is not None:
+            return decorator(func)
+        return decorator
+
+
+def _permission_for_scene(command_id: str, scene: Scene) -> Permission:
+    if scene == "group":
+        return group_message_permission_for_command(command_id)
+    if scene == "private":
+        return private_message_permission_for_command(command_id)
+    return group_or_private_message_permission_for_command(command_id)
+
+
+def _plugin_tag_from_command_id(command_id: str) -> str:
+    return (command_id.split(".", 1)[0] if command_id else "").strip() or "plugin"
+
+
+def message_command(
+    command_id: str,
+    prefix: str,
+    *,
+    aliases: Sequence[str] = (),
+    scene: Scene = "both",
+    cd_sec: int | None = 0,
+    priority: int = 5,
+    block: bool = True,
+) -> PluginCommand:
+    """注册口令 matcher；``prefix`` 为主命令名，``aliases`` 共享同一 handler 时需多次调用 handle。"""
+    primary = (prefix or "").strip()
+    if not primary:
+        raise ValueError("prefix 不能为空")
+    plugin_tag = _plugin_tag_from_command_id(command_id)
+    cmd = on_command(
+        primary,
+        priority=priority,
+        block=block,
+        permission=_permission_for_scene(command_id, scene),
+    )
+    binding = PluginCommand(
+        matcher=cmd,
+        command_id=command_id,
+        default_cd_sec=cd_sec,
+        plugin_tag=plugin_tag,
+    )
+    binding._alias_matchers = []  # type: ignore[attr-defined]
+    for alias in aliases:
+        alias_name = (alias or "").strip()
+        if not alias_name or alias_name.casefold() == primary.casefold():
+            continue
+        alias_matcher = on_command(
+            alias_name,
+            priority=priority,
+            block=block,
+            permission=_permission_for_scene(command_id, scene),
+        )
+        binding._alias_matchers.append(  # type: ignore[attr-defined]
+            PluginCommand(
+                matcher=alias_matcher,
+                command_id=command_id,
+                default_cd_sec=cd_sec,
+                plugin_tag=plugin_tag,
+            )
+        )
+    return binding
+
+
+def group_command(
+    command_id: str,
+    prefix: str,
+    *,
+    aliases: Sequence[str] = (),
+    cd_sec: int | None = 0,
+    priority: int = 5,
+    block: bool = True,
+) -> PluginCommand:
+    return message_command(
+        command_id,
+        prefix,
+        aliases=aliases,
+        scene="group",
+        cd_sec=cd_sec,
+        priority=priority,
+        block=block,
+    )
+
+
+def private_command(
+    command_id: str,
+    prefix: str,
+    *,
+    aliases: Sequence[str] = (),
+    cd_sec: int | None = 0,
+    priority: int = 5,
+    block: bool = True,
+) -> PluginCommand:
+    return message_command(
+        command_id,
+        prefix,
+        aliases=aliases,
+        scene="private",
+        cd_sec=cd_sec,
+        priority=priority,
+        block=block,
+    )
+
+
+def bind_alias_handlers(primary: PluginCommand, handler: HandlerFunc) -> None:
+    """主命令与别名 matcher 绑定同一 handler。"""
+    primary.handle(handler)
+    for alias_binding in getattr(primary, "_alias_matchers", ()):
+        alias_binding.handle(handler)

--- a/src/platform/bot_runtime/plugin_matrix.py
+++ b/src/platform/bot_runtime/plugin_matrix.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 
 CORE_PLUGIN_NAMES: frozenset[str] = frozenset({
+    "pb_core",
     "repeater",
     "help",
     "pallas_webui",

--- a/src/plugins/duel/__init__.py
+++ b/src/plugins/duel/__init__.py
@@ -16,8 +16,6 @@ from src.features.cmd_perm.metadata_defaults import (
 from src.features.cmd_perm.metadata_text import SCENE_GROUP, join_usage, usage_line
 from src.features.plugin_storage import plugin_storage_list, plugin_storage_row
 from src.features.plugin_storage.startup import register_plugin_storage_startup_hook
-
-register_plugin_storage_startup_hook()
 from src.platform.ingress.policy_registry import text_matches_plugin_fanout
 from src.plugins.duel import duel_penalty  # noqa: F401 — 注册惩罚消息 matcher
 from src.plugins.duel.config import plugin_config
@@ -40,6 +38,8 @@ from src.plugins.duel.duel_round_engine import (
     try_claim_duel_user_reply,
 )
 from src.plugins.duel.duel_session import clear_duel_pair, start_duel_pair
+
+register_plugin_storage_startup_hook()
 
 
 @get_driver().on_startup

--- a/src/plugins/help/visibility.py
+++ b/src/plugins/help/visibility.py
@@ -5,10 +5,17 @@ from typing import Any
 
 from src.foundation.paths import plugin_data_dir
 
-from .visibility import BUILTIN_HELP_HIDDEN_PLUGINS
-
 _VISIBILITY_FILE = "help_visibility.json"
 _STORAGE_KEY = "hidden_plugins"
+
+BUILTIN_HELP_HIDDEN_PLUGINS = frozenset({
+    "pallas_webui",
+    "pallas_protocol",
+    "ingress_gate",
+    "community_stats",
+    "relogin_forward",
+    "maa_hub",
+})
 
 
 def _visibility_path():

--- a/src/plugins/pallas_webui/__init__.py
+++ b/src/plugins/pallas_webui/__init__.py
@@ -20,7 +20,8 @@ from src.shared.utils.format_exception import format_exception_for_log
 
 from .api import register_api
 from .config import Config, plugin_config
-from .extended_api import register_extended_api, set_console_meta, warm_console_read_caches
+from .console_meta_store import set_console_meta
+from .extended_api import register_extended_api, warm_console_read_caches
 from .manager import (
     bot_has_release_update,
     bot_is_development_build,

--- a/src/plugins/pb_core/__init__.py
+++ b/src/plugins/pb_core/__init__.py
@@ -1,0 +1,116 @@
+from nonebot.plugin import PluginMetadata
+
+from src.features.cmd_perm.metadata_defaults import (
+    PLUGIN_EXTRA_VERSION,
+    PLUGIN_HOMEPAGE,
+    PLUGIN_MENU_TEMPLATE,
+)
+from src.features.cmd_perm.metadata_text import SCENE_BOTH, join_usage, usage_line
+from src.features.plugin_sdk import (
+    bind_alias_handlers,
+    command_limit_list,
+    command_limit_row,
+    command_perm_list,
+    command_perm_row,
+    message_command,
+)
+
+from .handlers import (
+    handle_console,
+    handle_plugins,
+    handle_restart,
+    handle_status,
+    handle_update_check,
+)
+
+__plugin_meta__ = PluginMetadata(
+    name="牛牛核心",
+    description="进程状态、控制台入口、插件概览与本体更新检查。",
+    usage=join_usage(
+        usage_line("牛牛状态", "查看版本、分片与连接摘要"),
+        usage_line("牛牛控制台", "回显 WebUI 地址"),
+        usage_line("牛牛插件", "已加载 core/extra 插件概览"),
+        usage_line("牛牛更新", "检查本体 release 是否有更新"),
+        usage_line("牛牛重启", "调度优雅重启"),
+    ),
+    type="application",
+    homepage=PLUGIN_HOMEPAGE,
+    supported_adapters={"~onebot.v11"},
+    extra={
+        "version": PLUGIN_EXTRA_VERSION,
+        "menu_template": PLUGIN_MENU_TEMPLATE,
+        "command_permissions": command_perm_list(
+            command_perm_row("pb_core.status", "牛牛状态", "staff"),
+            command_perm_row("pb_core.console", "牛牛控制台", "staff"),
+            command_perm_row("pb_core.plugins", "牛牛插件", "staff"),
+            command_perm_row("pb_core.update_check", "牛牛更新", "superuser"),
+            command_perm_row("pb_core.restart", "牛牛重启", "superuser"),
+        ),
+        "command_limits": command_limit_list(
+            command_limit_row("pb_core.status", 10),
+            command_limit_row("pb_core.console", 10),
+            command_limit_row("pb_core.plugins", 15),
+            command_limit_row("pb_core.update_check", 60),
+            command_limit_row("pb_core.restart", 120),
+        ),
+        "menu_data": [
+            {
+                "func": "牛牛状态",
+                "trigger_method": "on_cmd",
+                "trigger_scene": SCENE_BOTH,
+                "trigger_condition": "牛牛状态",
+                "command_permission": "pb_core.status",
+                "brief_des": "进程与分片摘要",
+                "detail_des": "版本、Git、分片角色、编排脚本与本进程已连接牛牛。",
+            },
+            {
+                "func": "牛牛控制台",
+                "trigger_method": "on_cmd",
+                "trigger_scene": SCENE_BOTH,
+                "trigger_condition": "牛牛控制台",
+                "command_permission": "pb_core.console",
+                "brief_des": "WebUI 地址",
+                "detail_des": "回显控制台 URL；完整管理仍建议在浏览器打开 WebUI。",
+            },
+            {
+                "func": "牛牛插件",
+                "trigger_method": "on_cmd",
+                "trigger_scene": SCENE_BOTH,
+                "trigger_condition": "牛牛插件",
+                "command_permission": "pb_core.plugins",
+                "brief_des": "插件加载概览",
+                "detail_des": "列出已加载 core/extra 插件与扩展包提示。",
+            },
+            {
+                "func": "牛牛更新",
+                "trigger_method": "on_cmd",
+                "trigger_scene": SCENE_BOTH,
+                "trigger_condition": "牛牛更新",
+                "command_permission": "pb_core.update_check",
+                "brief_des": "检查本体 release",
+                "detail_des": "只读对比 GitHub 最新发布；应用更新请用 WebUI 或 pallas update bot。",
+            },
+            {
+                "func": "牛牛重启",
+                "trigger_method": "on_cmd",
+                "trigger_scene": SCENE_BOTH,
+                "trigger_condition": "牛牛重启",
+                "command_permission": "pb_core.restart",
+                "brief_des": "调度优雅重启",
+                "detail_des": "约 3 秒后按当前 unified/分片编排重启；需环境存在 run_*_bot.sh。",
+            },
+        ],
+    },
+)
+
+status_cmd = message_command("pb_core.status", "牛牛状态", cd_sec=10)
+console_cmd = message_command("pb_core.console", "牛牛控制台", cd_sec=10)
+plugins_cmd = message_command("pb_core.plugins", "牛牛插件", cd_sec=15)
+update_cmd = message_command("pb_core.update_check", "牛牛更新", cd_sec=60)
+restart_cmd = message_command("pb_core.restart", "牛牛重启", cd_sec=120)
+
+bind_alias_handlers(status_cmd, handle_status)
+bind_alias_handlers(console_cmd, handle_console)
+bind_alias_handlers(plugins_cmd, handle_plugins)
+bind_alias_handlers(update_cmd, handle_update_check)
+bind_alias_handlers(restart_cmd, handle_restart)

--- a/src/plugins/pb_core/console.py
+++ b/src/plugins/pb_core/console.py
@@ -1,0 +1,53 @@
+"""控制台地址与插件矩阵摘要。"""
+
+from __future__ import annotations
+
+from nonebot import get_driver
+
+from src.console.web import public_base_url
+from src.platform.bot_runtime.plugin_matrix import (
+    CORE_PLUGIN_NAMES,
+    EXTRA_PLUGIN_NAMES,
+    extra_package_for_plugin,
+    is_core_plugin,
+)
+
+
+def format_console_hint_text() -> str:
+    try:
+        from src.plugins.pallas_webui.config import get_config as get_webui_config
+
+        cfg = get_webui_config()
+        if not cfg.pallas_webui_enabled:
+            return "网页控制台已在本实例关闭（pallas_webui_enabled=false）。"
+    except Exception:
+        cfg = None
+
+    driver = get_driver()
+    base = public_base_url(host=driver.config.host, port=driver.config.port)
+    path = ""
+    if cfg is not None:
+        path = (cfg.pallas_webui_http_base or "/pallas").strip()
+        if path and not path.startswith("/"):
+            path = f"/{path}"
+    url = f"{base.rstrip('/')}{path or '/pallas'}/"
+    return f"控制台：{url}\n浏览器打开后使用启动日志中的口令登录。"
+
+
+def format_plugins_summary_text(*, loaded_names: set[str]) -> str:
+    core = sorted(name for name in loaded_names if is_core_plugin(name))
+    extra = sorted(name for name in loaded_names if name in EXTRA_PLUGIN_NAMES)
+    lines = [
+        f"已加载 core 插件 {len(core)}：{', '.join(core) if core else '（无）'}",
+        f"已加载 extra 插件 {len(extra)}：{', '.join(extra) if extra else '（无）'}",
+        f"core 全集 {len(CORE_PLUGIN_NAMES)} · extra 全集 {len(EXTRA_PLUGIN_NAMES)}",
+    ]
+    missing_core = sorted(CORE_PLUGIN_NAMES - loaded_names)
+    if missing_core:
+        lines.append(f"未加载 core：{', '.join(missing_core)}")
+    if extra:
+        packs = sorted({extra_package_for_plugin(name) for name in extra if extra_package_for_plugin(name)})
+        if packs:
+            lines.append(f"对应扩展包：{', '.join(packs)}")
+    lines.append("安装扩展：WebUI 插件页，或 uv sync --extra <name>。")
+    return "\n".join(lines)

--- a/src/plugins/pb_core/handlers.py
+++ b/src/plugins/pb_core/handlers.py
@@ -1,0 +1,46 @@
+"""pb_core 命令 handler。"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from nonebot import get_loaded_plugins
+
+from src.console.cli.bot_process import bot_lifecycle_available, schedule_bot_restart
+from src.console.cli.runtime_mode import resolve_bot_mode
+
+if TYPE_CHECKING:
+    from src.features.plugin_sdk import PluginHandlerContext
+
+from .console import format_console_hint_text, format_plugins_summary_text
+from .status import format_runtime_status_text
+from .update import format_update_check_text
+
+
+async def handle_status(ctx: PluginHandlerContext) -> None:
+    await ctx.finish(format_runtime_status_text())
+
+
+async def handle_console(ctx: PluginHandlerContext) -> None:
+    await ctx.finish(format_console_hint_text())
+
+
+async def handle_plugins(ctx: PluginHandlerContext) -> None:
+    loaded = {p.name for p in get_loaded_plugins() if p.name}
+    await ctx.finish(format_plugins_summary_text(loaded_names=loaded))
+
+
+async def handle_update_check(ctx: PluginHandlerContext) -> None:
+    await ctx.finish(await format_update_check_text())
+
+
+async def handle_restart(ctx: PluginHandlerContext) -> None:
+    if not bot_lifecycle_available():
+        await ctx.finish("当前环境未检测到 run_unified_bot / run_sharded_bot，无法自动重启。")
+        return
+    mode = resolve_bot_mode("auto")
+    scheduled = schedule_bot_restart(mode=mode, delay_s=3.0)
+    if not scheduled:
+        await ctx.finish("重启调度失败，请改用 WebUI 或 pallas restart。")
+        return
+    await ctx.finish(f"将在约 3 秒后重启（{mode}）。若未恢复请查看日志。")

--- a/src/plugins/pb_core/status.py
+++ b/src/plugins/pb_core/status.py
@@ -1,0 +1,43 @@
+"""牛牛核心：进程/分片/版本摘要。"""
+
+from __future__ import annotations
+
+from nonebot import get_bots
+
+from src.console.cli.bot_process import bot_lifecycle_available
+from src.console.cli.runtime_mode import detect_running_bot_mode
+from src.foundation.bot_version import get_bot_current_version, get_pallas_bot_version_for_reporting
+from src.platform.shard import context as shard_ctx
+
+
+def format_runtime_status_text() -> str:
+    lines: list[str] = []
+    version = get_pallas_bot_version_for_reporting()
+    lines.append(f"版本：{version or 'unknown'}")
+
+    git_info = get_bot_current_version()
+    commit = (git_info.get("commit") or "").strip()
+    tag = (git_info.get("tag") or "").strip()
+    if commit:
+        suffix = f"（{tag}）" if tag else ""
+        lines.append(f"Git：{commit}{suffix}")
+
+    if shard_ctx.sharding_active():
+        lines.append(f"分片：{shard_ctx.role()} · shard #{shard_ctx.shard_id()}")
+    else:
+        lines.append("运行模式：单进程 unified")
+
+    detected = detect_running_bot_mode()
+    if detected:
+        lines.append(f"编排脚本检测：{detected} 运行中")
+    elif bot_lifecycle_available():
+        lines.append("编排脚本检测：未运行（当前应为 nb 前台或自定义守护）")
+
+    bots = get_bots()
+    if bots:
+        ids = ", ".join(sorted(bots.keys()))
+        lines.append(f"本进程已连接牛牛：{len(bots)}（{ids}）")
+    else:
+        lines.append("本进程已连接牛牛：0")
+
+    return "\n".join(lines)

--- a/src/plugins/pb_core/update.py
+++ b/src/plugins/pb_core/update.py
@@ -1,0 +1,55 @@
+"""本体更新检查摘要。"""
+
+from __future__ import annotations
+
+from src.shared.utils.format_exception import format_exception_for_log
+
+
+async def format_update_check_text() -> str:
+    from src.plugins.pallas_webui.config import get_config as get_webui_config
+    from src.plugins.pallas_webui.manager import (
+        bot_has_release_update,
+        bot_is_development_build,
+        fetch_latest_bot_release,
+        get_bot_current_version,
+        inspect_bot_deployment,
+    )
+
+    plugin_config = get_webui_config()
+    github_token = str(getattr(plugin_config, "pallas_protocol_github_token", "") or "").strip()
+    current = get_bot_current_version()
+    current_tag = str(current.get("tag") or "").strip()
+    current_commit = str(current.get("commit") or "").strip()
+    lines = [f"当前：{current_tag or current_commit or 'unknown'}"]
+
+    try:
+        latest = await fetch_latest_bot_release("PallasBot/Pallas-Bot", token=github_token)
+        latest_tag = str(latest.get("tag") or "").strip()
+    except Exception as exc:  # noqa: BLE001
+        lines.append(f"检查失败：{format_exception_for_log(exc)}")
+        return "\n".join(lines)
+
+    lines.append(f"最新发布：{latest_tag or 'unknown'}")
+    has_update = bot_has_release_update(
+        latest_tag=latest_tag,
+        current_tag=current_tag,
+        current_commit=current_commit,
+    )
+    dev_build = bot_is_development_build(
+        latest_tag=latest_tag,
+        current_tag=current_tag,
+        current_commit=current_commit,
+    )
+    if has_update:
+        lines.append("结论：有新版本可更新。")
+    elif dev_build:
+        lines.append("结论：开发构建，可能领先于最新 release。")
+    else:
+        lines.append("结论：已是最新 release。")
+
+    deploy = inspect_bot_deployment()
+    mode = str(deploy.get("deployment_mode") or "").strip()
+    if mode:
+        lines.append(f"部署：{mode}")
+    lines.append("应用更新请用 WebUI 或 pallas update bot；群内仅只读检查。")
+    return "\n".join(lines)

--- a/tests/common/test_plugin_matrix.py
+++ b/tests/common/test_plugin_matrix.py
@@ -10,6 +10,7 @@ from src.platform.bot_runtime.plugin_matrix import (
 
 
 def test_core_plugins_include_repeater_and_help():
+    assert "pb_core" in CORE_PLUGIN_NAMES
     assert "repeater" in CORE_PLUGIN_NAMES
     assert "llm_chat" in CORE_PLUGIN_NAMES
     assert "help" in CORE_PLUGIN_NAMES

--- a/tests/features/plugin_sdk/test_declare.py
+++ b/tests/features/plugin_sdk/test_declare.py
@@ -1,0 +1,29 @@
+import pytest
+
+from src.features.plugin_sdk import command_limit_list, command_limit_row, missing_command_declarations
+
+
+def test_command_limit_row():
+    row = command_limit_row("demo.echo", 30)
+    assert row == {"id": "demo.echo", "cd_sec": 30}
+
+
+def test_command_limit_row_rejects_empty_id():
+    with pytest.raises(ValueError):
+        command_limit_row("", 0)
+
+
+def test_command_limit_list():
+    rows = command_limit_list(command_limit_row("a", 1), command_limit_row("b", 0))
+    assert len(rows) == 2
+
+
+def test_missing_command_declarations():
+    extra = {
+        "command_permissions": [{"id": "demo.a", "label": "A", "default": "everyone"}],
+        "command_limits": [{"id": "demo.a", "cd_sec": 5}],
+    }
+    assert missing_command_declarations(extra, command_ids={"demo.a"}) == []
+    missing = missing_command_declarations(extra, command_ids={"demo.a", "demo.b"})
+    assert "demo.b: command_permissions" in missing
+    assert "demo.b: command_limits" in missing

--- a/tests/features/plugin_sdk/test_matcher.py
+++ b/tests/features/plugin_sdk/test_matcher.py
@@ -1,0 +1,7 @@
+from src.features.plugin_sdk.matcher import _plugin_tag_from_command_id
+
+
+def test_plugin_tag_from_command_id():
+    assert _plugin_tag_from_command_id("pb_core.status") == "pb_core"
+    assert _plugin_tag_from_command_id("praise_me.praise") == "praise_me"
+    assert _plugin_tag_from_command_id("") == "plugin"

--- a/tests/features/test_plugin_capabilities.py
+++ b/tests/features/test_plugin_capabilities.py
@@ -84,3 +84,4 @@ def test_build_plugin_capabilities_ui_groups(monkeypatch) -> None:
     assert draw["commands"][0]["effective_cd_sec"] == 3
     assert draw["llm_tools"][0]["name"] == "draw.image"
     assert draw["storage_keys"][0]["key"] == "daily_usage"
+    assert draw.get("reload_policy") in (None, "config_only")

--- a/tests/features/test_plugin_reload.py
+++ b/tests/features/test_plugin_reload.py
@@ -1,0 +1,25 @@
+from nonebot.plugin import PluginMetadata
+
+from src.features.plugin_reload import (
+    DEFAULT_RELOAD_POLICY,
+    normalize_reload_policy,
+    reload_policy_from_metadata,
+)
+
+
+def test_normalize_reload_policy_defaults():
+    assert normalize_reload_policy(None) == DEFAULT_RELOAD_POLICY
+    assert normalize_reload_policy("unknown") == DEFAULT_RELOAD_POLICY
+    assert normalize_reload_policy("metadata") == "metadata"
+    assert normalize_reload_policy("FULL") == "full"
+
+
+def test_reload_policy_from_metadata():
+    meta = PluginMetadata(
+        name="t",
+        description="t。",
+        usage="",
+        extra={"reload_policy": "metadata"},
+    )
+    assert reload_policy_from_metadata(meta) == "metadata"
+    assert reload_policy_from_metadata(None) == DEFAULT_RELOAD_POLICY

--- a/tests/plugins/pb_core/test_metadata.py
+++ b/tests/plugins/pb_core/test_metadata.py
@@ -1,0 +1,17 @@
+from src.features.plugin_sdk import missing_command_declarations
+from src.plugins.pb_core import __plugin_meta__
+
+
+def test_pb_core_metadata_declares_all_commands():
+    command_ids = {
+        "pb_core.status",
+        "pb_core.console",
+        "pb_core.plugins",
+        "pb_core.update_check",
+        "pb_core.restart",
+    }
+    assert missing_command_declarations(__plugin_meta__.extra, command_ids=command_ids) == []
+
+
+def test_pb_core_help_name():
+    assert __plugin_meta__.name == "牛牛核心"

--- a/tests/plugins/pb_core/test_status.py
+++ b/tests/plugins/pb_core/test_status.py
@@ -1,0 +1,7 @@
+from src.plugins.pb_core.status import format_runtime_status_text
+
+
+def test_format_runtime_status_text_includes_version_line():
+    text = format_runtime_status_text()
+    assert text.startswith("版本：")
+    assert "运行模式" in text or "分片" in text


### PR DESCRIPTION
## Summary

- 新增 `plugin_sdk` 组合式 matcher API（权限/CD/上下文封装）与 `command_limit_row` 声明 helper
- 新增 core 插件 `pb_core`（牛牛状态/控制台/插件/更新/重启五条运维口令）
- 补充 `core-devx-roadmap` 设计文档、`reload_policy` 解析桩与热重载分级文档
- Cookbook / structure / Skill 对齐 `plugin_storage` + `GroupPluginStorage` 默认写法
- 修复 `help/visibility` 自引用导入与 `pallas_webui` 启动链循环导入

## Test plan

- [x] `uv run ruff check` / `format --check`（变更 `src/` 路径）
- [x] `uv run pytest tests/features/plugin_sdk/ tests/features/test_plugin_reload.py tests/features/test_plugin_capabilities.py tests/plugins/pb_core/ tests/common/test_plugin_matrix.py tests/plugins/help/test_visibility.py`
- [ ] 群内验证：`牛牛状态` / `牛牛控制台` / `牛牛插件` / `牛牛更新` / `牛牛重启` 权限与文案
- [ ] WebUI 插件页「能力总览」面板（需 WebUI 仓 `feat/4.0` 对应 dist 或联调）

## 关联

- WebUI 能力总览 UI：`Pallas-Bot-WebUI` 分支 `feat/4.0`（独立 PR）
- M5 `pb_webui` / `pb_protocol` 改名 intentionally 不在本 PR

## Summary by Sourcery

引入插件开发 SDK 和新的核心运维插件，同时编写核心开发体验与热重载分层文档，并将插件能力和文档串联起来以呈现这些特性。

New Features:
- 新增 `plugin_sdk` 辅助模块，提供统一的命令匹配器、处理上下文，以及用于声明命令限制和权限的辅助工具。
- 新增核心运维插件 `pb_core`，对外提供状态、控制台 URL、插件概览、更新检查和重启命令，并附带相应的用户文档。
- 暴露插件重载策略（reload policy）元数据，并通过插件能力聚合层和 WebUI API 对外呈现。

Enhancements:
- 更新插件使用手册、匹配器决策指南、路径与数据使用规范，以及黄金插件检查清单，推荐使用 `plugin_storage` + `GroupPluginStorage`，以及基于新 `plugin_sdk` 的命令风格。
- 扩展插件能力 schema 和 WebUI 插件 API，在能力概览中加入 storage keys 和 `reload_policy`。
- 在插件约定、开发概览和技能文档中，进一步阐明核心开发体验路线图、热重载分层，以及推荐的 SDK 使用方式。
- 优化帮助信息的可见性处理，将内置隐藏插件集合内联，并避免自导入问题。

Tests:
- 新增针对 `plugin_sdk` 辅助工具、`reload_policy` 解析、以及 `pb_core` 元数据和状态格式化的单元测试，并扩展现有的插件能力与核心插件矩阵测试以覆盖 `pb_core` 和 `reload_policy`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a plugin development SDK and a new core operations plugin while documenting core dev experience and hot-reload tiers, and wiring plugin capabilities and docs to surface these features.

New Features:
- Add plugin_sdk helper module providing unified command matchers, handler context, and declaration helpers for command limits and permissions.
- Add core operations plugin pb_core exposing status, console URL, plugin overview, update check, and restart commands, with corresponding user-facing documentation.
- Expose plugin reload policy metadata and surface it through the plugin capabilities aggregation and WebUI API.

Enhancements:
- Update plugin cookbook, matcher decision guide, path and data guidelines, and golden plugin checklist to recommend plugin_storage plus GroupPluginStorage and the new plugin_sdk-based command style.
- Extend plugin capabilities schema and WebUI plugins API to include storage keys and reload_policy for capability overviews.
- Clarify plugin convention, development overview, and skills docs around core devx roadmap, hot-reload tiers, and recommended SDK usage.
- Refine help visibility handling by inlining the built-in hidden plugins set and avoiding self-import issues.

Tests:
- Add unit tests for plugin_sdk helpers, reload_policy parsing, and pb_core metadata and status formatting, and extend existing plugin capabilities and core plugin matrix tests to cover pb_core and reload_policy.

</details>